### PR TITLE
Add nostr link to /funds pages

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -135,6 +135,7 @@ export const Funds = defineDocumentType(() => ({
     coverImage: { type: 'string', required: true },
     git: { type: 'string' },
     twitter: { type: 'string' },
+    nostr: { type: 'string' },
     personalTwitter: { type: 'string' },
     zaprite: { type: 'string', required: true },
     btcpay: { type: 'string', required: true },

--- a/data/authors/default.mdx
+++ b/data/authors/default.mdx
@@ -5,7 +5,7 @@ occupation: 501(c)(3) public charity
 company: OpenSats
 email: support@opensats.org
 twitter: https://twitter.com/OpenSats
-nostr: npub10pensatlcfwktnvjjw2dtem38n6rvw8g6fv73h84cuacxn4c28eqyfn34f
+nostr: 'npub10pensatlcfwktnvjjw2dtem38n6rvw8g6fv73h84cuacxn4c28eqyfn34f'
 github: https://github.com/OpenSats
 ---
 

--- a/data/funds/general.mdx
+++ b/data/funds/general.mdx
@@ -7,6 +7,7 @@ website: 'https://opensats.org'
 coverImage: '/static/images/projects/opensats_logo.png'
 git: 'https://github.com/OpenSats'
 twitter: 'opensats'
+nostr: 'npub10pensatlcfwktnvjjw2dtem38n6rvw8g6fv73h84cuacxn4c28eqyfn34f'
 hidden: false
 bonusUSD: 20670000
 zaprite: '32WbND8heqmY5wYYnIpa'

--- a/data/funds/nostr.mdx
+++ b/data/funds/nostr.mdx
@@ -7,6 +7,7 @@ website: 'https://opensats.org'
 coverImage: '/static/images/projects/nostr.png'
 git: 'https://github.com/OpenSats'
 twitter: 'opensats'
+nostr: 'npub10pensatlcfwktnvjjw2dtem38n6rvw8g6fv73h84cuacxn4c28eqyfn34f'
 zaprite: 'OoYtzNjilW1NRtDsxLAj'
 btcpay: 'nostr'
 tags: ['OpenSats', 'Fund']

--- a/data/funds/ops.mdx
+++ b/data/funds/ops.mdx
@@ -5,6 +5,7 @@ summary: 'Contributions to the OpenSats Operations Budget will be used to cover 
 coverImage: '/static/images/projects/opensats_operations.png'
 nym: 'OpenSats'
 twitter: 'opensats'
+nostr: 'npub10pensatlcfwktnvjjw2dtem38n6rvw8g6fv73h84cuacxn4c28eqyfn34f'
 website: 'https://opensats.org/'
 git: 'https://github.com/OpenSats'
 zaprite: 'lZo1wcsJ0SQb58XfGC4e'


### PR DESCRIPTION
Link to our nostr was missing on all [/funds](https://opensats.org/funds) pages. This fixes it.