### PR TITLE
Update Wave 13 Bitcoin renewals (links, dates)

### DIFF
--- a/data/blog/thirteenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/thirteenth-wave-of-bitcoin-grants.mdx
@@ -26,9 +26,9 @@ First-time project grants:
 
 Grant renewals:
 
-- [ASmap](/blog/bitcoin-grants-september-2024-7th-wave#asmap)
-- [Blitz Wallet](/blog/bitcoin-grants-july-2024-6th-wave#blitz-wallet)
-- [@hodlinator](/blog/caring-for-bitcoin-core#hodlinator)
+- ASmap ([Sep. 2024](/blog/bitcoin-grants-september-2024-7th-wave#asmap))
+- @hodlinator ([Aug. 2024](/blog/caring-for-bitcoin-core#hodlinator))
+- Blitz Wallet ([Jul. 2024](/blog/bitcoin-grants-july-2024-6th-wave#blitz-wallet))
 
 Each project addresses a specific need—from drop-in Tor libraries and Silent
 Payments coordination to hardened live-OS builds,


### PR DESCRIPTION
Changes

- Fix in-article anchors for the renewals list.
- Add announcement dates (e.g., Jul. 2023) next to each item.
- Link each date to the corresponding announcement post.

Build Preview
- [/blog/thirteenth-wave-of-bitcoin-grants](https://os-website-git-arvin21m-patch-5-opensats.vercel.app/blog/thirteenth-wave-of-bitcoin-grants)