### PR TITLE
Link to /donate in Nav

### DIFF
--- a/data/headerNavLinks.ts
+++ b/data/headerNavLinks.ts
@@ -4,7 +4,7 @@ const headerNavLinks = [
   { href: '/about', title: 'About' },
   { href: '/blog', title: 'Blog' },
   { href: '/faq', title: 'FAQ' },
-  { href: '/apply', title: 'Apply', isButton: true },
+  { href: '/donate', title: 'Donate', isButton: true },
 ]
 
 export default headerNavLinks


### PR DESCRIPTION
Better to link to [/donate](https://opensats.org/donate) now, in prep for some structural changes and EOY report.