### PR TITLE
Disable form submission after form submit

### DIFF
--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -6,6 +6,7 @@ import FormButton from '@/components/FormButton'
 
 export default function ApplicationForm() {
   const [loading, setLoading] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
   const router = useRouter()
   const {
     watch,
@@ -39,6 +40,7 @@ export default function ApplicationForm() {
         const res = await fetchPostJSON('/api/sendgrid', data)
         if (res.message === 'success') {
           router.push('/submitted')
+          setSubmitted(true)
         } else {
           setFailureReason(res.message)
         }
@@ -279,7 +281,7 @@ export default function ApplicationForm() {
       </div>
 
       <FormButton
-        variant={isFLOSS ? 'enabled' : 'disabled'}
+        variant={isFLOSS && !submitted ? 'enabled' : 'disabled'}
         type="submit"
         disabled={loading}
       >

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -20,6 +20,7 @@ export default function ApplicationForm() {
 
   const onSubmit = async (data: any) => {
     setLoading(true)
+    setSubmitted(true)
     console.log(data)
 
     try {
@@ -40,13 +41,14 @@ export default function ApplicationForm() {
         const res = await fetchPostJSON('/api/sendgrid', data)
         if (res.message === 'success') {
           router.push('/submitted')
-          setSubmitted(true)
         } else {
           setFailureReason(res.message)
+          setSubmitted(false)
         }
       } catch (e) {
         if (e instanceof Error) {
           setFailureReason(e.message)
+          setSubmitted(false)
         }
       } finally {
         setLoading(false)

--- a/components/LTSApplicationForm.tsx
+++ b/components/LTSApplicationForm.tsx
@@ -6,6 +6,7 @@ import FormButton from '@/components/FormButton'
 
 export default function ApplicationForm() {
   const [loading, setLoading] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
   const router = useRouter()
   const {
     watch,
@@ -39,6 +40,7 @@ export default function ApplicationForm() {
         const res = await fetchPostJSON('/api/sendgrid', data)
         if (res.message === 'success') {
           router.push('/submitted')
+          setSubmitted(true)
         } else {
           setFailureReason(res.message)
         }
@@ -230,7 +232,7 @@ export default function ApplicationForm() {
       </div>
 
       <FormButton
-        variant={isFLOSS ? 'enabled' : 'disabled'}
+        variant={isFLOSS && !submitted ? 'enabled' : 'disabled'}
         type="submit"
         disabled={loading}
       >

--- a/components/LTSApplicationForm.tsx
+++ b/components/LTSApplicationForm.tsx
@@ -20,6 +20,7 @@ export default function ApplicationForm() {
 
   const onSubmit = async (data: any) => {
     setLoading(true)
+    setSubmitted(true)
     console.log(data)
 
     try {
@@ -40,12 +41,13 @@ export default function ApplicationForm() {
         const res = await fetchPostJSON('/api/sendgrid', data)
         if (res.message === 'success') {
           router.push('/submitted')
-          setSubmitted(true)
         } else {
+          setSubmitted(false)
           setFailureReason(res.message)
         }
       } catch (e) {
         if (e instanceof Error) {
+          setSubmitted(false)
           setFailureReason(e.message)
         }
       } finally {

--- a/components/WebsiteApplicationForm.tsx
+++ b/components/WebsiteApplicationForm.tsx
@@ -6,6 +6,7 @@ import FormButton from '@/components/FormButton'
 
 export default function ApplicationForm() {
   const [loading, setLoading] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
   const router = useRouter()
   const {
     watch,
@@ -39,6 +40,7 @@ export default function ApplicationForm() {
         const res = await fetchPostJSON('/api/sendgrid', data)
         if (res.message === 'success') {
           router.push('/submitted')
+          setSubmitted(true)
         } else {
           setFailureReason(res.message)
         }
@@ -258,7 +260,7 @@ export default function ApplicationForm() {
       </div>
 
       <FormButton
-        variant={isFLOSS ? 'enabled' : 'disabled'}
+        variant={isFLOSS && !submitted ? 'enabled' : 'disabled'}
         type="submit"
         disabled={loading}
       >

--- a/components/WebsiteApplicationForm.tsx
+++ b/components/WebsiteApplicationForm.tsx
@@ -20,6 +20,7 @@ export default function ApplicationForm() {
 
   const onSubmit = async (data: any) => {
     setLoading(true)
+    setSubmitted(true)
     console.log(data)
 
     try {
@@ -40,12 +41,13 @@ export default function ApplicationForm() {
         const res = await fetchPostJSON('/api/sendgrid', data)
         if (res.message === 'success') {
           router.push('/submitted')
-          setSubmitted(true)
         } else {
+          setSubmitted(false)
           setFailureReason(res.message)
         }
       } catch (e) {
         if (e instanceof Error) {
+          setSubmitted(false)
           setFailureReason(e.message)
         }
       } finally {


### PR DESCRIPTION
Added "submitted" state variable to form pages to track status of submission;

Upon sending successful email to opensats, toggle submitted variable and disable 'submit' button

@dergigi I had limited ability to test this PR (presumably due to not having sendgrid credentials etc.) so apologies if there is something awry.