### PR TITLE
Update j9.mdx to replace broken URL for CBDC Tracker

### DIFF
--- a/data/authors/j9.mdx
+++ b/data/authors/j9.mdx
@@ -102,4 +102,4 @@ Dn4ov1TIyu+YPqvTKqLrK2NeicLfEXwqCZ516iPoipN+w/oNhGO6fwhn0+Y=
 ```
 
 [tmibp]: https://enegnei.github.io/This-Month-In-Bitcoin-Privacy/
-[cbdc]: https://cbdctracker.hrf.org/home
+[cbdc]: https://cbdctracker.hrf.org/fellows

--- a/data/authors/j9.mdx
+++ b/data/authors/j9.mdx
@@ -102,4 +102,4 @@ Dn4ov1TIyu+YPqvTKqLrK2NeicLfEXwqCZ516iPoipN+w/oNhGO6fwhn0+Y=
 ```
 
 [tmibp]: https://enegnei.github.io/This-Month-In-Bitcoin-Privacy/
-[cbdc]: https://cbdchumanrights.org/
+[cbdc]: https://cbdctracker.hrf.org/home


### PR DESCRIPTION
J9's bio on the opensats.org site has a hyperlink associated with the "CBDC Tracker Fellowship" words. This hyperlink is broken (https://cbdchumanrights.org/). It needs to be replaced with the following (https://cbdctracker.hrf.org/fellows) in order to direct viewers to the CBDC Tracker Fellowship page hosted by HRF.