### PR TITLE
Update Wave 10 Bitcoin renewals (links, dates)

### DIFF
--- a/data/blog/tenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/tenth-wave-of-bitcoin-grants.mdx
@@ -25,9 +25,9 @@ The three first-time project grants in this wave are:
 
 In addition to the above, OpenSats has renewed project grants for:
 
-- [Floresta](/blog/bitcoin-grants-september-2024-7th-wave#floresta)
-- [Krux](/blog/bitcoin-grants-july-2024#krux)
-- [Krux-Installer](/blog/bitcoin-grants-july-2024#krux-installer)
+- Floresta ([Sep. 2024](/blog/bitcoin-grants-september-2024-7th-wave#floresta))
+- Krux ([Jul. 2024](/blog/bitcoin-grants-july-2024#krux))
+- Krux-Installer ([Jul. 2024](/blog/bitcoin-grants-july-2024#krux-installer))
 
 Thanks to the generosity of our donors, OpenSats can actively support the
 open-source developers and projects that are building key infrastructure


### PR DESCRIPTION
Changes
- Fix in-article anchors for the renewals list.
- Add announcement dates (e.g., Jul. 2023) next to each item.
- Link each date to the corresponding announcement post.

Build Preview:
- [/blog/tenth-wave-of-bitcoin-grants](https://os-website-git-arvin21m-patch-4-opensats.vercel.app/blog/tenth-wave-of-bitcoin-grants)