### PR TITLE
Filter by multiple tags

### DIFF
--- a/components/Tag.tsx
+++ b/components/Tag.tsx
@@ -1,20 +1,14 @@
 import Link from 'next/link'
 import { kebabCase } from 'pliny/utils/kebabCase'
-import { usePathname } from 'next/navigation'
 
 interface Props {
   text: string
 }
 
 const Tag = ({ text }: Props) => {
-  const path = usePathname()
-  let tagSegment = `/tags/${kebabCase(text)}`
-  if (path.split('/').at(-2) == 'tags') {
-    tagSegment = `${path}/${kebabCase(text)}`
-  }
   return (
     <Link
-      href={tagSegment}
+      href={`/tags/${kebabCase(text)}`}
       className="mr-3 text-sm font-medium uppercase text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
     >
       {text.split(' ').join('-')}

--- a/components/Tag.tsx
+++ b/components/Tag.tsx
@@ -1,14 +1,20 @@
 import Link from 'next/link'
 import { kebabCase } from 'pliny/utils/kebabCase'
+import { usePathname } from 'next/navigation'
 
 interface Props {
   text: string
 }
 
 const Tag = ({ text }: Props) => {
+  const path = usePathname()
+  let tagSegment = `/tags/${kebabCase(text)}`
+  if (path.split('/').at(-2) == 'tags') {
+    tagSegment = `${path}/${kebabCase(text)}`
+  }
   return (
     <Link
-      href={`/tags/${kebabCase(text)}`}
+      href={tagSegment}
       className="mr-3 text-sm font-medium uppercase text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
     >
       {text.split(' ').join('-')}

--- a/pages/tags/[tag]/[tag2].tsx
+++ b/pages/tags/[tag]/[tag2].tsx
@@ -18,13 +18,15 @@ export async function getStaticPaths() {
       tag2: tag 
     },
   }))
-  //oneTagPaths.push( {params: {tag: 'new'}})*/
+//oneTagPaths.push( {params: {tag: 'new'}})*/
   return {
     paths: [
-      { params: {
-        tag: 'opensats',
-        tag2: 'funding'
-      }}
+      {
+        params: {
+          tag: 'opensats',
+          tag2: 'funding',
+        },
+      },
     ],
     fallback: false,
   }
@@ -32,14 +34,15 @@ export async function getStaticPaths() {
 
 export const getStaticProps = async (context) => {
   const tag = context.params.tag as string
-  // adjust filtered posts for tag1 && tag2
+  const tag2 = context.params.tag2 as string
   const filteredPosts = allCoreContent(
     allBlogs.filter(
       (post) =>
-        post.draft !== true && post.tags.map((t) => kebabCase(t)).includes(tag)
+        post.draft !== true &&
+        post.tags.map((t) => kebabCase(t)).includes(tag) &&
+        post.tags.map((t) => kebabCase(t)).includes(tag2)
     )
   )
-
   return { props: { posts: filteredPosts, tag } }
 }
 

--- a/pages/tags/[tag]/[tag2].tsx
+++ b/pages/tags/[tag]/[tag2].tsx
@@ -5,22 +5,34 @@ import { kebabCase } from 'pliny/utils/kebabCase'
 import { getAllTags, allCoreContent } from 'pliny/utils/contentlayer'
 import { InferGetStaticPropsType } from 'next'
 import { allBlogs } from 'contentlayer/generated'
+import { usePathname } from 'next/navigation'
 
 export async function getStaticPaths() {
   const tags = await getAllTags(allBlogs)
-
+  //generate all paths
+  // create params that include:
+  // { params: {tag: 'tag1'} }                ./tags/tag1
+  // { params: {tag: 'tag1', 'tag2'} }        ./tags/tag1/tag2
+  /*const oneTagPaths = Object.keys(tags).map((tag) => ({
+    params: {
+      tag2: tag 
+    },
+  }))
+  //oneTagPaths.push( {params: {tag: 'new'}})*/
   return {
-    paths: Object.keys(tags).map((tag) => ({
-      params: {
-        tag,
-      },
-    })),
+    paths: [
+      { params: {
+        tag: 'opensats',
+        tag2: 'funding'
+      }}
+    ],
     fallback: false,
   }
 }
 
 export const getStaticProps = async (context) => {
   const tag = context.params.tag as string
+  // adjust filtered posts for tag1 && tag2
   const filteredPosts = allCoreContent(
     allBlogs.filter(
       (post) =>
@@ -36,13 +48,18 @@ export default function Tag({
   tag,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   // Capitalize first letter and convert space to dash
+  // adjust title to account for multiple tags
   const title = tag[0].toUpperCase() + tag.split(' ').join('-').slice(1)
+  const x = usePathname()
+  console.log(x)
+  const y = x.split('/')
   return (
     <>
       <TagSEO
         title={`${tag} - ${siteMetadata.title}`}
         description={`${tag} tags - ${siteMetadata.author}`}
       />
+      Tags: {`${y.at(-1)}`}
       <ListLayout posts={posts} title={title} />
     </>
   )

--- a/pages/tags/[tag]/[tag2].tsx
+++ b/pages/tags/[tag]/[tag2].tsx
@@ -9,16 +9,8 @@ import { usePathname } from 'next/navigation'
 
 export async function getStaticPaths() {
   const tags = await getAllTags(allBlogs)
-  //generate all paths
-  // create params that include:
-  // { params: {tag: 'tag1'} }                ./tags/tag1
-  // { params: {tag: 'tag1', 'tag2'} }        ./tags/tag1/tag2
-  /*const oneTagPaths = Object.keys(tags).map((tag) => ({
-    params: {
-      tag2: tag 
-    },
-  }))
-//oneTagPaths.push( {params: {tag: 'new'}})*/
+  // complete remainingpaths
+  //****be sure to account for double tag selection e.g. opensats/opensats***
   return {
     paths: [
       {
@@ -53,16 +45,14 @@ export default function Tag({
   // Capitalize first letter and convert space to dash
   // adjust title to account for multiple tags
   const title = tag[0].toUpperCase() + tag.split(' ').join('-').slice(1)
-  const x = usePathname()
-  console.log(x)
-  const y = x.split('/')
+  const path = usePathname().split('/')
   return (
     <>
       <TagSEO
         title={`${tag} - ${siteMetadata.title}`}
         description={`${tag} tags - ${siteMetadata.author}`}
       />
-      Tags: {`${y.at(-1)}`}
+      Tags: {`${path.at(-2)}, ${path.at(-1)}`}
       <ListLayout posts={posts} title={title} />
     </>
   )

--- a/pages/tags/[tag]/[tag2].tsx
+++ b/pages/tags/[tag]/[tag2].tsx
@@ -9,17 +9,22 @@ import { usePathname } from 'next/navigation'
 
 export async function getStaticPaths() {
   const tags = await getAllTags(allBlogs)
-  // complete remainingpaths
-  //****be sure to account for double tag selection e.g. opensats/opensats***
+  const myPaths = []
+  for (const tagX in tags) {
+    for (const tagY in tags) {
+      if (tagX != tagY) {
+        // /tags/opensats/opensats gives 404 error
+        myPaths.push({
+          params: {
+            tag: tagX,
+            tag2: tagY,
+          },
+        })
+      }
+    }
+  }
   return {
-    paths: [
-      {
-        params: {
-          tag: 'opensats',
-          tag2: 'funding',
-        },
-      },
-    ],
+    paths: myPaths,
     fallback: false,
   }
 }

--- a/pages/tags/[tag]/[tag2].tsx
+++ b/pages/tags/[tag]/[tag2].tsx
@@ -5,7 +5,6 @@ import { kebabCase } from 'pliny/utils/kebabCase'
 import { getAllTags, allCoreContent } from 'pliny/utils/contentlayer'
 import { InferGetStaticPropsType } from 'next'
 import { allBlogs } from 'contentlayer/generated'
-import { usePathname } from 'next/navigation'
 
 export async function getStaticPaths() {
   const tags = await getAllTags(allBlogs)
@@ -50,14 +49,12 @@ export default function Tag({
   // Capitalize first letter and convert space to dash
   // adjust title to account for multiple tags
   const title = tag[0].toUpperCase() + tag.split(' ').join('-').slice(1)
-  const path = usePathname().split('/')
   return (
     <>
       <TagSEO
         title={`${tag} - ${siteMetadata.title}`}
         description={`${tag} tags - ${siteMetadata.author}`}
       />
-      Tags: {`${path.at(-2)}, ${path.at(-1)}`}
       <ListLayout posts={posts} title={title} />
     </>
   )

--- a/pages/tags/[tag]/index.tsx
+++ b/pages/tags/[tag]/index.tsx
@@ -1,0 +1,61 @@
+import { TagSEO } from '@/components/SEO'
+import siteMetadata from '@/data/siteMetadata'
+import ListLayout from '@/layouts/ListLayout'
+import { kebabCase } from 'pliny/utils/kebabCase'
+import { getAllTags, allCoreContent } from 'pliny/utils/contentlayer'
+import { InferGetStaticPropsType } from 'next'
+import { allBlogs } from 'contentlayer/generated'
+import { usePathname } from 'next/navigation'
+
+export async function getStaticPaths() {
+  const tags = await getAllTags(allBlogs)
+  // create params that include:
+  // { params: {tag: 'tag1'} }                ./tags/tag1
+  // { params: {tag: 'tag1', 'tag2'} }        ./tags/tag1/tag2
+  const oneTagPaths = Object.keys(tags).map((tag) => ({
+    params: {
+      tag,
+    },
+  }))
+  oneTagPaths.push( {params: {tag: 'new'}})
+  
+  return {
+    paths: oneTagPaths,
+    fallback: false,
+  }
+}
+
+export const getStaticProps = async (context) => {
+  const tag = context.params.tag as string
+  // adjust filtered posts for tag1 && tag2
+  const filteredPosts = allCoreContent(
+    allBlogs.filter(
+      (post) =>
+        post.draft !== true && post.tags.map((t) => kebabCase(t)).includes(tag)
+    )
+  )
+
+  return { props: { posts: filteredPosts, tag } }
+}
+
+export default function Tag({
+  posts,
+  tag,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
+  // Capitalize first letter and convert space to dash
+  // adjust title to account for multiple tags
+  const title = tag[0].toUpperCase() + tag.split(' ').join('-').slice(1)
+  const x = usePathname()
+  console.log(x)
+  const y = x.split('/')
+  return (
+    <>
+      <TagSEO
+        title={`${tag} - ${siteMetadata.title}`}
+        description={`${tag} tags - ${siteMetadata.author}`}
+      />
+      Tags: {`${y.at(-1)}`}
+      <ListLayout posts={posts} title={title} />
+    </>
+  )
+}

--- a/pages/tags/[tag]/index.tsx
+++ b/pages/tags/[tag]/index.tsx
@@ -5,7 +5,6 @@ import { kebabCase } from 'pliny/utils/kebabCase'
 import { getAllTags, allCoreContent } from 'pliny/utils/contentlayer'
 import { InferGetStaticPropsType } from 'next'
 import { allBlogs } from 'contentlayer/generated'
-import { usePathname } from 'next/navigation'
 
 export async function getStaticPaths() {
   const tags = await getAllTags(allBlogs)
@@ -36,14 +35,12 @@ export default function Tag({
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   // Capitalize first letter and convert space to dash
   const title = tag[0].toUpperCase() + tag.split(' ').join('-').slice(1)
-  const path = usePathname().split('/')
   return (
     <>
       <TagSEO
         title={`${tag} - ${siteMetadata.title}`}
         description={`${tag} tags - ${siteMetadata.author}`}
       />
-      Tags: {`${path.at(-1)}`}
       <ListLayout posts={posts} title={title} />
     </>
   )

--- a/pages/tags/[tag]/index.tsx
+++ b/pages/tags/[tag]/index.tsx
@@ -17,8 +17,8 @@ export async function getStaticPaths() {
       tag,
     },
   }))
-  oneTagPaths.push( {params: {tag: 'new'}})
-  
+  oneTagPaths.push({ params: { tag: 'new' } })
+
   return {
     paths: oneTagPaths,
     fallback: false,

--- a/pages/tags/[tag]/index.tsx
+++ b/pages/tags/[tag]/index.tsx
@@ -9,32 +9,24 @@ import { usePathname } from 'next/navigation'
 
 export async function getStaticPaths() {
   const tags = await getAllTags(allBlogs)
-  // create params that include:
-  // { params: {tag: 'tag1'} }                ./tags/tag1
-  // { params: {tag: 'tag1', 'tag2'} }        ./tags/tag1/tag2
-  const oneTagPaths = Object.keys(tags).map((tag) => ({
-    params: {
-      tag,
-    },
-  }))
-  oneTagPaths.push({ params: { tag: 'new' } })
-
   return {
-    paths: oneTagPaths,
+    paths: Object.keys(tags).map((tag) => ({
+      params: {
+        tag,
+      },
+    })),
     fallback: false,
   }
 }
 
 export const getStaticProps = async (context) => {
   const tag = context.params.tag as string
-  // adjust filtered posts for tag1 && tag2
   const filteredPosts = allCoreContent(
     allBlogs.filter(
       (post) =>
         post.draft !== true && post.tags.map((t) => kebabCase(t)).includes(tag)
     )
   )
-
   return { props: { posts: filteredPosts, tag } }
 }
 
@@ -43,18 +35,15 @@ export default function Tag({
   tag,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   // Capitalize first letter and convert space to dash
-  // adjust title to account for multiple tags
   const title = tag[0].toUpperCase() + tag.split(' ').join('-').slice(1)
-  const x = usePathname()
-  console.log(x)
-  const y = x.split('/')
+  const path = usePathname().split('/')
   return (
     <>
       <TagSEO
         title={`${tag} - ${siteMetadata.title}`}
         description={`${tag} tags - ${siteMetadata.author}`}
       />
-      Tags: {`${y.at(-1)}`}
+      Tags: {`${path.at(-1)}`}
       <ListLayout posts={posts} title={title} />
     </>
   )


### PR DESCRIPTION
@dergigi I've created paths such as /tags/tag1/tag2 like so:

![Screenshot at 2025-02-25 22-50-59](https://github.com/user-attachments/assets/ab046c18-9ca8-4e6c-ab2d-6a78d29d8515)

(/tags/opensats/funding is the only working route right now as a test case)

I've set it up such that users can select up to two tags by successively clicking on the tags they want to filter on. After selecting two tags, a third tag selection resets the previously selected tags.

Still working to flesh out the routes subject to any comments!