### PR TITLE
Fix list in "Doubling Down" blog post

### DIFF
--- a/data/blog/doubling-down-on-nostr.mdx
+++ b/data/blog/doubling-down-on-nostr.mdx
@@ -40,6 +40,7 @@ long-term support grants.
 
 We gave additional grants to:
 
+- [0xchat](/blog/nostr-grants-october-2023#0xchat)
 - [Damus](/blog/nostr-grants-july-2023#damus)
 - [Gossip](/blog/nostr-grants-july-2023#gossip)
 - [nostr.build](/blog/nostr-grants-july-2023#nostrbuild)
@@ -84,3 +85,9 @@ donation to [The Nostr Fund](/funds/nostr):
 If you are an open-source developer working on nostr (and other stuff), please
 don't hesitate to apply for a grant: [https://opensats.org/apply/grant
 ](/apply/grant)
+
+---
+
+<small>
+<i>This post was updated to include [0xchat](/blog/nostr-grants-october-2023#0xchat) to the list of additional grants.</i>
+</small>


### PR DESCRIPTION
Minor correction. Adds [0xchat](https://opensats.org/blog/nostr-grants-october-2023#0xchat) to the list of grants, which I somehow overlooked.

---

**Build preview:**

- [/blog/doubling-down-on-nostr](https://os-website-git-dd-update-open-sats.vercel.app/blog/doubling-down-on-nostr)