### PR TITLE
Fix project images

### DIFF
--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -5,11 +5,13 @@ import { Project } from 'contentlayer/generated'
 export type ProjectCardProps = {
   project: Project
   openPaymentModal: (project: Project) => void
+  customImageStyles?: React.CSSProperties
 }
 
 const ProjectCard: React.FC<ProjectCardProps> = ({
   project,
   openPaymentModal,
+  customImageStyles,
 }) => {
   const {
     slug,
@@ -42,20 +44,20 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
   return (
     <figure className={cardStyle}>
       <Link href={`/projects/${slug}`} passHref>
-        <div className="relative h-64 w-full">
+        <div className="flex h-36 w-full sm:h-52">
           <Image
             alt={title}
             src={coverImage}
-            layout="fill"
-            objectFit="cover"
-            objectPosition="50% 50%"
+            width={1200}
+            height={800}
+            style={{objectFit: "fill", ...customImageStyles}}
             className="cursor-pointer rounded-t-xl bg-white dark:bg-black"
           />
         </div>
-        <figcaption className="space-y-1 pb-4 pl-2 pr-2 pt-4">
+        <figcaption className="p-2">
           <h2 className="font-bold">{title}</h2>
-          <div className="mb-8 text-sm">by {nym}</div>
-          <div className="line-clamp-4">{summary}</div>
+          <div className="mb-4 text-sm underline">by {nym}</div>
+          <div className="mb-2 line-clamp-3">{summary}</div>
         </figcaption>
       </Link>
     </figure>

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -50,7 +50,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
             src={coverImage}
             width={1200}
             height={800}
-            style={{objectFit: "fill", ...customImageStyles}}
+            style={{ objectFit: 'fill', ...customImageStyles }}
             className="cursor-pointer rounded-t-xl bg-white dark:bg-black"
           />
         </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -268,7 +268,7 @@ export default function Home({
           <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14">
             Explore Projects
           </h1>
-          <p className="pt-2 text-lg leading-7 text-gray-500 dark:text-gray-400">
+          <p className="pb-2 text-lg leading-7 text-gray-500 dark:text-gray-400">
             Browse through and{' '}
             <CustomLink href="/projects" className="underline">
               directly support projects

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -48,7 +48,7 @@ const AllProjects: NextPage<{ projects: Project[] }> = ({ projects }) => {
           {openSatsProjects &&
             openSatsProjects.map((p, i) => (
               <li key={i} className="">
-                <ProjectCard project={p} openPaymentModal={openPaymentModal} />
+                <ProjectCard project={p} openPaymentModal={openPaymentModal} customImageStyles={{objectFit: "cover"}}/>
               </li>
             ))}
         </ul>

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -48,7 +48,11 @@ const AllProjects: NextPage<{ projects: Project[] }> = ({ projects }) => {
           {openSatsProjects &&
             openSatsProjects.map((p, i) => (
               <li key={i} className="">
-                <ProjectCard project={p} openPaymentModal={openPaymentModal} customImageStyles={{objectFit: "cover"}}/>
+                <ProjectCard
+                  project={p}
+                  openPaymentModal={openPaymentModal}
+                  customImageStyles={{ objectFit: 'cover' }}
+                />
               </li>
             ))}
         </ul>


### PR DESCRIPTION
Fixes project image styles/responsiveness

1. Remove deprecated props on the Image comp
2. Modify Image comp styles 
3. Add customImageStyle prop to ProjectCard comp to style Opensat projects independently of other projects.  

Small changes but makes all the images consistent and properly sized. 