### PR TITLE
Edit to Advancements in Nostr Clients: small wording change for clarity

### DIFF
--- a/data/blog/advancements-in-nostr-clients.mdx
+++ b/data/blog/advancements-in-nostr-clients.mdx
@@ -107,8 +107,8 @@ direct-messaging standard, closing metadata leaks that were present in the older
 private communication on nostr substantially harder to track or analyze from the
 outside.
 
-Discovery features also evolved. Version [0.93.0] introduced a dedicated image
-feed powered by Olas, a photo-focused nostr service, an "Around Me" feed that
+Discovery features also evolved. Version [0.93.0] introduced support for image
+feeds from Olas, a photo-focused nostr service, an "Around Me" feed that
 highlights posts tied to the user's approximate location, and [NIP-63]
 interactive stories. These additions allow users to browse photos in a focused
 stream, see what is happening nearby, or tap through story-style posts that feel


### PR DESCRIPTION
**Original line:**
"Version 0.93.0 introduced a dedicated image feed powered by Olas..."

**Change to:**
"Version 0.93.0 introduced support for image feeds from Olas..."

**Build Preview:**
[/blog/advancements-in-nostr-clients#amethyst](https://os-website-git-arvin21m-patch-1-opensats.vercel.app/blog/advancements-in-nostr-clients#amethyst)