### PR TITLE
Fix RSS feed generation by using direct JSON file reading

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "next dev",
     "dev": "cross-env INIT_CWD=$PWD next dev",
-    "build": "npx contentlayer build && cross-env INIT_CWD=$PWD next build && cross-env NODE_OPTIONS='--experimental-json-modules' node -r esbuild-register ./scripts/postbuild.mjs",
+    "build": "npx contentlayer build && cross-env INIT_CWD=$PWD next build && node -r esbuild-register ./scripts/postbuild.mjs",
     "serve": "next start",
     "analyze": "cross-env ANALYZE=true next build",
     "lint": "next lint --fix --dir pages --dir components --dir lib --dir layouts --dir scripts",

--- a/scripts/rss.mjs
+++ b/scripts/rss.mjs
@@ -1,15 +1,19 @@
 import { generateRSS } from 'pliny/utils/generate-rss.js'
 import siteMetadata from '../data/siteMetadata.js'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
 
 const rss = async () => {
-  try {
-    const { allBlogs } = await import('../.contentlayer/generated/index.mjs')
-    generateRSS(siteMetadata, allBlogs)
-    console.log('RSS feed generated...')
-  } catch (error) {
-    console.log(
-      'RSS feed generation skipped due to contentlayer import error...'
-    )
-  }
+  // Read the blog data directly from the JSON file
+  const blogDataPath = join(__dirname, '../.contentlayer/generated/Blog/_index.json')
+  const allBlogs = JSON.parse(readFileSync(blogDataPath, 'utf8'))
+  
+  generateRSS(siteMetadata, allBlogs)
+  console.log('RSS feed generated...')
 }
+
 export default rss

--- a/scripts/search.mjs
+++ b/scripts/search.mjs
@@ -1,21 +1,24 @@
-import { writeFileSync } from 'fs'
+import { writeFileSync, readFileSync } from 'fs'
 import { allCoreContent } from 'pliny/utils/contentlayer.js'
 import siteMetadata from '../data/siteMetadata.js'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
 
 const search = async () => {
-  try {
-    const { allBlogs } = await import('../.contentlayer/generated/index.mjs')
-    if (siteMetadata?.search?.kbarConfig?.searchDocumentsPath) {
-      writeFileSync(
-        `public/${siteMetadata.search.kbarConfig.searchDocumentsPath}`,
-        JSON.stringify(allCoreContent(allBlogs))
-      )
-      console.log('Local search index generated...')
-    }
-  } catch (error) {
-    console.log(
-      'Search index generation skipped due to contentlayer import error...'
+  // Read the blog data directly from the JSON file
+  const blogDataPath = join(__dirname, '../.contentlayer/generated/Blog/_index.json')
+  const allBlogs = JSON.parse(readFileSync(blogDataPath, 'utf8'))
+  
+  if (siteMetadata?.search?.kbarConfig?.searchDocumentsPath) {
+    writeFileSync(
+      `public/${siteMetadata.search.kbarConfig.searchDocumentsPath}`,
+      JSON.stringify(allCoreContent(allBlogs))
     )
+    console.log('Local search index generated...')
   }
 }
+
 export default search

--- a/scripts/sitemap.mjs
+++ b/scripts/sitemap.mjs
@@ -1,15 +1,19 @@
 import { generateSitemap } from 'pliny/utils/generate-sitemap.js'
 import siteMetadata from '../data/siteMetadata.js'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
 
 const sitemap = async () => {
-  try {
-    const { allBlogs } = await import('../.contentlayer/generated/index.mjs')
-    generateSitemap(siteMetadata.siteUrl, allBlogs)
-    console.log('Sitemap generated...')
-  } catch (error) {
-    console.log(
-      'Sitemap generation skipped due to contentlayer import error...'
-    )
-  }
+  // Read the blog data directly from the JSON file
+  const blogDataPath = join(__dirname, '../.contentlayer/generated/Blog/_index.json')
+  const allBlogs = JSON.parse(readFileSync(blogDataPath, 'utf8'))
+  
+  generateSitemap(siteMetadata.siteUrl, allBlogs)
+  console.log('Sitemap generated...')
 }
+
 export default sitemap


### PR DESCRIPTION
The RSS feed generation was silently failing due to JSON import assertion compatibility issues with contentlayer generated files. This fix replaces the problematic contentlayer imports with direct JSON file reading using fs module, ensuring RSS feed and sitemap generation work properly without dependency on experimental Node.js flags.

`NODE_OPTIONS='--experimental-json-modules'` is not required anymore as per https://github.com/nodejs/node/pull/41736