### PR TITLE
Add license & heading to application form

### DIFF
--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -272,19 +272,7 @@ export default function ApplicationForm() {
         />
       </label>
       <hr />
-      <h2>Prior Contributions & References</h2>
-      <label className="block">
-        Prior Contributions
-        <br />
-        <small>
-          Please list any prior contributions to other open-source or
-          Bitcoin-related projects.
-        </small>
-        <textarea
-          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
-          {...register('bios')}
-        />
-      </label>
+      <h2>References & Prior Contributions</h2>
       <label className="block">
         References *<br />
         <small>
@@ -295,6 +283,18 @@ export default function ApplicationForm() {
         <textarea
           className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
           {...register('references', { required: true })}
+        />
+      </label>
+      <label className="block">
+        Prior Contributions
+        <br />
+        <small>
+          Please list any prior contributions to other open-source or
+          Bitcoin-related projects.
+        </small>
+        <textarea
+          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
+          {...register('bios')}
         />
       </label>
       <hr />

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -295,6 +295,15 @@ export default function ApplicationForm() {
           {...register('references', { required: true })}
         />
       </label>
+      <hr />
+      <h2>Anything Else We Should Know?</h2>
+      <label className="block">
+        Feel free to share whatever else might be important.
+        <textarea
+          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
+          {...register('anything_else')}
+        />
+      </label>
       <div className="prose">
         <small>
           Open Sats may require each recipient to sign a Grant Agreement before

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -271,6 +271,8 @@ export default function ApplicationForm() {
           {...register('other_contact')}
         />
       </label>
+      <hr />
+      <h2>Prior Contributions & References</h2>
       <label className="block">
         Prior Contributions
         <br />

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -54,6 +54,7 @@ ${req.body.anything_else ? req.body.anything_else : 'No.'}
 
 ---
 
+${req.body.license ? `License: ${req.body.license}` : ''}
 ${req.body.github ? req.body.github : ''}
 ${req.body.personal_github ? req.body.personal_github : ''}
         `


### PR DESCRIPTION
Minor change; diff is big because I switched the order of "references" (mandatory) & "prior contributions" (not mandatory).