### PR TITLE
Make FOSS checkbox required

### DIFF
--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -147,7 +147,7 @@ export default function ApplicationForm() {
         <input
           type="checkbox"
           className="rounded-md border-gray-300 shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
-          {...register('free_open_source')}
+          {...register('free_open_source', { required: true })}
         />
         <span className="ml-2">Is the project free and open-source?</span>
       </label>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -149,7 +149,7 @@ export default function ApplicationForm() {
           className="rounded-md border-gray-300 shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
           {...register('free_open_source', { required: true })}
         />
-        <span className="ml-2">Is the project free and open-source?</span>
+        <span className="ml-2">Is the project free and open-source? *</span>
       </label>
 
       <label className="block">

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -160,9 +160,9 @@ export default function ApplicationForm() {
           {...register('license', { required: true })}
         />
         <small>
-          We focus on supporting projects that are free as in freedom and open
-          to all. Your project must have a proper open-source license &
-          educational materials must be available to the public under a{' '}
+          We only support projects that are free as in freedom and open to all.
+          Your project must have a proper open-source license & educational
+          materials must be available to the public under a{' '}
           <CustomLink href="https://www.gnu.org/licenses/license-list.html">
             free and open license
           </CustomLink>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -161,8 +161,8 @@ export default function ApplicationForm() {
         />
         <small>
           We focus on supporting projects that are free as in freedom and open
-          to all. Your project should have a proper open-source license &
-          educational materials should be available to the public under a{' '}
+          to all. Your project must have a proper open-source license &
+          educational materials must be available to the public under a{' '}
           <CustomLink href="https://www.gnu.org/licenses/license-list.html">
             free and open license
           </CustomLink>


### PR DESCRIPTION
Two changes:
- Checking the checkbox is now mandatory
- Stronger wording regarding FOSS licensing

Build preview:
- [/apply/grant](https://os-website-git-require-foss-opensats.vercel.app/apply/grant)