### PR TITLE
Update Wave 10 Nostr renewals (links, dates)

### DIFF
--- a/data/blog/10th-wave-of-nostr-grants.mdx
+++ b/data/blog/10th-wave-of-nostr-grants.mdx
@@ -30,7 +30,7 @@ In addition, OpenSats has renewed project grants for:
 
 - futr ([Sep. 2024](/blog/7th-wave-of-nostr-grants#futr))
 - Notedeck ([Sep. 2024](/blog/7th-wave-of-nostr-grants#notedeck))
-- Npub.cash ([Jul. 2024](blog/nostr-grants-july-2024#npubcash))
+- Npub.cash ([Jul. 2024](/blog/nostr-grants-july-2024#npubcash))
 
 Our ability to support these projects is made possible by the generosity of our
 donors. If you would like to help us continue funding important advancements


### PR DESCRIPTION
Changes
- Fix in-article anchors for the renewals list.
- Add announcement dates (e.g., Jul. 2023) next to each item.
- Link each date to the corresponding announcement post.

Build Preview
- [/blog/10th-wave-of-nostr-grants](https://os-website-git-arvin21m-patch-1-opensats.vercel.app/blog/10th-wave-of-nostr-grants)