### PR TITLE
Add sats denomination to donation form

### DIFF
--- a/components/DonationForm.tsx
+++ b/components/DonationForm.tsx
@@ -45,6 +45,14 @@ const DonationSteps: React.FC<DonationStepsProps> = ({
     '500',
   ])
 
+  // used to set the value input field if presetValue is chosen
+  const satValues = {
+    '50k': '50000',
+    '100k': '100000',
+    '250k': '250000',
+    '500k': '500000',
+  }
+
   const formRef = useRef<HTMLFormElement | null>(null)
 
   const radioHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -58,11 +66,10 @@ const DonationSteps: React.FC<DonationStepsProps> = ({
       setDenomination('SATS')
       setAmount('')
       setPresetDonationsValues([
-        '100,000',
-        '250,000',
-        '500,000',
-        '1,000,000',
-        '5,000,000',
+        '50k',
+        '100k',
+        '250k',
+        '500k',
       ])
     } else {
       setDenomination('USD')
@@ -77,11 +84,11 @@ const DonationSteps: React.FC<DonationStepsProps> = ({
     if (denomination == 'USD') {
       setAmount(value)
     } else {
-      setAmount(value.replace(/[,]/g, ''))
-      // Remove commas before converting sat amount to btc
+      const satValue = satValues[value] || ''
+      setAmount(satValue)
+        
       // Convert sats to btc before adding to btcpayserver payload
-      const santizedAmount = value.replace(/[,]/g, '')
-      const formatSats = convertToBtc(santizedAmount)
+      const formatSats = convertToBtc(satValue)
       setBtcAmount(formatSats)
     }
   }
@@ -272,14 +279,13 @@ const DonationSteps: React.FC<DonationStepsProps> = ({
               className="group"
               onClick={(e) => handleAmountClick(e, value?.toString() ?? '')}
             >
-              {value && denomination === 'USD' ? `$${value}` : `${value} sats`}
+              {value && denomination === 'USD' ? `$${value}` : `${value}`}
             </button>
           ))}
           <div className="relative flex w-full">
-            <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-              {/* <FontAwesomeIcon icon={faDollarSign} className="w-5 h-5 text-black" /> */}
-              <span className="mb-2 h-5 w-5 font-mono text-xl">
-                {denomination === 'USD' ? '$' : 'sats'}
+            <div className={`pointer-events-none absolute inset-y-0 left-0 flex items-center ${denomination === 'USD' ? 'pl-2' : ''}`}>
+              <span className="mb-2 h-5 w-5 text-lg text-black pl-2">
+                {denomination === 'USD' ? '$' : 'sat'}
               </span>
             </div>
             <input

--- a/components/DonationForm.tsx
+++ b/components/DonationForm.tsx
@@ -65,12 +65,7 @@ const DonationSteps: React.FC<DonationStepsProps> = ({
     if (value === 'USD') {
       setDenomination('SATS')
       setAmount('')
-      setPresetDonationsValues([
-        '50k',
-        '100k',
-        '250k',
-        '500k',
-      ])
+      setPresetDonationsValues(['50k', '100k', '250k', '500k'])
     } else {
       setDenomination('USD')
       setAmount('')
@@ -86,7 +81,7 @@ const DonationSteps: React.FC<DonationStepsProps> = ({
     } else {
       const satValue = satValues[value] || ''
       setAmount(satValue)
-        
+
       // Convert sats to btc before adding to btcpayserver payload
       const formatSats = convertToBtc(satValue)
       setBtcAmount(formatSats)
@@ -136,7 +131,7 @@ const DonationSteps: React.FC<DonationStepsProps> = ({
 
     setReadyToPayFiat(fiatValid)
     setReadyToPayBTC(btcValid)
-  }, [deductible, amount, btcAmount, email, name])
+  }, [denomination, deductible, amount, btcAmount, email, name])
 
   async function handleBtcPay() {
     const validity = formRef.current?.checkValidity()
@@ -283,8 +278,12 @@ const DonationSteps: React.FC<DonationStepsProps> = ({
             </button>
           ))}
           <div className="relative flex w-full">
-            <div className={`pointer-events-none absolute inset-y-0 left-0 flex items-center ${denomination === 'USD' ? 'pl-2' : ''}`}>
-              <span className="mb-2 h-5 w-5 text-lg text-black pl-2">
+            <div
+              className={`pointer-events-none absolute inset-y-0 left-0 flex items-center ${
+                denomination === 'USD' ? 'pl-2' : ''
+              }`}
+            >
+              <span className="mb-2 h-5 w-5 pl-2 text-lg text-black">
                 {denomination === 'USD' ? '$' : 'sat'}
               </span>
             </div>

--- a/components/DonationForm.tsx
+++ b/components/DonationForm.tsx
@@ -19,7 +19,6 @@ type DonationStepsProps = {
   zaprite: string
 }
 
-
 const DonationSteps: React.FC<DonationStepsProps> = ({
   projectNamePretty,
   btcpay,
@@ -30,7 +29,7 @@ const DonationSteps: React.FC<DonationStepsProps> = ({
 
   const [deductible, setDeductible] = useState('yes')
   const [amount, setAmount] = useState('')
-  const [btcAmount, setBtcAmount] = useState("")
+  const [btcAmount, setBtcAmount] = useState('')
 
   const [readyToPayFiat, setReadyToPayFiat] = useState(false)
   const [readyToPayBTC, setReadyToPayBTC] = useState(false)
@@ -38,70 +37,94 @@ const DonationSteps: React.FC<DonationStepsProps> = ({
   const [btcPayLoading, setBtcpayLoading] = useState(false)
   const [fiatLoading, setFiatLoading] = useState(false)
 
-  const [denomination, setDenomination] = useState("USD")
-  const [presetDonationValues, setPresetDonationsValues] = useState(["50", "100", "250", "500"])
-
+  const [denomination, setDenomination] = useState('USD')
+  const [presetDonationValues, setPresetDonationsValues] = useState([
+    '50',
+    '100',
+    '250',
+    '500',
+  ])
 
   const formRef = useRef<HTMLFormElement | null>(null)
 
   const radioHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
     setDeductible(event.target.value)
   }
-  
+
   // toggles between USD and SATS denomination
   function handleDenomination(e: React.MouseEvent, value: string) {
     e.preventDefault()
-    if (value === "USD") {
-        setDenomination("SATS")
-        setAmount("")
-        setPresetDonationsValues(["100,000", "250,000", "500,000", "1,000,000", "5,000,000"])
+    if (value === 'USD') {
+      setDenomination('SATS')
+      setAmount('')
+      setPresetDonationsValues([
+        '100,000',
+        '250,000',
+        '500,000',
+        '1,000,000',
+        '5,000,000',
+      ])
     } else {
-        setDenomination("USD")
-        setAmount("")
-        setPresetDonationsValues(["50", "100", "250", "500"])
+      setDenomination('USD')
+      setAmount('')
+      setPresetDonationsValues(['50', '100', '250', '500'])
     }
-
   }
 
   // Adds preset amount to input field
   function handleAmountClick(e: React.MouseEvent, value: string) {
     e.preventDefault()
-    if (denomination == "USD") {
-        setAmount(value)
+    if (denomination == 'USD') {
+      setAmount(value)
     } else {
-        setAmount(value.replace(/[,]/g, ""))
-        // Remove commas before converting sat amount to btc
-        // Convert sats to btc before adding to btcpayserver payload 
-        const santizedAmount = value.replace(/[,]/g, "") 
-        const formatSats = convertToBtc(santizedAmount) 
-        setBtcAmount(formatSats)
+      setAmount(value.replace(/[,]/g, ''))
+      // Remove commas before converting sat amount to btc
+      // Convert sats to btc before adding to btcpayserver payload
+      const santizedAmount = value.replace(/[,]/g, '')
+      const formatSats = convertToBtc(santizedAmount)
+      setBtcAmount(formatSats)
     }
-
   }
 
   // Convert SATS to BTC for the onBlur of amount input field
   // Needed in order to pass it to btcpayserver
   function handleSatToBtcConversion(value: string) {
-      const convertedAmount = convertToBtc(value)
-      setBtcAmount(convertedAmount)
+    const convertedAmount = convertToBtc(value)
+    setBtcAmount(convertedAmount)
   }
-  
+
   useEffect(() => {
     let fiatValid = false
     let btcValid: boolean
-    let amountChecks = amount && typeof parseInt(amount) === "number"
+    const amountChecks = amount && typeof parseInt(amount) === 'number'
 
-    if (amountChecks && parseFloat(amount) > 0 && denomination === "USD" && deductible === "yes" && (name && email)) {
-        fiatValid = true
-        btcValid = true  
-    } else if (amountChecks && denomination === "USD" && deductible === "no" && parseFloat(amount) > 0) {
-        fiatValid = true
-        btcValid = true
-    } else if (denomination === "SATS" && deductible === "no" && satsIsGreaterThanZero(btcAmount)) {
-        btcValid = true
+    if (
+      amountChecks &&
+      parseFloat(amount) > 0 &&
+      denomination === 'USD' &&
+      deductible === 'yes' &&
+      name &&
+      email
+    ) {
+      fiatValid = true
+      btcValid = true
+    } else if (
+      amountChecks &&
+      denomination === 'USD' &&
+      deductible === 'no' &&
+      parseFloat(amount) > 0
+    ) {
+      fiatValid = true
+      btcValid = true
+    } else if (
+      denomination === 'SATS' &&
+      deductible === 'no' &&
+      satsIsGreaterThanZero(btcAmount)
+    ) {
+      btcValid = true
     } else {
-        fiatValid = false
-        btcValid = false
+      fiatValid = false
+      btcValid = false
     }
 
     setReadyToPayFiat(fiatValid)
@@ -113,18 +136,18 @@ const DonationSteps: React.FC<DonationStepsProps> = ({
     if (!validity) {
       return
     }
-    
+
     setBtcpayLoading(true)
     try {
       const payload = {
         btcpay,
         zaprite,
-        ...(denomination === "USD" ? { amount } : { btcAmount }),
-        ...(denomination === "SATS" ? { currency: "BTC" } : {}),
+        ...(denomination === 'USD' ? { amount } : { btcAmount }),
+        ...(denomination === 'SATS' ? { currency: 'BTC' } : {}),
         ...(email ? { email } : {}),
         ...(name ? { name } : {}),
-      };
-      
+      }
+
       console.log(payload)
 
       const data = await fetchPostJSON('/api/btcpay', payload)
@@ -236,26 +259,28 @@ const DonationSteps: React.FC<DonationStepsProps> = ({
           <h3>How much would you like to donate?</h3>
         </div>
         <div className="flex flex-col gap-2 py-2 sm:flex-row" role="group">
-            <button
-                name="denomination"
-                className="group"
-                onClick={(e) => handleDenomination(e, denomination)}
-            >
-                {denomination}
-            </button>
-            {(presetDonationValues.map((value, index) => (
+          <button
+            name="denomination"
+            className="group"
+            onClick={(e) => handleDenomination(e, denomination)}
+          >
+            {denomination}
+          </button>
+          {presetDonationValues.map((value, index) => (
             <button
               key={index}
               className="group"
               onClick={(e) => handleAmountClick(e, value?.toString() ?? '')}
             >
-              {value && denomination === "USD" ? `$${value}` : `${value} sats`}
+              {value && denomination === 'USD' ? `$${value}` : `${value} sats`}
             </button>
-          )))}
+          ))}
           <div className="relative flex w-full">
             <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
               {/* <FontAwesomeIcon icon={faDollarSign} className="w-5 h-5 text-black" /> */}
-              <span className="mb-2 h-5 w-5 font-mono text-xl">{denomination === 'USD' ? '$': 'sats'}</span>
+              <span className="mb-2 h-5 w-5 font-mono text-xl">
+                {denomination === 'USD' ? '$' : 'sats'}
+              </span>
             </div>
             <input
               type="number"
@@ -264,9 +289,17 @@ const DonationSteps: React.FC<DonationStepsProps> = ({
               onChange={(e) => {
                 setAmount(e.target.value)
               }}
-              onBlur={(e) => { denomination === "SATS" ? handleSatToBtcConversion(e.target.value) : setAmount(e.target.value)}}
+              onBlur={(e) => {
+                denomination === 'SATS'
+                  ? handleSatToBtcConversion(e.target.value)
+                  : setAmount(e.target.value)
+              }}
               className="mt-1 block w-full w-full rounded-md border-gray-300 !pl-10 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
-              placeholder= {denomination === "USD" ? "Enter custom amount" : "Enter custom amount in sats"}
+              placeholder={
+                denomination === 'USD'
+                  ? 'Enter custom amount'
+                  : 'Enter custom amount in sats'
+              }
             />
           </div>
         </div>
@@ -292,7 +325,7 @@ const DonationSteps: React.FC<DonationStepsProps> = ({
           name="stripe"
           onClick={handleFiat}
           className="pay"
-          disabled={!readyToPayFiat || fiatLoading || denomination === "SATS"} 
+          disabled={!readyToPayFiat || fiatLoading || denomination === 'SATS'}
         >
           {fiatLoading ? (
             <Spinner />

--- a/pages/api/btcpay.ts
+++ b/pages/api/btcpay.ts
@@ -13,12 +13,13 @@ export default async function handler(
   res: NextApiResponse
 ) {
   if (req.method === 'POST') {
-    const { amount, btcpay, email, name }: PayReq = req.body
+    const { amount, btcpay, email, name, currency = CURRENCY }: PayReq = req.body
     const REDIRECT = 'http://opensats.org/thankyou'
 
     try {
       // Validate the amount that was passed from the client.
-      if (amount != null && amount < MIN_AMOUNT) {
+      // Skip BTC verification done client side
+      if (currency !== "BTC" && amount != null && amount < MIN_AMOUNT) {
         throw new Error('Invalid amount.')
       }
       if (!btcpay) {
@@ -32,7 +33,7 @@ export default async function handler(
         throw new Error('Invalid project.')
       }
       const reqData = {
-        currency: CURRENCY,
+        currency: currency,
         metadata: {
           orderId: project.btcpay,
           project_name: project.title,
@@ -50,7 +51,7 @@ export default async function handler(
         },
         checkout: { redirectURL: REDIRECT },
       }
-
+        
       if (amount) {
         Object.assign(reqData, { amount })
       }

--- a/pages/api/btcpay.ts
+++ b/pages/api/btcpay.ts
@@ -13,13 +13,19 @@ export default async function handler(
   res: NextApiResponse
 ) {
   if (req.method === 'POST') {
-    const { amount, btcpay, email, name, currency = CURRENCY }: PayReq = req.body
+    const {
+      amount,
+      btcpay,
+      email,
+      name,
+      currency = CURRENCY,
+    }: PayReq = req.body
     const REDIRECT = 'http://opensats.org/thankyou'
 
     try {
       // Validate the amount that was passed from the client.
       // Skip BTC verification done client side
-      if (currency !== "BTC" && amount != null && amount < MIN_AMOUNT) {
+      if (currency !== 'BTC' && amount != null && amount < MIN_AMOUNT) {
         throw new Error('Invalid amount.')
       }
       if (!btcpay) {
@@ -51,7 +57,7 @@ export default async function handler(
         },
         checkout: { redirectURL: REDIRECT },
       }
-        
+
       if (amount) {
         Object.assign(reqData, { amount })
       }

--- a/utils/convertToBitcoin.ts
+++ b/utils/convertToBitcoin.ts
@@ -1,0 +1,31 @@
+/**
+* @param {string} amount - A string representation of satoshis  
+* @returns {string} - Returns a string representation of the amount in BTC notation 
+*/
+export default function convertToBtc(amount: string): string | null {
+        // convert and round amount to integer - must use parseInt here
+        const parseAmount = parseInt(amount, 10);
+        const roundedAmount  = Math.round(parseAmount);
+
+        let btcAmount: string;
+
+        if (!Number.isNaN(roundedAmount)) {
+            const leadingZeros = 9  
+            // calculate leading zeros required
+            // add leading zeros to rounded amount 
+            const addZeros = `0`.repeat(Math.max(leadingZeros - roundedAmount.toString().length, 0)) + roundedAmount;
+            // add period leaving 8 decimals places 
+            const addDecimalPoint = addZeros.replace(/(\d+)(\d{8})$/,
+                                                     (match, part1, part2) => `${part1}.${part2}`);
+
+            // additonal formating for large amounts - add required commas
+            const [integerPart, decimalPart] = addDecimalPoint.split('.');
+            const formatLocale = Number(integerPart).toLocaleString();
+            
+            btcAmount = `${formatLocale}.${decimalPart}`;
+        } else {
+            return null;
+        }
+        return btcAmount;
+}
+

--- a/utils/satsIsGreaterThanZero.ts
+++ b/utils/satsIsGreaterThanZero.ts
@@ -1,0 +1,10 @@
+/**
+ * @param {string} value - a string representation of a float with 8 decimal points (btc)
+ * @returns {boolean} - Returns true if value passed is larger then 1 sat
+ */
+export default function satsIsGreaterThanZero(value: string): boolean {
+  const parsedValue = parseFloat(value);
+  const threshold = 0.00000001; 
+
+  return parsedValue >= threshold;
+}

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,5 +1,6 @@
 export type PayReq = {
   amount: number
+  currency: string 
   btcpay: string
   project_name: string
   email?: string


### PR DESCRIPTION
Hello everyone! This pull request addresses issue #41 

Changes made: 

1. Adds a `SATS` and `USD` toggle infront of the preset donation amounts
2. Input field accepts an amount in satoshi if toggle is set to `SATS`. 
3. If `SATS` is used, amount is first converted to `BTC` format before being added to the `/api/btcpay` `POST` request. `BTC` invoice payload currency field will be set to `BTC` if `sats` are used, otherwise defaults to `USD`.
4. Refactored conditional logic in `useEffect` on `DonationForm` component used to set btc/fiat payment buttons valid
5. Changed `Object.assign` for payload creation to use the spread syntax to accommodate my changes and enhance readability.

<img src="https://github.com/OpenSats/website/assets/55212954/2a3f8a0d-35f9-40d8-be23-d22303d56dd8" width="250" height="75">
<br>
<img src="https://github.com/OpenSats/website/assets/55212954/03b3c323-eebb-4374-ac89-3e11515b49cc" width="250" height="75">
<br>


Notes:
1. I've tested this locally and the payload/post requests appear to be working as intended but I cannot fully it test it as I do not have the capability of making calls to the BtcPay Server or to Stripe checkout (no changes made to USD donations). 
3. Since this impacts users' ability to donate it would be great if a couple people could review and test. As far as I can tell this mimics the current production build however I have tighten up client side validation of the amount being passed (e.g. cannot submit an amount of 0). 

If you have any suggestions/remarks or need clarification on some of the changes I made, please let me know :) 


