### PR TITLE
Fix anchor linking (opensats.org/faq/application)

### DIFF
--- a/data/pages/faq-application.mdx
+++ b/data/pages/faq-application.mdx
@@ -31,7 +31,7 @@ not covered below.
 - [If my application is rejected, can I reapply?](#if-my-application-is-rejected-can-i-reapply)
 - [Can anyone apply?](#can-anyone-apply)
 - [What should I do if I have general praise or criticism regarding OpenSats?](#what-should-i-do-if-i-have-general-praise-or-criticism-regarding-opensats)
-- [I have a question that isn't covered here; whom should I email?](#i-have-a-question-that-isnt-covered-here-whom-should-i-email)
+- [I have a question that isn't covered here; what do I do?](#i-have-a-question-that-isnt-covered-here-what-do-i-do)
 
 ---
 
@@ -155,7 +155,7 @@ If you have something that irks you and/or suggestions for improvements, please
 let us know via support@opensats.org. We are learning as we go, so any
 feedback is highly appreciated.
 
-### I have a question that isn't covered here; whom should I email?
+### I have a question that isn't covered here; what do I do?
 
 Have a look at the [General FAQ](/faq). Your question might be answered there.
 

--- a/data/pages/faq-application.mdx
+++ b/data/pages/faq-application.mdx
@@ -155,7 +155,7 @@ If you have something that irks you and/or suggestions for improvements, please
 let us know via support@opensats.org. We are learning as we go, so any
 feedback is highly appreciated.
 
-### I have a question that isn't covered here; what do I do?
+### I have a question that isn't covered here; whom should I email?
 
 Have a look at the [General FAQ](/faq). Your question might be answered there.
 


### PR DESCRIPTION
Pointed out by Jon Atack.

Change wording for FAQ header in content to match FAQ list in ToC to properly jump/scroll to question.

"...what do I do?" --> "... whom should I email?"