### PR TITLE
Remove `grant` and deprecated `website` tags

### DIFF
--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -91,10 +91,7 @@ ${
     }
 
     // Tag depending on request for grant and/or request for listing
-    req.body.general_fund && issueLabels.push('grant')
-    req.body.LTS && issueLabels.push('grant') // LTS = subset of grant
     req.body.LTS && issueLabels.push('LTS')
-    req.body.explore_page && issueLabels.push('website')
 
     // Additional tags based on yes/no answers
     req.body.has_received_funding && issueLabels.push('prior funding')


### PR DESCRIPTION
The `website` label is not needed anymore, and thus the `grant` label is obsolete too.