### PR TITLE
docs(transparency): update COI reference to bylaws

### DIFF
--- a/data/pages/transparency.mdx
+++ b/data/pages/transparency.mdx
@@ -86,7 +86,7 @@ as in the internal and external processes of our organization.
 - [2025-Q1](/docs/minutes/2025-Q1.pdf)
 - [2025-Q2](/docs/minutes/2025-Q2.pdf)
 
-[coi]: /docs/conflict.pdf
+[coi]: /docs/bylaws.pdf
 [tax]: /docs/tax.pdf
 [owc]: /canary
 [rrp]: /docs/rrp.pdf


### PR DESCRIPTION
Updates the transparency page to point the `[coi]` reference at `/docs/bylaws.pdf` (which is more precise).