### PR TITLE
Showcase organization fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,6 @@
 /node_modules
 /.pnp
 .pnp.js
-/.yarn/*
-!/.yarn/releases
-!/.yarn/plugins
-!/.yarn/sdks
 
 # testing
 /coverage
@@ -34,8 +30,6 @@ public/sitemap.xml
 # debug
 *.log
 npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
 
 # local env files
 .env.local

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This website was bootstrapped with [`tailwind-nextjs-starter-blog`](https://gith
 
 To run a development environment locally, run:
 
-  - `yarn` to install dependencies
-  - `yarn dev` to run the local development version
+  - `npm install` to install dependencies
+  - `npm run dev` to run the local development version
 
 Please refer to their [Quick Start Guide](https://github.com/timlrx/tailwind-nextjs-starter-blog#quick-start-guide) for further details.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5998,8 +5998,7 @@
       },
       "engines": {
         "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
+        "npm": ">=6"
       }
     },
     "node_modules/cross-fetch": {

--- a/pages/funds/index.tsx
+++ b/pages/funds/index.tsx
@@ -50,7 +50,7 @@ const AllProjects: NextPage<{ projects: Project[]; funds: Fund[] }> = ({
         <div className="flex w-full items-center justify-between pb-8">
           <h1 id="funds">Project Showcase</h1>
         </div>
-        <ul className="grid max-w-5xl grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-4">
+        <ul className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
           {showcaseProjects &&
             showcaseProjects.map((p, i) => (
               <li key={i} className="">


### PR DESCRIPTION
We only use 8 showcase projects but try to display them in a 9 item grid. This creates the following look with one box missing:

![image](https://github.com/user-attachments/assets/d9763c86-4a6d-40e5-8c63-bd372e111a71)

To prevent this, I changed it to properly fit 8 boxes on this viewport. 
![image](https://github.com/user-attachments/assets/c2a8af02-1307-4f65-911e-07317167ab08)

