### PR TITLE
Add years of dev experience to application form

### DIFF
--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -316,6 +316,14 @@ export default function ApplicationForm() {
         />
       </label>
       <label className="block">
+        Number of Years of Developer Experience
+        <input
+          type="text"
+          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
+          {...register('years_experience')}
+        />
+      </label>
+      <label className="block">
         Other Contact Details (if applicable)
         <br />
         <small>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -316,14 +316,6 @@ export default function ApplicationForm() {
         />
       </label>
       <label className="block">
-        Number of Years of Developer Experience
-        <input
-          type="text"
-          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
-          {...register('years_experience')}
-        />
-      </label>
-      <label className="block">
         Other Contact Details (if applicable)
         <br />
         <small>
@@ -360,6 +352,14 @@ export default function ApplicationForm() {
         <textarea
           className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
           {...register('bios')}
+        />
+      </label>
+      <label className="block">
+        Number of Years of Developer Experience
+        <input
+          type="text"
+          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
+          {...register('years_experience')}
         />
       </label>
       <hr />

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -389,7 +389,7 @@ export default function ApplicationForm() {
       <FormButton
         variant={isFLOSS ? 'enabled' : 'disabled'}
         type="submit"
-        disabled={loading}
+        disabled={true || loading}
       >
         Submit Grant Application
       </FormButton>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -389,7 +389,7 @@ export default function ApplicationForm() {
       <FormButton
         variant={isFLOSS ? 'enabled' : 'disabled'}
         type="submit"
-        disabled={true || loading}
+        disabled={loading}
       >
         Submit Grant Application
       </FormButton>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -355,7 +355,7 @@ export default function ApplicationForm() {
         />
       </label>
       <label className="block">
-        Number of Years of Developer Experience
+        Years of Developer Experience
         <input
           type="text"
           className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"

--- a/components/LTSApplicationForm.tsx
+++ b/components/LTSApplicationForm.tsx
@@ -119,7 +119,7 @@ export default function ApplicationForm() {
         />
       </label>
       <label className="block">
-        Number of Years of Developer Experience
+        Years of Developer Experience
         <input
           type="text"
           className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"

--- a/components/LTSApplicationForm.tsx
+++ b/components/LTSApplicationForm.tsx
@@ -108,14 +108,6 @@ export default function ApplicationForm() {
         />
       </label>
       <label className="block">
-        Number of Years of Developer Experience
-        <input
-          type="text"
-          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
-          {...register('years_experience')}
-        />
-      </label>
-      <label className="block">
         Prior Contributions *<br />
         <small>
           Describe the contributions you've made to Bitcoin Core or other
@@ -126,7 +118,14 @@ export default function ApplicationForm() {
           {...register('bios', { required: true })}
         />
       </label>
-
+      <label className="block">
+        Number of Years of Developer Experience
+        <input
+          type="text"
+          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
+          {...register('years_experience')}
+        />
+      </label>
       <h2>What Will You Work On?</h2>
 
       <label className="block">

--- a/components/LTSApplicationForm.tsx
+++ b/components/LTSApplicationForm.tsx
@@ -108,6 +108,14 @@ export default function ApplicationForm() {
         />
       </label>
       <label className="block">
+        Number of Years of Developer Experience
+        <input
+          type="text"
+          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
+          {...register('years_experience')}
+        />
+      </label>
+      <label className="block">
         Prior Contributions *<br />
         <small>
           Describe the contributions you've made to Bitcoin Core or other

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -51,10 +51,11 @@ ${req.body.references}
 
 ${req.body.bios ? req.body.bios : 'No prior contributions.'}
 
+**Years of dev experience:**
 ${
   req.body.years_experience
-    ? `${req.body.years_experience} years experience`
-    : 'No experience.'
+    ? `${req.body.years_experience}`
+    : '0'
 }
 
 ### Anything Else

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -51,7 +51,11 @@ ${req.body.references}
 
 ${req.body.bios ? req.body.bios : 'No prior contributions.'}
 
-${req.body.years_experience ? `${req.body.years_experience} years experience` : 'No experience.'}
+${
+  req.body.years_experience
+    ? `${req.body.years_experience} years experience`
+    : 'No experience.'
+}
 
 ### Anything Else
 

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -51,6 +51,8 @@ ${req.body.references}
 
 ${req.body.bios ? req.body.bios : 'No prior contributions.'}
 
+${req.body.years_experience ? `${req.body.years_experience} years experience` : 'No experience.'}
+
 ### Anything Else
 
 ${req.body.anything_else ? req.body.anything_else : 'No.'}

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -52,11 +52,7 @@ ${req.body.references}
 ${req.body.bios ? req.body.bios : 'No prior contributions.'}
 
 **Years of dev experience:**
-${
-  req.body.years_experience
-    ? `${req.body.years_experience}`
-    : '0'
-}
+${req.body.years_experience ? `${req.body.years_experience}` : '0'}
 
 ### Anything Else
 


### PR DESCRIPTION
**Build preview:**
- [/apply/grant](https://os-website-git-fork-moteanup24-ask-for-dev-experience-opensats.vercel.app/apply/grant)
- [/apply/lts](https://os-website-git-fork-moteanup24-ask-for-dev-experience-opensats.vercel.app/apply/lts)

---

I've added in the question after asking for the applicant's personal website/github but please let me know if you'd prefer it elsewhere, or anything else (e.g. make it required?). Thanks!

I've edited both `GrantApplicationForm` and the `LTSApplicationForm`.

![Screenshot at 2025-03-20 10-35-54](https://github.com/user-attachments/assets/d0461402-eb36-455e-8084-e4a82b3f3c5f)
