### PR TITLE
Add email confirmation field to forms

### DIFF
--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -11,6 +11,7 @@ export default function ApplicationForm() {
     watch,
     register,
     handleSubmit,
+    getValues,
     formState: { errors },
   } = useForm()
 
@@ -20,7 +21,6 @@ export default function ApplicationForm() {
   const onSubmit = async (data: any) => {
     setLoading(true)
     console.log(data)
-
     try {
       // Track application in GitHub
       const res = await fetchPostJSON('/api/github', data)
@@ -197,6 +197,22 @@ export default function ApplicationForm() {
           placeholder="satoshin@gmx.com"
           {...register('email', { required: true })}
         />
+      </label>
+      <label className="block">
+        Re-enter Email *
+        <input
+          type="email"
+          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
+          placeholder="satoshin@gmx.com"
+          {...register('email2', {
+            required: true,
+            validate: () =>
+              getValues('email') === getValues('email2') || 'Emails must match',
+          })}
+        />
+        <small className="text-red-500">
+          {errors?.email2 && errors.email2.message.toString()}
+        </small>
       </label>
       <label className="inline-flex items-center">
         <input

--- a/components/LTSApplicationForm.tsx
+++ b/components/LTSApplicationForm.tsx
@@ -11,6 +11,7 @@ export default function ApplicationForm() {
     watch,
     register,
     handleSubmit,
+    getValues,
     formState: { errors },
   } = useForm()
 
@@ -20,7 +21,6 @@ export default function ApplicationForm() {
   const onSubmit = async (data: any) => {
     setLoading(true)
     console.log(data)
-
     try {
       // Track application in GitHub
       const res = await fetchPostJSON('/api/github', data)
@@ -87,6 +87,22 @@ export default function ApplicationForm() {
           placeholder="satoshin@gmx.com"
           {...register('email', { required: true })}
         />
+      </label>
+      <label className="block">
+        Re-enter Email *
+        <input
+          type="email"
+          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
+          placeholder="satoshin@gmx.com"
+          {...register('email2', {
+            required: true,
+            validate: () =>
+              getValues('email') === getValues('email2') || 'Emails must match',
+          })}
+        />
+        <small className="text-red-500">
+          {errors?.email2 && errors.email2.message.toString()}
+        </small>
       </label>
       <label className="block">
         Personal Website, GitHub profile, or other Social Media

--- a/components/WebsiteApplicationForm.tsx
+++ b/components/WebsiteApplicationForm.tsx
@@ -11,6 +11,7 @@ export default function ApplicationForm() {
     watch,
     register,
     handleSubmit,
+    getValues,
     formState: { errors },
   } = useForm()
 
@@ -20,7 +21,6 @@ export default function ApplicationForm() {
   const onSubmit = async (data: any) => {
     setLoading(true)
     console.log(data)
-
     try {
       // Track application in GitHub
       const res = await fetchPostJSON('/api/github', data)
@@ -183,6 +183,22 @@ export default function ApplicationForm() {
           placeholder="satoshin@gmx.com"
           {...register('email', { required: true })}
         />
+      </label>
+      <label className="block">
+        Re-enter Email *
+        <input
+          type="email"
+          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
+          placeholder="satoshin@gmx.com"
+          {...register('email2', {
+            required: true,
+            validate: () =>
+              getValues('email') === getValues('email2') || 'Emails must match',
+          })}
+        />
+        <small className="text-red-500">
+          {errors?.email2 && errors.email2.message.toString()}
+        </small>
       </label>
       <label className="inline-flex items-center">
         <input


### PR DESCRIPTION
The website currently does some standard validation of email inputs. 

I've incorporated here @abitcoinperson 's suggestion of having a "re-enter email" field that checks that the two emails provided are the same.

@dergigi let me know if you had something different in mind. For example, it looks like higher levels (Pro, Premier) of sendgrid have other types of email validation. See https://sendgrid.com/en-us/pricing