### PR TITLE
Update Supporters > Andrew W. Blair

### DIFF
--- a/components/Supporters.tsx
+++ b/components/Supporters.tsx
@@ -85,7 +85,7 @@ const Credits = () => {
       nym: 'Ten31',
     },
     {
-      link: 'https://www.poynerspruill.com/professionals/andy-blair/',
+      link: 'https://adamshowell.com/about/',
       image: andrewWBlairLogo,
       nym: 'Andrew W. Blair',
       person: true,


### PR DESCRIPTION
Andy is no longer with Poyner Spruill (404 link broken).  Now a partner at Adams | Howell as of 2 months ago.  His info is not on the new firm site yet. 
Inserted Andrew's new firm About Us URL.
Alternatively you can use his LinkedIn profile URL instead (http://linkedin.com/in/andrew-w-blair-00b55b1)

![image](https://github.com/OpenSats/website/assets/141419722/82f6a4c0-04c1-4db5-ac82-ed2d07e68c3e)
