### PR TITLE
Improve order of "Main Focus" List

### DIFF
--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -74,10 +74,10 @@ export default function ApplicationForm() {
         >
           <option value="">(Choose One)</option>
           <option value="core">Bitcoin Core</option>
+          <option value="education">Education</option>
           <option value="layer1">Layer1 / Bitcoin</option>
           <option value="layer2">Layer2 / Lightning</option>
           <option value="eCash">Layer3 / eCash</option>
-          <option value="education">Education</option>
           <option value="nostr">Nostr</option>
           <option value="other">Other</option>
         </select>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -73,8 +73,9 @@ export default function ApplicationForm() {
           {...register('main_focus', { required: true })}
         >
           <option value="">(Choose One)</option>
-          <option value="layer1">Bitcoin / Layer1</option>
-          <option value="layer2">Lightning / Layer2</option>
+          <option value="layer1">Layer1 / Bitcoin</option>
+          <option value="layer2">Layer2 / Lightning</option>
+          <option value="eCash">Layer3 / eCash</option>
           <option value="core">Bitcoin Core</option>
           <option value="education">Education</option>
           <option value="nostr">nostr</option>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -73,10 +73,10 @@ export default function ApplicationForm() {
           {...register('main_focus', { required: true })}
         >
           <option value="">(Choose One)</option>
+          <option value="core">Bitcoin Core</option>
           <option value="layer1">Layer1 / Bitcoin</option>
           <option value="layer2">Layer2 / Lightning</option>
           <option value="eCash">Layer3 / eCash</option>
-          <option value="core">Bitcoin Core</option>
           <option value="education">Education</option>
           <option value="nostr">Nostr</option>
           <option value="other">Other</option>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -78,7 +78,7 @@ export default function ApplicationForm() {
           <option value="eCash">Layer3 / eCash</option>
           <option value="core">Bitcoin Core</option>
           <option value="education">Education</option>
-          <option value="nostr">nostr</option>
+          <option value="nostr">Nostr</option>
           <option value="other">Other</option>
         </select>
       </label>

--- a/components/LTSApplicationForm.tsx
+++ b/components/LTSApplicationForm.tsx
@@ -196,10 +196,10 @@ export default function ApplicationForm() {
           {...register('main_focus', { required: true })}
         >
           <option value="">(Choose One)</option>
+          <option value="core">Bitcoin Core</option>
           <option value="layer1">Layer1 / Bitcoin</option>
           <option value="layer2">Layer2 / Lightning</option>
           <option value="eCash">Layer3 / eCash</option>
-          <option value="core">Bitcoin Core</option>
           <option value="nostr">Nostr</option>
           <option value="other">Other</option>
         </select>

--- a/components/LTSApplicationForm.tsx
+++ b/components/LTSApplicationForm.tsx
@@ -196,8 +196,9 @@ export default function ApplicationForm() {
           {...register('main_focus', { required: true })}
         >
           <option value="">(Choose One)</option>
-          <option value="layer1">Bitcoin / Layer1</option>
-          <option value="layer2">Lightning / Layer2</option>
+          <option value="layer1">Layer1 / Bitcoin</option>
+          <option value="layer2">Layer2 / Lightning</option>
+          <option value="eCash">Layer3 / eCash</option>
           <option value="core">Bitcoin Core</option>
           <option value="nostr">nostr</option>
           <option value="other">Other</option>

--- a/components/LTSApplicationForm.tsx
+++ b/components/LTSApplicationForm.tsx
@@ -200,7 +200,7 @@ export default function ApplicationForm() {
           <option value="layer2">Layer2 / Lightning</option>
           <option value="eCash">Layer3 / eCash</option>
           <option value="core">Bitcoin Core</option>
-          <option value="nostr">nostr</option>
+          <option value="nostr">Nostr</option>
           <option value="other">Other</option>
         </select>
       </label>


### PR DESCRIPTION
In short:
- Rename Layer1 & 2
- Add Layer3 to auto-tag `eCash` applications
- Re-order items to make things easier on the eyes

Note that we don't do LTS for education, which is why it's missing there.