### PR TITLE
Add "wave" tag to bitcoin/nostr wave announcements

### DIFF
--- a/data/blog/bitcoin-and-nostr-grants-august-2023.mdx
+++ b/data/blog/bitcoin-and-nostr-grants-august-2023.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Grants for BDK, LNbits, Nostr, and More!"
 date: '2023-08-17'
-tags: ['OpenSats', 'grants', 'bitcoin', 'nostr']
+tags: ['OpenSats', 'grants', 'bitcoin', 'nostr', 'wave']
 draft: false
 authors: ['odell']
 images: ['/static/images/blog/06-august.jpg']

--- a/data/blog/bitcoin-grants-december-2023.mdx
+++ b/data/blog/bitcoin-grants-december-2023.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Third Wave of Bitcoin Grants"
 date: '2023-12-18'
-tags: ['OpenSats', 'grants', 'bitcoin']
+tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
 draft: false
 authors: ['dergigi', 'odell']
 images: ['/static/images/blog/17-bitcoin-dec.jpg']

--- a/data/blog/bitcoin-grants-feb-2024.mdx
+++ b/data/blog/bitcoin-grants-feb-2024.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Fourth Wave of Bitcoin Grants"
 date: '2024-02-25'
-tags: ['OpenSats', 'grants', 'bitcoin']
+tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
 draft: false
 authors: ['rob', 'dergigi']
 images: ['/static/images/blog/24-bitcoin-feb.jpg']

--- a/data/blog/bitcoin-grants-july-2023.mdx
+++ b/data/blog/bitcoin-grants-july-2023.mdx
@@ -1,7 +1,7 @@
 ---
 title: "First Wave of Bitcoin Grants"
 date: '2023-07-14'
-tags: ['OpenSats', 'grants', 'bitcoin']
+tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
 draft: false
 authors: ['dergigi']
 images: ['/static/images/blog/04-bitcoin.jpg']

--- a/data/blog/bitcoin-grants-july-2024.mdx
+++ b/data/blog/bitcoin-grants-july-2024.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Fifth Wave of Bitcoin Grants"
 date: '2024-07-02'
-tags: ['OpenSats', 'grants', 'bitcoin']
+tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
 draft: false
 authors: ['btcschellingpt', 'arvin']
 images: ['/static/images/blog/36-bitcoin-jul.jpg']

--- a/data/blog/nostr-grants-december-2023.mdx
+++ b/data/blog/nostr-grants-december-2023.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Fourth Wave of Nostr Grants"
 date: '2023-12-21'
-tags: ['OpenSats', 'grants', 'nostr']
+tags: ['OpenSats', 'grants', 'nostr', 'wave']
 draft: false
 authors: ['nvk', 'dergigi']
 images: ['/static/images/blog/18-nostr-dec.jpg']

--- a/data/blog/nostr-grants-july-2023.mdx
+++ b/data/blog/nostr-grants-july-2023.mdx
@@ -1,7 +1,7 @@
 ---
 title: "First Wave of Nostr Grants"
 date: '2023-07-08'
-tags: ['OpenSats', 'grants', 'nostr']
+tags: ['OpenSats', 'grants', 'nostr', 'wave']
 draft: false
 authors: ['dergigi']
 images: ['/static/images/blog/03-nostr.jpg']

--- a/data/blog/nostr-grants-july-2024.mdx
+++ b/data/blog/nostr-grants-july-2024.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Fifth Wave of Nostr Grants"
 date: '2024-07-15'
-tags: ['OpenSats', 'grants', 'nostr']
+tags: ['OpenSats', 'grants', 'nostr', 'wave']
 draft: false
 authors: ['arvin', 'jason']
 images: ['/static/images/blog/39-nostr-jul.jpg']

--- a/data/blog/nostr-grants-october-2023.mdx
+++ b/data/blog/nostr-grants-october-2023.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Third Wave of Nostr Grants"
 date: '2023-10-18'
-tags: ['OpenSats', 'grants', 'nostr']
+tags: ['OpenSats', 'grants', 'nostr', 'wave']
 draft: false
 authors: ['dergigi', 'odell']
 images: ['/static/images/blog/11-nostr-oct.jpg']


### PR DESCRIPTION
Adds the "[wave](https://os-website-git-add-wave-tag-open-sats.vercel.app/tags/wave)" tag to all blog posts that announced a batch of grants.