### PR TITLE
Tag application coming from Common Grant app 

### DIFF
--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -77,6 +77,11 @@ ${
     if (mainFocus === 'layer1' || mainFocus === 'layer2') {
       issueLabels.push('bitcoin') // L1 & L2 = subset of Bitcoin
     }
+    
+    // Add label for applications from common grant app
+    if (req.body.source === 'common-grant-app') {
+      issueLabels.push('common-grant-app')
+    }
 
     // Repo set according to "main focus"
     let appRepo = GH_APP_REPO

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -30,6 +30,10 @@ ${req.body.short_description}
 
 ${req.body.potential_impact}
 
+### Organizations Applied To
+
+${req.body.organizations ? `This application was submitted to: ${req.body.organizations.join(', ')}` : 'No organizations specified'}
+
 ### Timeline & Milestones
 
 ${req.body.duration ? `Grant duration: ${req.body.duration}` : ''}

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -30,9 +30,13 @@ ${req.body.short_description}
 
 ${req.body.potential_impact}
 
-### Organizations Applied To
+### Other Organizations Applied To
 
-${req.body.organizations ? `This application was submitted to: ${req.body.organizations.join(', ')}` : 'No organizations specified'}
+${
+  req.body.organizations
+    ? `This application was submitted to: ${req.body.organizations.join(', ')}`
+    : 'No organizations specified'
+}
 
 ### Timeline & Milestones
 
@@ -81,7 +85,7 @@ ${
     if (mainFocus === 'layer1' || mainFocus === 'layer2') {
       issueLabels.push('bitcoin') // L1 & L2 = subset of Bitcoin
     }
-    
+
     // Add label for applications from common grant app
     if (req.body.source === 'common-grant-app') {
       issueLabels.push('common-grant-app')


### PR DESCRIPTION
This PR tags applications coming from the common grant app and adds data about the organizations the grantee applied to

- Added a new label 'common-grant-app' in github issues to identify applications submitted through the common grant application
- Added a new section "Organizations Applied To" in the GitHub issue body to display which organizations the grantee has applied to