### PR TITLE
Added Donor Advised Fund Widget script files

### DIFF
--- a/DAF_Widget/DAF Direct Widget Hyperlink (Copy-Paste Usage).txt
+++ b/DAF_Widget/DAF Direct Widget Hyperlink (Copy-Paste Usage).txt
@@ -1,0 +1,3 @@
+DAF Direct Widget Hyperlink (Copy-Paste Usage):
+
+https://www.dafdirect.org/DAFDirect/daflink?_dafdirect_settings=ODUyNzIyMjQ5XzIxMTFfMjU4NjM2NDMtZGUxYS00Yjc1LTk4NGEtM2U0MTg5ZjZjZmEz&designatedText=&amountValue=

--- a/DAF_Widget/DAF Direct Widget Script (160 x 273 px).txt
+++ b/DAF_Widget/DAF Direct Widget Script (160 x 273 px).txt
@@ -1,0 +1,3 @@
+DAF Direct Widget Script (160 x 273 px):
+
+<script type = "text/javascript">_dafdirect_settings="852722249_1111_68591dca-5075-45f8-a915-02991f4111c8"</script><script type = "text/javascript" src = "https://www.dafdirect.org/ddirect/dafdirect4.js"></script>

--- a/DAF_Widget/DAF Direct Widget Script (250 x 327 px).txt
+++ b/DAF_Widget/DAF Direct Widget Script (250 x 327 px).txt
@@ -1,0 +1,3 @@
+DAF Direct Widget Script (250 x 327 px):
+
+<script type = "text/javascript">_dafdirect_settings="852722249_2111_5cfc50f3-b664-4d85-8335-89fd5b6ef1ff"</script><script type = "text/javascript" src = "https://www.dafdirect.org/ddirect/dafdirect4.js"></script>


### PR DESCRIPTION
@dergigi 

I have not made any changes to the code. This pull request includes the necessary resources for adding the Donor Advised Fund Widget to the website:

1. Hyperlink File: Contains a direct website hyperlink to access the widget (for social media shares, text messages, etc.)
2. Narrow Widget Script (160 x 273 px)
3. Square Widget Script (250 x 327 px)

This PR is based on the original Issue under Volunteers. [Reference original Issue here.](https://github.com/OpenSats/volunteers/issues/13)


**The following screenshot is merely a suggestion to where the Widget feature can live once a Donor click on the Donate button from the website:**


![Suggested location of DAF Direct Payment Widget](https://github.com/OpenSats/website/assets/141419722/1e17ef2e-0fdf-477b-8593-678b391180f6)


