### PR TITLE
Show related announcements for funds based on tags

### DIFF
--- a/utils/relatedPosts.ts
+++ b/utils/relatedPosts.ts
@@ -1,4 +1,4 @@
-import type { Project, Blog } from 'contentlayer/generated'
+import type { Project, Blog, Fund } from 'contentlayer/generated'
 
 /**
  * Finds blog posts that mention a given project by searching through
@@ -25,4 +25,31 @@ export function getRelatedBlogPostsForProject(
     return searchContent.includes(projectTitle)
   })
 }
+
+// Map fund slugs to the tags that should be considered "related" for announcements
+const FUND_TAGS_BY_SLUG: Record<string, string[]> = {
+  nostr: ['nostr'],
+  general: ['bitcoin'],
+  ops: ['funding'],
+}
+
+/**
+ * Finds blog posts that are related to a given fund by matching tags.
+ *
+ * This uses a simple mapping from fund slug to one or more tags and then
+ * returns all blog posts that share at least one of those tags.
+ */
+export function getRelatedBlogPostsForFund(fund: Fund, blogs: Blog[]): Blog[] {
+  if (!fund) return []
+
+  const slug = fund.slug.split('/').pop() || fund.slug
+  const relatedTags = (FUND_TAGS_BY_SLUG[slug] || []).map((t) => t.toLowerCase())
+  if (!relatedTags.length) return []
+
+  return blogs.filter((blog) => {
+    const blogTags = (blog.tags || []).map((t) => t.toLowerCase())
+    return blogTags.some((tag) => relatedTags.includes(tag))
+  })
+}
+
 


### PR DESCRIPTION
This adds functionality to display related blog announcements on fund pages by matching tags. The implementation includes a new `getRelatedBlogPostsForFund` function that maps fund slugs to relevant tags (nostr, bitcoin, funding) and filters blog posts accordingly. The fund page now displays a "Related Announcements" section when matching posts are found.

- Added `getRelatedBlogPostsForFund` utility function with tag-based matching logic
- Updated fund page to fetch and display related blog posts using the `PostList` component

**Build preview:**

- [/funds/general](https://os-website-git-show-announcements-related-to-funds-opensats.vercel.app/funds/general)
- [/funds/ops](https://os-website-git-show-announcements-related-to-funds-opensats.vercel.app/funds/ops)
- [/funds/nostr](https://os-website-git-show-announcements-related-to-funds-opensats.vercel.app/funds/nostr)