### PR TITLE
Edit to Andrew's LTS Blog Post: add quote

### DIFF
--- a/data/blog/andrew-toth-receives-lts-grant.mdx
+++ b/data/blog/andrew-toth-receives-lts-grant.mdx
@@ -33,6 +33,13 @@ Andrew's other contributions to projects such as [bitcoinjs], [rust-bitcoin],
 and [Electrum Personal Server] reflect his commitment to the benefit of the
 Bitcoin ecosystem.
 
+> I’m grateful and honored to receive this grant to continue my work on Bitcoin
+> Core. Performance and privacy are essential for using Bitcoin in a
+> self-sovereign way, and I’m glad to see these efforts recognized and
+> supported.
+>
+> <cite>—Andrew Toth</cite>
+
 With support from this LTS grant, Andrew plans to continue work on several areas
 of Bitcoin Core, including:
 


### PR DESCRIPTION
Grantee replied back with a quote to add to his LTS announcement.

**Original blog post:**
https://opensats.org/blog/andrew-toth-receives-lts-grant

**Build Preview:**
[/blog/andrew-toth-receives-lts-grant](https://os-website-git-arvin21m-patch-2-opensats.vercel.app/blog/andrew-toth-receives-lts-grant)