### PR TITLE
Remove Bottle Pay from Supporter List

### DIFF
--- a/components/Supporters.tsx
+++ b/components/Supporters.tsx
@@ -8,7 +8,6 @@ const Credits = () => {
   const thebitcoincompanyLogo = '/img/supporters/tbc.png'
   const unchainedLogo = '/img/supporters/unchained.png'
   const lianaLogo = '/img/supporters/liana.png'
-  const bottlepayLogo = '/img/supporters/bottlepay.png'
   const btcPayServerLogo = '/img/supporters/btc-pay-server.png'
   const duxReserveLogoWithCastlenine =
     '/img/supporters/castlenine-dux-reserve.jpg'
@@ -25,11 +24,6 @@ const Credits = () => {
   const zapirte = '/img/supporters/zaprite.png'
 
   const supporters: CreditItemProps[] = [
-    {
-      link: 'https://bottlepay.com/',
-      image: bottlepayLogo,
-      nym: 'Bottlepay',
-    },
     {
       link: 'https://btcpayserver.org/',
       image: btcPayServerLogo,


### PR DESCRIPTION
Bottle Pay is no longer in service, so I would think to remove them from our list of supporters... although, I can understand the argument against that.

<img width="1012" alt="image" src="https://github.com/OpenSats/website/assets/8769819/15109b40-3cb1-4130-979b-c5dc65300eac">
