### PR TITLE
Change `Discuss on nostr` footer link from Habla to Njump

### DIFF
--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -13,7 +13,7 @@ import ScrollTopAndComment from '@/components/ScrollTopAndComment'
 
 const editUrl = (path) => `${siteMetadata.siteRepo}/blob/master/data/${path}`
 const discussUrl = () =>
-  `https://habla.news/p/npub10pensatlcfwktnvjjw2dtem38n6rvw8g6fv73h84cuacxn4c28eqyfn34f`
+  `https://njump.me/npub10pensatlcfwktnvjjw2dtem38n6rvw8g6fv73h84cuacxn4c28eqyfn34f`
 
 const postDateTemplate: Intl.DateTimeFormatOptions = {
   weekday: 'long',


### PR DESCRIPTION
**From** 
https://habla.news/p/npub10pensatlcfwktnvjjw2dtem38n6rvw8g6fv73h84cuacxn4c28eqyfn34f

**To**
https://njump.me/npub10pensatlcfwktnvjjw2dtem38n6rvw8g6fv73h84cuacxn4c28eqyfn34f

**Build Preview example:**
https://os-website-git-arvin21m-patch-1-opensats.vercel.app/blog/twelfth-wave-of-nostr-grants