### PR TITLE
Disable volunteer flag for select authors

### DIFF
--- a/data/authors/jason.mdx
+++ b/data/authors/jason.mdx
@@ -6,7 +6,6 @@ occupation: Volunteer
 company: OpenSats
 email: jason@opensats.org
 nostr: npub1eea85mad6p7lyg0m0megw7v0k84u844evmav762v2masqrcyew4qn0d45v
-volunteer: true
 ---
 
 Jason, like the characters in _The Matrix_, felt from an early age there was

--- a/data/authors/julian.mdx
+++ b/data/authors/julian.mdx
@@ -7,7 +7,6 @@ company: OpenSats
 email: julian@opensats.org
 nostr: npub16h5u7amjy5cwdxhru05mmql5cr954a2cpa2klj3685l72qzxm7wsskwy84
 github: https://github.com/julian2000-code
-volunteer: true
 ---
 
 Julian's life experiences taught him the value of self-sovereignty. When he


### PR DESCRIPTION
As per https://github.com/OpenSats/website/pull/474#issuecomment-3236371670

---

**Build preview:**
- [/about](https://os-website-git-rm-jason-julian-opensats.vercel.app/about)
- [Blog post w/ volunteer co-author](https://os-website-git-rm-jason-julian-opensats.vercel.app/blog/3rd-wave-of-education-grants)

My general point stands that it would be best if we'd have someone who takes care of the volunteer team in general, otherwise things will always be a bit flaky (which might be fine too, but still).