### PR TITLE
Add canary to /transparency

### DIFF
--- a/data/pages/canary.mdx
+++ b/data/pages/canary.mdx
@@ -21,7 +21,8 @@ This canary is linked at [0] and will be re-signed on the following dates:
 * August 1
 * November 1
 
-We will include a link to a recent news article [1] in each update to establish that the signature was not pre-generated.
+We will include a link to a recent news article [1] in each update to establish
+that the signature was not pre-generated.
 
 [0] https://opensats.org/transparency
 [1] https://www.nobsbitcoin.com/mutiny-wallet-to-shut-down-at-the-end-of-the-year/

--- a/data/pages/canary.mdx
+++ b/data/pages/canary.mdx
@@ -1,0 +1,60 @@
+---
+title: Canary
+summary: "If the canary died, it was time to get out of the mine."
+image: /static/images/avatar.png
+layout: PageLayout
+---
+
+
+```
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA256
+
+OpenSats has never been pressured to give up non-public information on grantees
+and forced to keep quiet about it. OpenSats has never been pressured by outside
+entities to stop funding certain people or projects.
+
+This canary is linked at [0] and will be re-signed on the following dates:
+
+* February 1
+* May 1
+* August 1
+* November 1
+
+We will include a link to a recent news article [1] in each update to establish that the signature was not pre-generated.
+
+[0] https://opensats.org/transparency
+[1] https://www.nobsbitcoin.com/mutiny-wallet-to-shut-down-at-the-end-of-the-year/
+-----BEGIN PGP SIGNATURE-----
+
+iQIzBAEBCAAdFiEEgZihhTClIqCVYSQ5icSiXmml3n8FAmayEN0ACgkQicSiXmml
+3n/2FQ//bjFGhHSxEN7lur8fQG+mudd0pNfxmWnS5jbWNTugKrquBZyJIAKEYlR7
+Zx/F2Ev8z1aeOrRiot2tc2PqLYLMNUVyRSXocgG2uKY6mk0akoE5IxJLmBQwDP+R
+qM8qOvljeWyvfRPilyaG+sILWj0b+cQyQZsml2ZjWADOQtcKhvsGCXqU4rZB7j8r
+Ho/vR21YFF2k5pGj3kX8qeaWX00CauVqPZ9ElWO1BmwvXYC5OFIdNrr79sGarPON
+pk9/yinXuzrKR8k3EfNxarBXeyTs6DxdCKrOPFV+JCgKlsIwZvXyA87oVbol46qz
+0zkxxA7YTAPhZrDv+85iodby1KcrV3BmzuAhsKUbBdgnmAx/6TFV5scIPWEYTuvm
+cc5uhBROJzzecanCelneUiVbwBkP7lxaKzYTI+FWK64XUYblBHt2bpJzXCoC9aA+
+bp5EMoYqQ2OqjERf0rYgMEbYksl5Zb5Nch3W5wkuCPbrkFHRu56Gcnn4T2Xgtu+y
+0GL0QVJ7NEynDtiKBaWxiOiSYIzlRjRfoy/9SPWyeeJ5i9JwNrU+X4eeTZ+dFkZQ
+N9fYKt+DAS839PT5h1Dwh7/14u+ujg4cNpvqZNvP2Up23h1NzhDrtiiXMTxtps46
+cxTuIaBrGxbWfLgNEIgjkT3IMWqe2ZKRhcbNblyOj7fJQ3qswDc=
+=S4fG
+-----END PGP SIGNATURE-----
+```
+
+---
+
+# Don't trust, verify
+
+1. Import the [PGP key](/about/dergigi) of our executive director
+2. Download the [signed canary statement][scs]
+3. Run `gpg --auto-key-retrieve --verify canary.txt.asc`
+4. You should get an output that is similar to the following (note the date that the canary was signed):
+```
+gpg: Signature made Tue  6 Aug 13:02:37 2024 WEST
+gpg:                using RSA key 8198A18530A522A09561243989C4A25E69A5DE7F
+gpg: Good signature from "Gigi D. <gigi@opensats.org>" [ultimate]
+```
+
+[scs]: /docs/canary.txt.asc

--- a/data/pages/transparency.mdx
+++ b/data/pages/transparency.mdx
@@ -52,7 +52,7 @@ as in the internal and external processes of our organization.
 
 [coi]: /docs/conflict.pdf
 [tax]: /docs/tax.pdf
-[owc]: /docs/canary.txt
+[owc]: /canary
 [rrp]: /docs/rrp.pdf
 [eeo]: /docs/eeo.pdf
 [wpp]: /docs/whistle.pdf

--- a/data/pages/transparency.mdx
+++ b/data/pages/transparency.mdx
@@ -37,6 +37,7 @@ as in the internal and external processes of our organization.
 
 - [Conflict of Interest][coi]
 - [Tax Policy][tax]
