### PR TITLE
Fix typo in env var

### DIFF
--- a/pages/api/sendgrid.ts
+++ b/pages/api/sendgrid.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next/types'
 
 const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY
-const TO_ADDRESS = process.env.SENDGRID_RECEPIENT
+const TO_ADDRESS = process.env.SENDGRID_RECIPIENT
 const CC_ADDRESS = process.env.SENDGRID_CC
 const FROM_ADDRESS = process.env.SENDGRID_VERIFIED_SENDER
 


### PR DESCRIPTION
Copied env var in Development, Preview, and Production. We now have one with the typo and one without. Will remove the typo one upon successful test & deploy.

Fixes #57