### PR TITLE
Add nym-friendliness to name field

### DIFF
--- a/components/ApplicationForm.tsx
+++ b/components/ApplicationForm.tsx
@@ -177,6 +177,9 @@ export default function ApplicationForm() {
             <h2>Applicant Details</h2>
             <label>
                 Your Name *
+                <small>
+                    Feel free to use your nym.
+                </small>
                 <input type="text" {...register('your_name', { required: true })} />
             </label>
             <label>


### PR DESCRIPTION
True Name is not needed at this stage. 

Many applicants have put nyms in the past, but it's better to be explicit here.