### PR TITLE
Add CC recipient to application form

### DIFF
--- a/pages/api/sendgrid.ts
+++ b/pages/api/sendgrid.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next/types'
 
 const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY
 const TO_ADDRESS = process.env.SENDGRID_RECEPIENT
+const CC_ADDRESS = process.env.SENDGRID_CC
 const FROM_ADDRESS = process.env.SENDGRID_VERIFIED_SENDER
 
 import sgMail from '@sendgrid/mail'
@@ -27,6 +28,7 @@ export default async function handler(
       console.log(process.env.SENDGRID_API_KEY)
       const msg = {
         to: TO_ADDRESS, // Change to your recipient
+        cc: CC_ADDRESS, 
         from: FROM_ADDRESS, // Change to your verified sender
         subject: `OpenSats Application for ${req.body.project_name}`,
         html: `${body}`,


### PR DESCRIPTION
Non-intrusive change for filtering & automation purposes. Add [CC](https://github.com/sendgrid/sendgrid-nodejs/blob/main/docs/use-cases/cc-bcc-reply-to.md) recipient.

I've set the `env` var and will test before deployment.