### PR TITLE
Add Application FAQ link to grant application page

### DIFF
--- a/pages/apply/grant.tsx
+++ b/pages/apply/grant.tsx
@@ -27,6 +27,8 @@ export default function Apply() {
         <p>
           Make sure to read the{' '}
           <CustomLink href="/apply#criteria">application criteria</CustomLink>{' '}
+          and the{' '}
+          <CustomLink href="/faq/application">Application FAQ</CustomLink>{' '}
           before sending in an application.
         </p>
         <GrantApplicationForm />


### PR DESCRIPTION
Adds a link to the Application FAQ on the grant application page to make it more visible to applicants. The link appears alongside the existing application criteria link in the instructions section.

**Build preview:**

- [/apply/grant](https://os-website-git-more-visible-link-to-application-faq-opensats.vercel.app/apply/grant)
