### PR TITLE
Route education applications to main applications repo

### DIFF
--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -105,9 +105,6 @@ ${
     if (mainFocus === 'core') {
       appRepo = `${GH_APP_REPO}-core`
     }
-    if (mainFocus === 'education') {
-      appRepo = `${GH_APP_REPO}-education`
-    }
     if (mainFocus === 'ecash') {
       appRepo = `${GH_APP_REPO}-ecash`
     }


### PR DESCRIPTION
Education applications will now be routed directly to the main `applications` repo.