### PR TITLE
Temporarily remove ops team

### DIFF
--- a/components/Credits.tsx
+++ b/components/Credits.tsx
@@ -140,13 +140,6 @@ const Credits = () => {
 
   return (
     <section className="bg-black p-4 flex flex-col items-center">
-      <h1 className="text-white my-4">Managing Director</h1>
-      <div className="credit container flex flex-wrap items-center justify-center mb-8">
-        {managing_director.map((m, i) => (
-          <CreditItem key={i} image={m.image} link={m.link} nym={m.nym} />
-        ))}
-      </div>
-      
       <h1 className="text-white my-4">Board</h1>
       <div className="credit container flex flex-wrap items-center justify-center mb-8">
         {board.map((b, i) => (


### PR DESCRIPTION
I suggest we create a separate page for the ops team (should probably be in ["About Us"](https://opensats.org/about), and most of what is in "About Us" today should probably extracted into some kind of mission statement) and display ops more cleanly once roles are defined properly.

I don't want to have inaccurate information on the page & I don't want to have a visual hierarchy that would suggest that I am above anyone else. I am not.