### PR TITLE
Updated Second's repo link to point to GitLab

### DIFF
--- a/data/blog/advancements-in-developer-libraries.mdx
+++ b/data/blog/advancements-in-developer-libraries.mdx
@@ -84,7 +84,7 @@ time.
 >innovative new layer one wallets. Looking forward, we also see BDK playing a
 >strong supporting role for layer two projects like
 >[ldk-node](https://github.com/lightningdevkit/ldk-node) and [Second's
->bark](https://codeberg.org/ark-bitcoin/bark). If there is a bitcoin project you
+>bark](https://gitlab.com/ark-bitcoin/bark). If there is a bitcoin project you
 >want to see in the world, BDK will help you build it.
 >
 ><cite>—Steve Myers, BDK director/core contributor</cite>


### PR DESCRIPTION
Second has moved from Codeberg to GitLab for development.