+- [Canary][owc]
 - [Record Retention Policy][rrp]
 - [EEO & Non-Discrimination Policy][eeo]
 - [Whistleblower Protection Policy][wpp]
@@ -51,6 +52,7 @@ as in the internal and external processes of our organization.
 
 [coi]: /docs/conflict.pdf
 [tax]: /docs/tax.pdf
+[owc]: /docs/canary.txt
 [rrp]: /docs/rrp.pdf
 [eeo]: /docs/eeo.pdf
 [wpp]: /docs/whistle.pdf

--- a/pages/canary.tsx
+++ b/pages/canary.tsx
@@ -1,0 +1,23 @@
+import { InferGetStaticPropsType } from 'next'
+import { allPages } from 'contentlayer/generated'
+import { MDXLayoutRenderer } from 'pliny/mdx-components'
+import { MDXComponents } from '@/components/MDXComponents'
+
+const DEFAULT_LAYOUT = 'PageLayout'
+
+export const getStaticProps = async () => {
+  const page = allPages.find((p) => p.slug === 'canary')
+  return { props: { page: page } }
+}
+
+export default function Canary({
+  page,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
+  return (
+    <MDXLayoutRenderer
+      layout={page.layout || DEFAULT_LAYOUT}
+      content={page}
+      MDXComponents={MDXComponents}
+    />
+  )
+}

--- a/public/docs/canary.txt
+++ b/public/docs/canary.txt
@@ -1,3 +1,15 @@
 OpenSats has never been pressured to give up non-public information on grantees
 and forced to keep quiet about it. OpenSats has never been pressured by outside
 entities to stop funding certain people or projects.
+
+This canary is linked at [0] and will be re-signed on the following dates:
+
+* February 1
+* May 1
+* August 1
+* November 1
+
+We will include a link to a recent news article [1] in each update to establish that the signature was not pre-generated.
+
+[0] https://opensats.org/transparency
+[1] https://www.nobsbitcoin.com/mutiny-wallet-to-shut-down-at-the-end-of-the-year/

--- a/public/docs/canary.txt
+++ b/public/docs/canary.txt
@@ -1,0 +1,3 @@
+OpenSats has never been pressured to give up non-public information on grantees
+and forced to keep quiet about it. OpenSats has never been pressured by outside
+entities to stop funding certain people or projects.

--- a/public/docs/canary.txt.asc
+++ b/public/docs/canary.txt.asc
@@ -18,17 +18,17 @@ We will include a link to a recent news article [1] in each update to establish 
 [1] https://www.nobsbitcoin.com/mutiny-wallet-to-shut-down-at-the-end-of-the-year/
 -----BEGIN PGP SIGNATURE-----
 
-iQIzBAEBCAAdFiEEgZihhTClIqCVYSQ5icSiXmml3n8FAmayEN0ACgkQicSiXmml
-3n/2FQ//bjFGhHSxEN7lur8fQG+mudd0pNfxmWnS5jbWNTugKrquBZyJIAKEYlR7
-Zx/F2Ev8z1aeOrRiot2tc2PqLYLMNUVyRSXocgG2uKY6mk0akoE5IxJLmBQwDP+R
-qM8qOvljeWyvfRPilyaG+sILWj0b+cQyQZsml2ZjWADOQtcKhvsGCXqU4rZB7j8r
-Ho/vR21YFF2k5pGj3kX8qeaWX00CauVqPZ9ElWO1BmwvXYC5OFIdNrr79sGarPON
-pk9/yinXuzrKR8k3EfNxarBXeyTs6DxdCKrOPFV+JCgKlsIwZvXyA87oVbol46qz
-0zkxxA7YTAPhZrDv+85iodby1KcrV3BmzuAhsKUbBdgnmAx/6TFV5scIPWEYTuvm
-cc5uhBROJzzecanCelneUiVbwBkP7lxaKzYTI+FWK64XUYblBHt2bpJzXCoC9aA+
-bp5EMoYqQ2OqjERf0rYgMEbYksl5Zb5Nch3W5wkuCPbrkFHRu56Gcnn4T2Xgtu+y
-0GL0QVJ7NEynDtiKBaWxiOiSYIzlRjRfoy/9SPWyeeJ5i9JwNrU+X4eeTZ+dFkZQ
-N9fYKt+DAS839PT5h1Dwh7/14u+ujg4cNpvqZNvP2Up23h1NzhDrtiiXMTxtps46
-cxTuIaBrGxbWfLgNEIgjkT3IMWqe2ZKRhcbNblyOj7fJQ3qswDc=
-=S4fG
+iQIzBAEBCAAdFiEEgZihhTClIqCVYSQ5icSiXmml3n8FAmayHtMACgkQicSiXmml
+3n/CIg//fHdgaFpO3fS3BWiKVVQs6r+Udpxulse7j8/fTowbH9CW+2DDrl+1Bln7
+nGGgddAD5vD4/5ePuHowbO1kwPnbzEQD9+uT45Q1xJNPybvBEEr0UlayjWqy5ZRa
+DDzanF1ZYz5vbNZV2ug809yoSE+/dCz+U2IjJVKMafwyz10iMuB+5bkvi5AwI8zh
+lqaH+V2JArMA8jzKWYQyDlmKk1akNDEusHRPdJT+Nfzg87s4oAp3G3iZC5bt7Siu
+ROHI4RG5iS8KXlHbXEBdXAH9UA1NSRaI8Tl7zW98Pex5BZuwiN+X656QcfiFMn7S
+BHjKtG7XeINvz1EoUWYC6Gogk1DP2OGLW2EMQsXQZ0KBoRysr+psDzV3SaBxI6GX
+RDqHTGdkpKbn2BY4z+KPAB2rG433HcSK7YpurN7SKMKvNycLvYzDIvVvP6fBPdh1
+JibEk799BH+e/rDI3xY4XSeigkYoVFTQ2VWhYRuD6S6sGt1OwxUOs0cPLxJUZEl7
+OqE3bHqP9jGbXIxEjK1L2qBz/csRFqhkRb57A0wvcu3B/Tr0NyobyvHpS782P9Yt
+eSrtsLY0iQqC4DB2cDBgNqFPOUN1vRNGN69TPRVXIp5bcp/VwEr4flj6MniK9jnR
+g6WDziT5Lb10u5a4PxFQwPDgZkIInSmBKsSE1JToPiM9DlsIi2o=
+=Zswk
 -----END PGP SIGNATURE-----

--- a/public/docs/canary.txt.asc
+++ b/public/docs/canary.txt.asc
@@ -1,0 +1,34 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA256
+
+OpenSats has never been pressured to give up non-public information on grantees
+and forced to keep quiet about it. OpenSats has never been pressured by outside
+entities to stop funding certain people or projects.
+
+This canary is linked at [0] and will be re-signed on the following dates:
+
+* February 1
+* May 1
+* August 1
+* November 1
+
+We will include a link to a recent news article [1] in each update to establish that the signature was not pre-generated.
+
+[0] https://opensats.org/transparency
+[1] https://www.nobsbitcoin.com/mutiny-wallet-to-shut-down-at-the-end-of-the-year/
+-----BEGIN PGP SIGNATURE-----
+
+iQIzBAEBCAAdFiEEgZihhTClIqCVYSQ5icSiXmml3n8FAmayEN0ACgkQicSiXmml
+3n/2FQ//bjFGhHSxEN7lur8fQG+mudd0pNfxmWnS5jbWNTugKrquBZyJIAKEYlR7
+Zx/F2Ev8z1aeOrRiot2tc2PqLYLMNUVyRSXocgG2uKY6mk0akoE5IxJLmBQwDP+R
+qM8qOvljeWyvfRPilyaG+sILWj0b+cQyQZsml2ZjWADOQtcKhvsGCXqU4rZB7j8r
+Ho/vR21YFF2k5pGj3kX8qeaWX00CauVqPZ9ElWO1BmwvXYC5OFIdNrr79sGarPON
+pk9/yinXuzrKR8k3EfNxarBXeyTs6DxdCKrOPFV+JCgKlsIwZvXyA87oVbol46qz
+0zkxxA7YTAPhZrDv+85iodby1KcrV3BmzuAhsKUbBdgnmAx/6TFV5scIPWEYTuvm
+cc5uhBROJzzecanCelneUiVbwBkP7lxaKzYTI+FWK64XUYblBHt2bpJzXCoC9aA+
+bp5EMoYqQ2OqjERf0rYgMEbYksl5Zb5Nch3W5wkuCPbrkFHRu56Gcnn4T2Xgtu+y
+0GL0QVJ7NEynDtiKBaWxiOiSYIzlRjRfoy/9SPWyeeJ5i9JwNrU+X4eeTZ+dFkZQ
+N9fYKt+DAS839PT5h1Dwh7/14u+ujg4cNpvqZNvP2Up23h1NzhDrtiiXMTxtps46
+cxTuIaBrGxbWfLgNEIgjkT3IMWqe2ZKRhcbNblyOj7fJQ3qswDc=
+=S4fG
+-----END PGP SIGNATURE-----


### PR DESCRIPTION
Heavily inspired by [Riseup's canary](https://riseup.net/about-us/canary).

---

Adds the following files and links:
- [opensats.org/canary](https://os-website-git-canary-open-sats.vercel.app/canary) (linked in [/transparency](https://os-website-git-canary-open-sats.vercel.app/transparency))
- [/docs/canary.txt](https://os-website-git-canary-open-sats.vercel.app/docs/canary.txt)
- [/docs/canary.txt.asc](https://os-website-git-canary-open-sats.vercel.app/docs/canary.txt.asc)