### PR TITLE
Update Wave 12 Bitcoin renewals (links, dates)

### DIFF
--- a/data/blog/twelfth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/twelfth-wave-of-bitcoin-grants.mdx
@@ -27,14 +27,13 @@ The five first-time project grants in this wave are:
 
 The seven project grant renewals in this wave are:
 
-- [Krux](/blog/bitcoin-grants-july-2024#krux)
-- [Vexl](/blog/bitcoin-grants-december-2023#vexl)
-- [Utreexo](/blog/bitcoin-grants-july-2024#utreexo)
-- [Nutshell](/blog/8th-wave-of-bitcoin-grants#cashu-nutshell)
-- [DLC Dev Kit](/blog/bitcoin-grants-september-2024-7th-wave#dlc-dev-kit)
-- [Bitcoin Core App](/blog/caring-for-bitcoin-core#bitcoin-core-app)
-- [Validating Lightning
-  Signer](/blog/bitcoin-grants-july-2024#validating-lightning-signer)
+- Nutshell ([Oct. 2024](/blog/8th-wave-of-bitcoin-grants#cashu-nutshell))
+- DLC Dev Kit ([Sep. 2024](/blog/bitcoin-grants-september-2024-7th-wave#dlc-dev-kit))
+- Bitcoin Core App ([Aug. 2024](/blog/caring-for-bitcoin-core#bitcoin-core-app))
+- Krux ([Jul. 2024](/blog/bitcoin-grants-july-2024#krux))
+- Utreexo ([Jul. 2024](/blog/bitcoin-grants-july-2024#utreexo))
+- Validating Lightning Signer ([Jul. 2024](/blog/bitcoin-grants-july-2024#validating-lightning-signer))
+- Vexl ([Dec. 2023](/blog/bitcoin-grants-december-2023#vexl))
 
 Together, these twelve projects highlight a shared goal: making Bitcoin more
 decentralized, transparent, and user-driven—while keeping it robust, usable,


### PR DESCRIPTION
Changes

- Fix in-article anchors for the renewals list.
- Add announcement dates (e.g., Jul. 2023) next to each item.
- Link each date to the corresponding announcement post.

Build Preview
- [/blog/twelfth-wave-of-bitcoin-grants](https://os-website-git-arvin21m-patch-6-opensats.vercel.app/blog/twelfth-wave-of-bitcoin-grants)