### PR TITLE
Add "List of Education Grants" to /transparency

### DIFF
--- a/data/pages/transparency.mdx
+++ b/data/pages/transparency.mdx
@@ -29,6 +29,7 @@ as in the internal and external processes of our organization.
 
 - [List of Bitcoin Grants](/tags/bitcoin)
 - [List of Nostr Grants](/tags/nostr)
+- [List of Education Grants](/tags/education)
 - [List of LTS Grantees](/tags/lts)
 - [Grant Selection Process](/selection)
 - [EOY Report: 2023](/blog/2023-year-in-review)


### PR DESCRIPTION
We'll have more `education` grants to announce soon, so we might as well link to all of them in [/transparency](https://opensats.org/transparency).