### PR TITLE
Fix social link of bitcoin-core

### DIFF
--- a/data/projects/bitcoin-core.mdx
+++ b/data/projects/bitcoin-core.mdx
@@ -6,7 +6,7 @@ nym: 'Bitcoin Core Developers'
 website: 'https://bitcoincore.org/en/download/'
 coverImage: '/static/images/projects/bitcoin-core.png'
 git: 'https://github.com/bitcoin/bitcoin'
-twitter: 'https://twitter.com/bitcoincoreorg'
+twitter: 'bitcoincoreorg'
 tags: ['Bitcoin']
 showcase: true
 ---


### PR DESCRIPTION
small link fix to match the formatting of other funded projects. the current link out to twitter/X does not resolve properly