### PR TITLE
Fix nostr fund link in blog post

### DIFF
--- a/data/blog/nostr-lts-long-term-support-for-nostr-developers.mdx
+++ b/data/blog/nostr-lts-long-term-support-for-nostr-developers.mdx
@@ -25,7 +25,7 @@ see fit, as long as it is bitcoin-only, free and open-source, and aligns with
 [our mission](/mission).
 
 All of our nostr grants, including our long-term support grants for nostr
-developers, are sourced from [The Nostr Fund](/projects/nostr) and made possible
+developers, are sourced from [The Nostr Fund](/funds/nostr) and made possible
 by generous donors like you.
 
 <center>


### PR DESCRIPTION
projects/nostr (404) --> funds/nostr

Found in the following blog article:
https://opensats.org/blog/nostr-lts-long-term-support-for-nostr-developers