### PR TITLE
Make btcpay api more usable externally

### DIFF
--- a/components/DonationForm.tsx
+++ b/components/DonationForm.tsx
@@ -60,7 +60,6 @@ const DonationSteps: React.FC<DonationStepsProps> = ({
       const payload = {
         amount,
         project_slug: projectSlug,
-        project_name: projectNamePretty,
         zaprite
       }
 


### PR DESCRIPTION
This allows others to use the btcpay api to donate mor easily as they only need to specify the slug and amount instead of zaprite, name, etc