### PR TITLE
Add OpenSats' lifetime statistics to /transparency page

### DIFF
--- a/components/LifetimeStats.tsx
+++ b/components/LifetimeStats.tsx
@@ -36,7 +36,8 @@ const LifetimeStats = () => {
                 {item.label}
               </dt>
               <dt className="order-first text-center text-4xl font-semibold tracking-tight text-orange-600">
-                {index == 1 ? '~' : ''}
+                {index == 1 ? '$ ' : ''}
+                {index == 2 ? '~' : ''}
                 {formatNumber(item.value)}
               </dt>
             </div>

--- a/components/LifetimeStats.tsx
+++ b/components/LifetimeStats.tsx
@@ -1,6 +1,19 @@
 import React, { useState, useEffect } from 'react'
 import PublicGoogleSheetsParser from 'public-google-sheets-parser'
 
+export function formatNumber(num: number): string {
+  const abbreviations = ['k', 'M', 'B', 'T']
+  let i = 0
+  while (num > 1e3 && i < abbreviations.length) {
+    num /= 1e3
+    if (num < 1e3) {
+      return `${num.toFixed(1)} ${abbreviations[i]}`
+    }
+    i += 1
+  }
+  return num.toString()
+}
+
 const LifetimeStats = () => {
   const [items, setItems] = useState([])
 
@@ -19,8 +32,10 @@ const LifetimeStats = () => {
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {items.map((item, index) => (
             <div key={index} className="rounded-lg bg-white p-4 shadow-md">
-              <h2 className="text-xl font-bold">{item.label}</h2>
-              <p className="text-2xl text-blue-600">{item.value}</p>
+              <h2 className="text-2xl font-bold text-orange-600">
+                ~{formatNumber(item.value)}
+              </h2>
+              <p className="text-l">{item.label}</p>
             </div>
           ))}
         </div>

--- a/components/LifetimeStats.tsx
+++ b/components/LifetimeStats.tsx
@@ -14,12 +14,17 @@ const LifetimeStats = () => {
   }, [])
 
   return (
-    <div>
-      <ul>
-        {items.map((item, index) => (
-          <li key={index}>{JSON.stringify(item)}</li>
-        ))}
-      </ul>
+    <div className="bg-gray-100 p-6">
+      <div className="container mx-auto">
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {items.map((item, index) => (
+            <div key={index} className="rounded-lg bg-white p-4 shadow-md">
+              <h2 className="text-xl font-bold">{item.label}</h2>
+              <p className="text-2xl text-blue-600">{item.value}</p>
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   )
 }

--- a/components/LifetimeStats.tsx
+++ b/components/LifetimeStats.tsx
@@ -1,0 +1,27 @@
+import React, { useState, useEffect } from 'react'
+import PublicGoogleSheetsParser from 'public-google-sheets-parser'
+
+const LifetimeStats = () => {
+  const [items, setItems] = useState([])
+
+  useEffect(() => {
+    const parser = new PublicGoogleSheetsParser(
+      '1mLEbHcrJibLN2PKxYq1LHJssq0CGuJRRoaZwot-ncZQ'
+    )
+    parser.parse().then((data) => {
+      setItems(data)
+    })
+  }, [])
+
+  return (
+    <div>
+      <ul>
+        {items.map((item, index) => (
+          <li key={index}>{JSON.stringify(item)}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default LifetimeStats

--- a/components/LifetimeStats.tsx
+++ b/components/LifetimeStats.tsx
@@ -27,18 +27,21 @@ const LifetimeStats = () => {
   }, [])
 
   return (
-    <div className="bg-gray-100 p-6">
-      <div className="container mx-auto">
-        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    <div className="py-4">
+      <div className="mx-auto">
+        <dl className="grid grid-cols-1 gap-x-2 gap-y-4 md:grid-cols-3">
           {items.map((item, index) => (
-            <div key={index} className="rounded-lg bg-white p-4 shadow-md">
-              <h2 className="text-2xl font-bold text-orange-600">
-                ~{formatNumber(item.value)}
-              </h2>
-              <p className="text-l">{item.label}</p>
+            <div key={index} className="mx-auto grid grid-cols-1">
+              <dt className="text-center text-base/7 text-gray-600 dark:text-gray-300">
+                {item.label}
+              </dt>
+              <dt className="order-first text-center text-4xl font-semibold tracking-tight text-orange-600">
+                {index == 1 ? '~' : ''}
+                {formatNumber(item.value)}
+              </dt>
             </div>
           ))}
-        </div>
+        </dl>
       </div>
     </div>
   )

--- a/components/MDXComponents.tsx
+++ b/components/MDXComponents.tsx
@@ -17,6 +17,7 @@ import DesignTeam from './DesignTeam'
 import Credits from './Supporters'
 import YouTubeEmbed from './YouTubeEmbed'
 import Members from './Members'
+import LifetimeStats from './LifetimeStats'
 
 export const Wrapper = ({ layout, content, ...rest }: MDXLayout) => {
   const Layout = require(`../layouts/${layout}`).default
@@ -40,4 +41,5 @@ export const MDXComponents: ComponentMap = {
   YouTubeEmbed,
   Credits,
   Members,
+  LifetimeStats,
 }

--- a/data/pages/transparency.mdx
+++ b/data/pages/transparency.mdx
@@ -10,6 +10,8 @@ transparency, integrity, and legal compliance standards. As an organization that
 is embedded in the free and open-source movement, we cherish the principles of
 transparency, openness, as well as conversing and working in public.
 
+<LifetimeStats/>
+
 By adhering to these principles, we aim to demonstrate our commitment to
 responsible bitcoin treasury management, good corporate citizenship, and the long-term
 sustainability of our organization.

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "next-themes": "^0.2.0",
         "pliny": "0.0.10",
         "postcss": "^8.4.16",
+        "public-google-sheets-parser": "^1.5.4",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-hook-form": "^7.43.9",
@@ -13271,6 +13272,12 @@
         "pbjs": "bin/pbjs",
         "pbts": "bin/pbts"
       }
+    },
+    "node_modules/public-google-sheets-parser": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/public-google-sheets-parser/-/public-google-sheets-parser-1.5.4.tgz",
+      "integrity": "sha512-NPjeXtT7Nk+Q9jRt1mdSCtWdqEbZLiNa5+aVR1U/1W/6hfnCAAJF9HSz/UA2VUxo5YEPWxZW3Nxotbt8rU2JWQ==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "next-themes": "^0.2.0",
     "pliny": "0.0.10",
     "postcss": "^8.4.16",
+    "public-google-sheets-parser": "^1.5.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.43.9",


### PR DESCRIPTION
Re-implementation of #406 using `public-google-sheets-parser` 

---

Build preview:
- [/transparency](https://os-website-git-transparency-widget-public-opensats.vercel.app//transparency)
