### PR TITLE
Removed yarn as a package manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,6 @@
 /node_modules
 /.pnp
 .pnp.js
-/.yarn/*
-!/.yarn/releases
-!/.yarn/plugins
-!/.yarn/sdks
 
 # testing
 /coverage
@@ -34,8 +30,6 @@ public/sitemap.xml
 # debug
 *.log
 npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
 
 # local env files
 .env.local

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This website was bootstrapped with [`tailwind-nextjs-starter-blog`](https://gith
 
 To run a development environment locally, run:
 
-  - `yarn` to install dependencies
-  - `yarn dev` to run the local development version
+  - `npm install` to install dependencies
+  - `npm run dev` to run the local development version
 
 Please refer to their [Quick Start Guide](https://github.com/timlrx/tailwind-nextjs-starter-blog#quick-start-guide) for further details.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5998,8 +5998,7 @@
       },
       "engines": {
         "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
+        "npm": ">=6"
       }
     },
     "node_modules/cross-fetch": {


### PR DESCRIPTION
We shouldn't be using two package managers, it can lead to errors such as:

> Module not found: Package path ./generated is not exported from package C:\Users\chase\OneDrive\Desktop\opensource\website\node_modules\contentlayer (see exports field in C:\Users\chase\OneDrive\Desktop\opensource\website\node_modules\contentlayer\package.json)
  4 | import { useEffect, useState } from 'react'
  5 | import ProjectCard from '../../components/ProjectCard'
> 6 | import { allProjects, allFunds } from 'contentlayer/generated'
  7 | import { Project, Fund } from 'contentlayer/generated'
  8 | 
  9 | const AllProjects: NextPage<{ projects: Project[]; funds: Fund[] }> = ({
10 |Import trace for requested module:
11 |./pages/index.tsx

I've removed yarn because installing packages with npm instead resolved this error (and likely prevents future ones).   


Changes in `README.md`:
* Updated the command to install dependencies from `yarn` to `npm install`.
* Updated the command to run the local development version from `yarn dev` to `npm run dev`.