### PR TITLE
Add education-specific requirements to grant application form

### DIFF
--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -14,7 +14,11 @@ export default function ApplicationForm() {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm()
+  } = useForm({
+    defaultValues: {
+      duration: '6 months',
+    },
+  })
 
   const isFLOSS = watch('free_open_source', false)
   const [failureReason, setFailureReason] = useState<string>()
@@ -184,7 +188,7 @@ export default function ApplicationForm() {
         >
           <option value="12 months">12 months</option>
           <option value="9 months">9 months</option>
-          <option value="6 months" selected>
+          <option value="6 months">
             6 months
           </option>
           <option value="3 months">3 months</option>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -111,7 +111,7 @@ export default function ApplicationForm() {
                 <li>
                   You MUST provide at least <strong>two references</strong> that we can reach out to
                 </li>
-                <li>Monthly progress reports MUST be submitted on time</li>
+                <li><strong>Monthly</strong> progress reports MUST be submitted on time</li>
                 <li>
                   Progress reports MUST contain proof-of-work that is easily verifiable by us
                 </li>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -119,8 +119,9 @@ export default function ApplicationForm() {
                   Progress reports MUST contain proof-of-work that is easily verifiable by us
                 </li>
               </ul>
+              <hr className="mt-3 mb-2 border-blue-200" />
               <p className="mt-2 mb-0 text-xs">¹For example: <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener noreferrer">CC BY</a>, <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener noreferrer">CC BY-SA</a>, <a href="https://creativecommons.org/publicdomain/zero/1.0/" target="_blank" rel="noopener noreferrer">CC0</a>, <a href="https://www.gnu.org/licenses/fdl-1.3.html" target="_blank" rel="noopener noreferrer">GNU FDL</a></p>
-              <p className="mt-0 mb-0 text-xs">²No paywalls, no signups, no invite-only systems</p>
+              <p className="mt-1 mb-0 text-xs">²No paywalls, no signups, no invite-only systems</p>
             </div>
           </div>
         </div>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -108,14 +108,15 @@ export default function ApplicationForm() {
                   Educational material MUST be published under an{' '}
                   <strong>
                     <a
-                      className="underline text-orange-600 dark:text-orange-400 hover:text-orange-700 dark:hover:text-orange-300"
+                      className="text-orange-600 underline hover:text-orange-700 dark:text-orange-400 dark:hover:text-orange-300"
                       href="https://www.gnu.org/philosophy/free-doc.html"
                       target="_blank"
                       rel="noopener noreferrer"
                     >
                       open license
                     </a>
-                  </strong>¹
+                  </strong>
+                  ¹
                 </li>
                 <li>
                   Educational material MUST be publicly available to anyone (for
@@ -142,7 +143,7 @@ export default function ApplicationForm() {
                 {' '}
                 (¹) For example:{' '}
                 <a
-                  className="underline text-orange-600 dark:text-orange-400 hover:text-orange-700 dark:hover:text-orange-300"
+                  className="text-orange-600 underline hover:text-orange-700 dark:text-orange-400 dark:hover:text-orange-300"
                   href="https://creativecommons.org/licenses/by/4.0/"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -151,7 +152,7 @@ export default function ApplicationForm() {
                 </a>
                 ,{' '}
                 <a
-                  className="underline text-orange-600 dark:text-orange-400 hover:text-orange-700 dark:hover:text-orange-300"
+                  className="text-orange-600 underline hover:text-orange-700 dark:text-orange-400 dark:hover:text-orange-300"
                   href="https://creativecommons.org/licenses/by-sa/4.0/"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -160,7 +161,7 @@ export default function ApplicationForm() {
                 </a>
                 ,{' '}
                 <a
-                  className="underline text-orange-600 dark:text-orange-400 hover:text-orange-700 dark:hover:text-orange-300"
+                  className="text-orange-600 underline hover:text-orange-700 dark:text-orange-400 dark:hover:text-orange-300"
                   href="https://creativecommons.org/publicdomain/zero/1.0/"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -169,7 +170,7 @@ export default function ApplicationForm() {
                 </a>
                 ,{' '}
                 <a
-                  className="underline text-orange-600 dark:text-orange-400 hover:text-orange-700 dark:hover:text-orange-300"
+                  className="text-orange-600 underline hover:text-orange-700 dark:text-orange-400 dark:hover:text-orange-300"
                   href="https://www.gnu.org/licenses/fdl-1.3.html"
                   target="_blank"
                   rel="noopener noreferrer"

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -99,7 +99,7 @@ export default function ApplicationForm() {
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 20 20"
               >
-                <path d="M10 2L3 7v11a1 1 0 001 1h12a1 1 0 001-1V7l-7-5zM8 15v-3h4v3H8zm6-4H6V8h8v3z" />
+                <path d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" />
               </svg>
             </div>
             <div>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -106,7 +106,15 @@ export default function ApplicationForm() {
               <ul className="list-disc pl-6 text-sm">
                 <li>
                   Educational material MUST be published under an{' '}
-                  <strong>open license</strong>¹
+                  <strong>
+                    <a
+                      href="https://www.gnu.org/philosophy/free-doc.html"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      open license
+                    </a>
+                  </strong>¹
                 </li>
                 <li>
                   Educational material MUST be publicly available to anyone (for

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -104,17 +104,17 @@ export default function ApplicationForm() {
             <div>
               <p className="font-bold mb-2">Application Requirements</p>
               <ul className="list-disc pl-6 text-sm">
-                <li>Educational material MUST be published under an <span className="font-semibold text-blue-900 dark:text-blue-200">open license</span>¹</li>
+                <li>Educational material MUST be published under an <strong>open license</strong>¹</li>
                 <li>
                   Educational material MUST be publicly available to anyone (for free)²
                 </li>
                 <li>
-                  You MUST provide at least <span className="font-semibold text-blue-900 dark:text-blue-200">two references</span> that we can reach out to
+                  You MUST provide at least <strong>two references</strong> that we can reach out to
                 </li>
               </ul>
               <p className="font-bold mt-4 mb-2">Reporting Requirements</p>
               <ul className="list-disc pl-6 text-sm">
-                <li><span className="font-semibold text-blue-900 dark:text-blue-200">Monthly</span> progress reports MUST be submitted on time</li>
+                <li><strong>Monthly</strong> progress reports MUST be submitted on time</li>
                 <li>
                   Progress reports MUST contain proof-of-work that is easily verifiable by us
                 </li>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -97,6 +97,10 @@ export default function ApplicationForm() {
             <li>
               You MUST provide at least <strong>two references</strong> that we can reach out to
             </li>
+            <li>Monthly progress reports MUST be submitted on time</li>
+            <li>
+              Progress reports MUST contain proof-of-work that is easily verifiable by us
+            </li>
           </ul>
           <p className="mt-2">*No paywalls, no signups, no invite-only systems</p>
         </div>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -104,7 +104,7 @@ export default function ApplicationForm() {
             <div>
               <p className="font-bold mb-2">Requirements</p>
               <ul className="list-disc pl-6 text-sm">
-                <li>Educational material MUST be published under an open license¹</li>
+                <li>Educational material MUST be published under an <strong>open license</strong>¹</li>
                 <li>
                   Educational material MUST be publicly available for anyone (for free)²
                 </li>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -90,9 +90,9 @@ export default function ApplicationForm() {
       {watch('main_focus') === 'education' && (
         <div className="mt-2">
           <ul className="list-disc pl-6">
-            <li>Educational material MUST be published under an open license†</li>
+            <li>Educational material MUST be published under an open license¹</li>
             <li>
-              Educational material MUST be publicly available for anyone (for free)‡
+              Educational material MUST be publicly available for anyone (for free)²
             </li>
             <li>
               You MUST provide at least <strong>two references</strong> that we can reach out to
@@ -102,8 +102,8 @@ export default function ApplicationForm() {
               Progress reports MUST contain proof-of-work that is easily verifiable by us
             </li>
           </ul>
-          <p className="mt-2">†For example: CC BY, CC BY-SA, CC0, GNU FDL</p>
-          <p className="mt-1">‡No paywalls, no signups, no invite-only systems</p>
+          <p className="mt-2">¹For example: CC BY, CC BY-SA, CC0, GNU FDL</p>
+          <p className="mt-1">²No paywalls, no signups, no invite-only systems</p>
         </div>
       )}
 

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -5,6 +5,8 @@ import { fetchPostJSON } from '../utils/api-helpers'
 import FormButton from '@/components/FormButton'
 import * as EmailValidator from 'email-validator'
 import CustomLink from './Link'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faGraduationCap } from '@fortawesome/free-solid-svg-icons'
 
 export default function ApplicationForm() {
   const [loading, setLoading] = useState(false)
@@ -94,13 +96,10 @@ export default function ApplicationForm() {
         >
           <div className="flex">
             <div className="py-1">
-              <svg
-                className="mr-4 h-6 w-6 fill-current text-blue-500"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-              >
-                <path d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" />
-              </svg>
+              <FontAwesomeIcon
+                icon={faGraduationCap}
+                className="mr-4 h-6 w-6 text-blue-500"
+              />
             </div>
             <div>
               <p className="font-bold mb-2">Education Grant Requirements</p>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -116,8 +116,8 @@ export default function ApplicationForm() {
                   Progress reports MUST contain proof-of-work that is easily verifiable by us
                 </li>
               </ul>
-              <p className="mt-2 text-sm">¹For example: <a href="https://creativecommons.org/licenses/by/4.0/">CC BY</a>, <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA</a>, <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0</a>, <a href="https://www.gnu.org/licenses/fdl-1.3.html">GNU FDL</a></p>
-              <p className="mt-1 text-sm">²No paywalls, no signups, no invite-only systems</p>
+              <p className="mt-2 text-xs">¹For example: <a href="https://creativecommons.org/licenses/by/4.0/">CC BY</a>, <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA</a>, <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0</a>, <a href="https://www.gnu.org/licenses/fdl-1.3.html">GNU FDL</a></p>
+              <span className="ml-3 text-xs">²No paywalls, no signups, no invite-only systems</span></p>
             </div>
           </div>
         </div>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -102,26 +102,72 @@ export default function ApplicationForm() {
               />
             </div>
             <div>
-              <p className="font-bold mb-2">Application Requirements</p>
+              <p className="mb-2 font-bold">Application Requirements</p>
               <ul className="list-disc pl-6 text-sm">
-                <li>Educational material MUST be published under an <strong>open license</strong>¹</li>
                 <li>
-                  Educational material MUST be publicly available to anyone (for free)²
+                  Educational material MUST be published under an{' '}
+                  <strong>open license</strong>¹
                 </li>
                 <li>
-                  You MUST provide at least <strong>two references</strong> that we can reach out to
+                  Educational material MUST be publicly available to anyone (for
+                  free)²
+                </li>
+                <li>
+                  You MUST provide at least <strong>two references</strong> that
+                  we can reach out to
                 </li>
               </ul>
-              <p className="font-bold mt-4 mb-2">Reporting Requirements</p>
+              <p className="mb-2 mt-4 font-bold">Reporting Requirements</p>
               <ul className="list-disc pl-6 text-sm">
-                <li><strong>Monthly</strong> progress reports MUST be submitted on time</li>
                 <li>
-                  Progress reports MUST contain proof-of-work that is easily verifiable by us
+                  <strong>Monthly</strong> progress reports MUST be submitted on
+                  time
+                </li>
+                <li>
+                  Progress reports MUST contain proof-of-work that is easily
+                  verifiable by us
                 </li>
               </ul>
-              <hr className="mt-6 mb-3 border-blue-200" />
-              <p className="mt-2 mb-0 text-xs"> (¹) For example: <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener noreferrer">CC BY</a>, <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener noreferrer">CC BY-SA</a>, <a href="https://creativecommons.org/publicdomain/zero/1.0/" target="_blank" rel="noopener noreferrer">CC0</a>, <a href="https://www.gnu.org/licenses/fdl-1.3.html" target="_blank" rel="noopener noreferrer">GNU FDL</a></p>
-              <p className="mt-1 mb-0 text-xs"> (²) No paywalls, no signups, no invite-only systems</p>
+              <hr className="mb-3 mt-6 border-blue-200" />
+              <p className="mb-0 mt-2 text-xs">
+                {' '}
+                (¹) For example:{' '}
+                <a
+                  href="https://creativecommons.org/licenses/by/4.0/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  CC BY
+                </a>
+                ,{' '}
+                <a
+                  href="https://creativecommons.org/licenses/by-sa/4.0/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  CC BY-SA
+                </a>
+                ,{' '}
+                <a
+                  href="https://creativecommons.org/publicdomain/zero/1.0/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  CC0
+                </a>
+                ,{' '}
+                <a
+                  href="https://www.gnu.org/licenses/fdl-1.3.html"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  GNU FDL
+                </a>
+              </p>
+              <p className="mb-0 mt-1 text-xs">
+                {' '}
+                (²) No paywalls, no signups, no invite-only systems
+              </p>
             </div>
           </div>
         </div>
@@ -227,9 +273,7 @@ export default function ApplicationForm() {
         >
           <option value="12 months">12 months</option>
           <option value="9 months">9 months</option>
-          <option value="6 months">
-            6 months
-          </option>
+          <option value="6 months">6 months</option>
           <option value="3 months">3 months</option>
           <option value="Other">Other (please elaborate below)</option>
         </select>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -92,7 +92,7 @@ export default function ApplicationForm() {
           <ul className="list-disc pl-6">
             <li>Educational material MUST be published under an open license</li>
             <li>
-              Educational material MUST be publicly available for anyone (for free)*
+              Educational material MUST be publicly available for anyone (for free)†
             </li>
             <li>
               You MUST provide at least <strong>two references</strong> that we can reach out to
@@ -102,7 +102,7 @@ export default function ApplicationForm() {
               Progress reports MUST contain proof-of-work that is easily verifiable by us
             </li>
           </ul>
-          <p className="mt-2">*No paywalls, no signups, no invite-only systems</p>
+          <p className="mt-2">†No paywalls, no signups, no invite-only systems</p>
         </div>
       )}
 

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -91,7 +91,7 @@ export default function ApplicationForm() {
       </label>
       {watch('main_focus') === 'education' && (
         <div
-          className="mt-2 rounded-b border-t-4 border-blue-500 bg-blue-100 px-4 py-3 text-blue-900 shadow-md"
+          className="not-prose mt-2 rounded-b border-t-4 border-blue-500 bg-blue-100 px-4 py-3 text-blue-900 shadow-md"
           role="alert"
         >
           <div className="flex">

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -116,7 +116,8 @@ export default function ApplicationForm() {
                   Progress reports MUST contain proof-of-work that is easily verifiable by us
                 </li>
               </ul>
-              <p className="mt-2 text-xs">¹For example: <a href="https://creativecommons.org/licenses/by/4.0/">CC BY</a>, <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA</a>, <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0</a>, <a href="https://www.gnu.org/licenses/fdl-1.3.html">GNU FDL</a><span className="ml-3">²No paywalls, no signups, no invite-only systems</span></p>
+              <p className="mt-2 text-xs">¹For example: <a href="https://creativecommons.org/licenses/by/4.0/">CC BY</a>, <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA</a>, <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0</a>, <a href="https://www.gnu.org/licenses/fdl-1.3.html">GNU FDL</a></p>
+              <p className="mt-0 text-xs">²No paywalls, no signups, no invite-only systems</p>
             </div>
           </div>
         </div>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -88,22 +88,39 @@ export default function ApplicationForm() {
         </select>
       </label>
       {watch('main_focus') === 'education' && (
-        <div className="mt-2">
-          <ul className="list-disc pl-6">
-            <li>Educational material MUST be published under an open license¹</li>
-            <li>
-              Educational material MUST be publicly available for anyone (for free)²
-            </li>
-            <li>
-              You MUST provide at least <strong>two references</strong> that we can reach out to
-            </li>
-            <li>Monthly progress reports MUST be submitted on time</li>
-            <li>
-              Progress reports MUST contain proof-of-work that is easily verifiable by us
-            </li>
-          </ul>
-          <p className="mt-2">¹For example: CC BY, CC BY-SA, CC0, GNU FDL</p>
-          <p className="mt-1">²No paywalls, no signups, no invite-only systems</p>
+        <div
+          className="mt-2 rounded-b border-t-4 border-blue-500 bg-blue-100 px-4 py-3 text-blue-900 shadow-md"
+          role="alert"
+        >
+          <div className="flex">
+            <div className="py-1">
+              <svg
+                className="mr-4 h-6 w-6 fill-current text-blue-500"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+              >
+                <path d="M10 2L3 7v11a1 1 0 001 1h12a1 1 0 001-1V7l-7-5zM8 15v-3h4v3H8zm6-4H6V8h8v3z" />
+              </svg>
+            </div>
+            <div>
+              <p className="font-bold mb-2">Education Grant Requirements</p>
+              <ul className="list-disc pl-6 text-sm">
+                <li>Educational material MUST be published under an open license¹</li>
+                <li>
+                  Educational material MUST be publicly available for anyone (for free)²
+                </li>
+                <li>
+                  You MUST provide at least <strong>two references</strong> that we can reach out to
+                </li>
+                <li>Monthly progress reports MUST be submitted on time</li>
+                <li>
+                  Progress reports MUST contain proof-of-work that is easily verifiable by us
+                </li>
+              </ul>
+              <p className="mt-2 text-sm">¹For example: CC BY, CC BY-SA, CC0, GNU FDL</p>
+              <p className="mt-1 text-sm">²No paywalls, no signups, no invite-only systems</p>
+            </div>
+          </div>
         </div>
       )}
 

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -102,7 +102,7 @@ export default function ApplicationForm() {
               />
             </div>
             <div>
-              <p className="font-bold mb-2">Requirements</p>
+              <p className="font-bold mb-2">Application Requirements</p>
               <ul className="list-disc pl-6 text-sm">
                 <li>Educational material MUST be published under an <strong>open license</strong>¹</li>
                 <li>
@@ -111,6 +111,9 @@ export default function ApplicationForm() {
                 <li>
                   You MUST provide at least <strong>two references</strong> that we can reach out to
                 </li>
+              </ul>
+              <p className="font-bold mt-4 mb-2">Reporting Requirements</p>
+              <ul className="list-disc pl-6 text-sm">
                 <li><strong>Monthly</strong> progress reports MUST be submitted on time</li>
                 <li>
                   Progress reports MUST contain proof-of-work that is easily verifiable by us

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -14,7 +14,7 @@ export default function ApplicationForm() {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm({
+  } = useForm<{ [key: string]: unknown }>({
     defaultValues: {
       duration: '6 months',
     },
@@ -87,6 +87,20 @@ export default function ApplicationForm() {
           <option value="other">Other</option>
         </select>
       </label>
+      {watch('main_focus') === 'education' && (
+        <div className="mt-2">
+          <ul className="list-disc pl-6">
+            <li>Educational material MUST be published under an open license</li>
+            <li>
+              Educational material MUST be publicly available for anyone (for free)*
+            </li>
+            <li>
+              You MUST provide at least <strong>two references</strong> that we can reach out to
+            </li>
+          </ul>
+          <p className="mt-2">*No paywalls, no signups, no invite-only systems</p>
+        </div>
+      )}
 
       <label className="block">
         Project Name *<br />
@@ -283,7 +297,7 @@ export default function ApplicationForm() {
           placeholder="satoshin@gmx.com"
           {...register('email', {
             required: true,
-            validate: (v) =>
+            validate: (v: string) =>
               EmailValidator.validate(v) ||
               'Please enter a valid email address',
           })}

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -116,7 +116,7 @@ export default function ApplicationForm() {
                   Progress reports MUST contain proof-of-work that is easily verifiable by us
                 </li>
               </ul>
-              <p className="mt-2 text-sm">¹For example: CC BY, CC BY-SA, CC0, GNU FDL</p>
+              <p className="mt-2 text-sm">¹For example: <a href="https://creativecommons.org/licenses/by/4.0/">CC BY</a>, <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA</a>, <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0</a>, <a href="https://www.gnu.org/licenses/fdl-1.3.html">GNU FDL</a></p>
               <p className="mt-1 text-sm">²No paywalls, no signups, no invite-only systems</p>
             </div>
           </div>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -104,23 +104,23 @@ export default function ApplicationForm() {
             <div>
               <p className="font-bold mb-2">Application Requirements</p>
               <ul className="list-disc pl-6 text-sm">
-                <li>Educational material MUST be published under an <strong>open license</strong>¹</li>
+                <li>Educational material MUST be published under an <span className="font-semibold text-blue-900 dark:text-blue-200">open license</span>¹</li>
                 <li>
                   Educational material MUST be publicly available to anyone (for free)²
                 </li>
                 <li>
-                  You MUST provide at least <strong>two references</strong> that we can reach out to
+                  You MUST provide at least <span className="font-semibold text-blue-900 dark:text-blue-200">two references</span> that we can reach out to
                 </li>
               </ul>
               <p className="font-bold mt-4 mb-2">Reporting Requirements</p>
               <ul className="list-disc pl-6 text-sm">
-                <li><strong>Monthly</strong> progress reports MUST be submitted on time</li>
+                <li><span className="font-semibold text-blue-900 dark:text-blue-200">Monthly</span> progress reports MUST be submitted on time</li>
                 <li>
                   Progress reports MUST contain proof-of-work that is easily verifiable by us
                 </li>
               </ul>
-              <p className="mt-2 text-xs">¹For example: <a href="https://creativecommons.org/licenses/by/4.0/">CC BY</a>, <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA</a>, <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0</a>, <a href="https://www.gnu.org/licenses/fdl-1.3.html">GNU FDL</a></p>
-              <p className="mt-0 text-xs">²No paywalls, no signups, no invite-only systems</p>
+              <p className="mt-2 mb-0 text-xs">¹For example: <a href="https://creativecommons.org/licenses/by/4.0/">CC BY</a>, <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA</a>, <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0</a>, <a href="https://www.gnu.org/licenses/fdl-1.3.html">GNU FDL</a></p>
+              <p className="mt-0 mb-0 text-xs">²No paywalls, no signups, no invite-only systems</p>
             </div>
           </div>
         </div>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -90,9 +90,9 @@ export default function ApplicationForm() {
       {watch('main_focus') === 'education' && (
         <div className="mt-2">
           <ul className="list-disc pl-6">
-            <li>Educational material MUST be published under an open license</li>
+            <li>Educational material MUST be published under an open license†</li>
             <li>
-              Educational material MUST be publicly available for anyone (for free)†
+              Educational material MUST be publicly available for anyone (for free)‡
             </li>
             <li>
               You MUST provide at least <strong>two references</strong> that we can reach out to
@@ -102,7 +102,8 @@ export default function ApplicationForm() {
               Progress reports MUST contain proof-of-work that is easily verifiable by us
             </li>
           </ul>
-          <p className="mt-2">†No paywalls, no signups, no invite-only systems</p>
+          <p className="mt-2">†For example: CC BY, CC BY-SA, CC0, GNU FDL</p>
+          <p className="mt-1">‡No paywalls, no signups, no invite-only systems</p>
         </div>
       )}
 

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -102,7 +102,7 @@ export default function ApplicationForm() {
               />
             </div>
             <div>
-              <p className="font-bold mb-2">Education Grant Requirements</p>
+              <p className="font-bold mb-2">Requirements</p>
               <ul className="list-disc pl-6 text-sm">
                 <li>Educational material MUST be published under an open license¹</li>
                 <li>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -119,7 +119,7 @@ export default function ApplicationForm() {
                   Progress reports MUST contain proof-of-work that is easily verifiable by us
                 </li>
               </ul>
-              <hr className="mt-3 mb-2 border-blue-200" />
+              <hr className="mt-6 mb-3 border-blue-200" />
               <p className="mt-2 mb-0 text-xs">¹For example: <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener noreferrer">CC BY</a>, <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener noreferrer">CC BY-SA</a>, <a href="https://creativecommons.org/publicdomain/zero/1.0/" target="_blank" rel="noopener noreferrer">CC0</a>, <a href="https://www.gnu.org/licenses/fdl-1.3.html" target="_blank" rel="noopener noreferrer">GNU FDL</a></p>
               <p className="mt-1 mb-0 text-xs">²No paywalls, no signups, no invite-only systems</p>
             </div>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -120,8 +120,8 @@ export default function ApplicationForm() {
                 </li>
               </ul>
               <hr className="mt-6 mb-3 border-blue-200" />
-              <p className="mt-2 mb-0 text-xs">¹For example: <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener noreferrer">CC BY</a>, <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener noreferrer">CC BY-SA</a>, <a href="https://creativecommons.org/publicdomain/zero/1.0/" target="_blank" rel="noopener noreferrer">CC0</a>, <a href="https://www.gnu.org/licenses/fdl-1.3.html" target="_blank" rel="noopener noreferrer">GNU FDL</a></p>
-              <p className="mt-1 mb-0 text-xs">²No paywalls, no signups, no invite-only systems</p>
+              <p className="mt-2 mb-0 text-xs"> (¹) For example: <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener noreferrer">CC BY</a>, <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener noreferrer">CC BY-SA</a>, <a href="https://creativecommons.org/publicdomain/zero/1.0/" target="_blank" rel="noopener noreferrer">CC0</a>, <a href="https://www.gnu.org/licenses/fdl-1.3.html" target="_blank" rel="noopener noreferrer">GNU FDL</a></p>
+              <p className="mt-1 mb-0 text-xs"> (²) No paywalls, no signups, no invite-only systems</p>
             </div>
           </div>
         </div>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -119,7 +119,7 @@ export default function ApplicationForm() {
                   Progress reports MUST contain proof-of-work that is easily verifiable by us
                 </li>
               </ul>
-              <p className="mt-2 mb-0 text-xs">¹For example: <a href="https://creativecommons.org/licenses/by/4.0/">CC BY</a>, <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA</a>, <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0</a>, <a href="https://www.gnu.org/licenses/fdl-1.3.html">GNU FDL</a></p>
+              <p className="mt-2 mb-0 text-xs">¹For example: <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener noreferrer">CC BY</a>, <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener noreferrer">CC BY-SA</a>, <a href="https://creativecommons.org/publicdomain/zero/1.0/" target="_blank" rel="noopener noreferrer">CC0</a>, <a href="https://www.gnu.org/licenses/fdl-1.3.html" target="_blank" rel="noopener noreferrer">GNU FDL</a></p>
               <p className="mt-0 mb-0 text-xs">²No paywalls, no signups, no invite-only systems</p>
             </div>
           </div>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -116,8 +116,7 @@ export default function ApplicationForm() {
                   Progress reports MUST contain proof-of-work that is easily verifiable by us
                 </li>
               </ul>
-              <p className="mt-2 text-xs">¹For example: <a href="https://creativecommons.org/licenses/by/4.0/">CC BY</a>, <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA</a>, <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0</a>, <a href="https://www.gnu.org/licenses/fdl-1.3.html">GNU FDL</a></p>
-              <span className="ml-3 text-xs">²No paywalls, no signups, no invite-only systems</span></p>
+              <p className="mt-2 text-xs">¹For example: <a href="https://creativecommons.org/licenses/by/4.0/">CC BY</a>, <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA</a>, <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0</a>, <a href="https://www.gnu.org/licenses/fdl-1.3.html">GNU FDL</a><span className="ml-3">²No paywalls, no signups, no invite-only systems</span></p>
             </div>
           </div>
         </div>

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -106,7 +106,7 @@ export default function ApplicationForm() {
               <ul className="list-disc pl-6 text-sm">
                 <li>Educational material MUST be published under an <strong>open license</strong>¹</li>
                 <li>
-                  Educational material MUST be publicly available for anyone (for free)²
+                  Educational material MUST be publicly available to anyone (for free)²
                 </li>
                 <li>
                   You MUST provide at least <strong>two references</strong> that we can reach out to

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -108,6 +108,7 @@ export default function ApplicationForm() {
                   Educational material MUST be published under an{' '}
                   <strong>
                     <a
+                      className="underline text-orange-600 dark:text-orange-400 hover:text-orange-700 dark:hover:text-orange-300"
                       href="https://www.gnu.org/philosophy/free-doc.html"
                       target="_blank"
                       rel="noopener noreferrer"
@@ -141,6 +142,7 @@ export default function ApplicationForm() {
                 {' '}
                 (¹) For example:{' '}
                 <a
+                  className="underline text-orange-600 dark:text-orange-400 hover:text-orange-700 dark:hover:text-orange-300"
                   href="https://creativecommons.org/licenses/by/4.0/"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -149,6 +151,7 @@ export default function ApplicationForm() {
                 </a>
                 ,{' '}
                 <a
+                  className="underline text-orange-600 dark:text-orange-400 hover:text-orange-700 dark:hover:text-orange-300"
                   href="https://creativecommons.org/licenses/by-sa/4.0/"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -157,6 +160,7 @@ export default function ApplicationForm() {
                 </a>
                 ,{' '}
                 <a
+                  className="underline text-orange-600 dark:text-orange-400 hover:text-orange-700 dark:hover:text-orange-300"
                   href="https://creativecommons.org/publicdomain/zero/1.0/"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -165,6 +169,7 @@ export default function ApplicationForm() {
                 </a>
                 ,{' '}
                 <a
+                  className="underline text-orange-600 dark:text-orange-400 hover:text-orange-700 dark:hover:text-orange-300"
                   href="https://www.gnu.org/licenses/fdl-1.3.html"
                   target="_blank"
                   rel="noopener noreferrer"

--- a/pages/apply/grant.tsx
+++ b/pages/apply/grant.tsx
@@ -1,7 +1,12 @@
-import GrantApplicationForm from '@/components/GrantApplicationForm'
+import dynamic from 'next/dynamic'
 import PageSection from '@/components/PageSection'
 import CustomLink from '@/components/Link'
 import ClosedNotice from '@/components/ClosedNotice'
+
+const GrantApplicationForm = dynamic(
+  () => import('@/components/GrantApplicationForm'),
+  { ssr: false }
+)
 
 export default function Apply() {
   return (


### PR DESCRIPTION
This PR adds conditional education requirements that appear when users select 'Education' as their main focus in the grant application form. Note that these additional requirements will _only_ show if 'Education' is selected.

**Build preview:**

- [/apply/grant](https://os-website-git-edu-criteria-opensats.vercel.app/apply/grant)

---

<img width="702" height="442" alt="Screenshot 2025-09-18 at 13 00 18" src="https://github.com/user-attachments/assets/44191d10-5dd0-4d83-bd84-330e041a6a15" />

