### PR TITLE
Fix link to nsecBunker

### DIFF
--- a/data/blog/pablofz7-receives-lts-grant.mdx
+++ b/data/blog/pablofz7-receives-lts-grant.mdx
@@ -12,7 +12,7 @@ We are excited to announce [PabloF7z](https://github.com/pablof7z) as our latest
 LTS grantee.
 
 Pablo is one of the most prolific developers within the Nostr community, with
-notable projects like [nsecBunker](https://nsecbunker.com/), [Nostr Development
+notable projects like [nsecBunker](https://github.com/kind-0/nsecbunkerd), [Nostr Development
 Kit (NDK)](https://github.com/nostr-dev-kit/ndk),
 [Shipyard](https://shipyard.pub/), [Highlighter](https://highlighter.com/),
 [Wikifreedia](https://wikifreedia.vercel.app/), and more.


### PR DESCRIPTION
https://nsecbunker.com/ (parked in 503 for now) >> https://github.com/kind-0/nsecbunkerd