### PR TITLE
Update Wave 12 Nostr renewals (links, dates)

### DIFF
--- a/data/blog/twelfth-wave-of-nostr-grants.mdx
+++ b/data/blog/twelfth-wave-of-nostr-grants.mdx
@@ -27,10 +27,10 @@ relay discovery, and cross-protocol integration:
 In addition, we've also renewed funding for four projects that continue to make
 critical contributions across the nostr ecosystem:
 
-- [Damus](/blog/nostr-grants-july-2023#damus)
-- [Camelus](/blog/nostr-grants-december-2023#camelus)
-- [Nostromo](/blog/nostr-grants-july-2024#nostrmo)
-- [Nostroots](/blog/nostr-grants-august-2024#nostroots)
+- Camelus ([Dec. 2023](/blog/nostr-grants-december-2023#camelus))
+- Damus ([Jul. 2023](/blog/nostr-grants-july-2023#damus))
+- Nostromo ([Jul. 2024](/blog/nostr-grants-july-2024#nostrmo))
+- Nostroots ([Aug. 2024](/blog/nostr-grants-august-2024#nostroots))
 
 This support is made possible by donors who believe in an open,
 censorship-resistant communications layer for the internet—and the builders


### PR DESCRIPTION
Changes

- Fix in-article anchors for the renewals list.
- Add announcement dates (e.g., Jul. 2023) next to each item.
- Link each date to the corresponding announcement post.

Build Preview
- [/blog/twelfth-wave-of-nostr-grants](https://os-website-git-arvin21m-patch-7-opensats.vercel.app/blog/twelfth-wave-of-nostr-grants)