### PR TITLE
Add `core` tag to core contributor announcements

### DIFF
--- a/data/blog/0xB10C-receives-lts-grant.mdx
+++ b/data/blog/0xB10C-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Long-Term Support For 0xB10C"
 date: '2024-02-06'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS']
+tags: ['OpenSats', 'grants', 'bitcoin', 'LTS', 'core']
 draft: false
 authors: ['cfunk', 'arvin']
 images: ['/static/images/blog/23-0xB10C.jpg']

--- a/data/blog/announcing-lts-grant-program-to-support-bitcoin-core-contributors.mdx
+++ b/data/blog/announcing-lts-grant-program-to-support-bitcoin-core-contributors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Long-Term Support Program for Bitcoin Core Developers"
 date: '2023-07-07'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS']
+tags: ['OpenSats', 'grants', 'bitcoin', 'LTS', 'core']
 draft: false
 authors: ['dergigi']
 images: ['/static/images/blog/02-lts.jpg']

--- a/data/blog/bruno-garcia-receives-lts-grant.mdx
+++ b/data/blog/bruno-garcia-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Long-Term Support For Bruno Garcia"
 date: '2024-03-19'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS']
+tags: ['OpenSats', 'grants', 'bitcoin', 'LTS', 'core']
 draft: false
 authors: ['cfunk']
 images: ['/static/images/blog/26-bruno-lts.jpg']

--- a/data/blog/gleb-naumenko-receives-lts-grant.mdx
+++ b/data/blog/gleb-naumenko-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Long-Term Support For Gleb Naumenko"
 date: '2023-10-18'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS']
+tags: ['OpenSats', 'grants', 'bitcoin', 'LTS', 'core']
 draft: false
 authors: ['dergigi', 'jamesob']
 images: ['/static/images/blog/12-gleb.jpg']

--- a/data/blog/josi-baker-receives-opensats-lts-grant.mdx
+++ b/data/blog/josi-baker-receives-opensats-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Long-Term Support For Josi Baker"
 date: '2023-08-16'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS']
+tags: ['OpenSats', 'grants', 'bitcoin', 'LTS', 'core']
 draft: false
 authors: ['jamesob']
 images: ['/static/images/blog/05-josi.jpg']

--- a/data/blog/sjors-provoost-receives-opensats-lts-grant.mdx
+++ b/data/blog/sjors-provoost-receives-opensats-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Long-Term Support For Sjors Provoost"
 date: '2023-09-08'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS']
+tags: ['OpenSats', 'grants', 'bitcoin', 'LTS', 'core']
 draft: false
 authors: ['dergigi']
 images: ['/static/images/blog/07-sjors.jpg']

--- a/data/blog/vasil-dimov-receives-lts-grant.mdx
+++ b/data/blog/vasil-dimov-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Long-Term Support For Vasil Dimov"
 date: '2023-10-16'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS']
+tags: ['OpenSats', 'grants', 'bitcoin', 'LTS', 'core']
 draft: false
 authors: ['dergigi']
 images: ['/static/images/blog/10-vasil.jpg']

--- a/data/blog/will-clark-receives-lts-grant-for-bitcoin-core.mdx
+++ b/data/blog/will-clark-receives-lts-grant-for-bitcoin-core.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Long-Term Support For Will Clark"
 date: '2023-11-20'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS']
+tags: ['OpenSats', 'grants', 'bitcoin', 'LTS', 'core']
 draft: false
 authors: ['dergigi']
 images: ['/static/images/blog/16-will-clark.jpg']


### PR DESCRIPTION
Added this so we can link to it in an upcoming announcement.