### PR TITLE
Fix font color on submit preview page when in dark mode

### DIFF
--- a/components/ReportPreview.tsx
+++ b/components/ReportPreview.tsx
@@ -7,7 +7,7 @@ interface ReportPreviewProps {
 
 export default function ReportPreview({ reportContent }: ReportPreviewProps) {
   return (
-    <div className="prose prose-sm max-w-none p-6 dark:prose-invert">
+    <div className="prose prose-sm max-w-none p-6 dark:prose-dark">
       <ReactMarkdown>{reportContent}</ReactMarkdown>
     </div>
   )


### PR DESCRIPTION
Quick fix to make the dark mode font color visible on the grant progress report preview page