### PR TITLE
Clarification on reference letters

### DIFF
--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -64,7 +64,7 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
       <FieldError
         errors={errors}
         name="has_references"
-        message="Please prepare your reference letters before continuing"
+        message="Please send the reference letters asap after submitting this application, as the review process only starts once we have at least 2 reference letters."
       />
 
       <label className="inline-flex items-start gap-2">

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -64,7 +64,7 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
       <FieldError
         errors={errors}
         name="has_references"
-        message="Please send the reference letters asap after submitting this application, as the review process only starts once we have at least 2 reference letters."
+        message="Please prepare your reference letters before continuing. Reference letters can be included as part of your application or emailed to support@opensats.org once your application is submitted. The evaluation of your application will not start until we have two references."
       />
 
       <label className="inline-flex items-start gap-2">


### PR DESCRIPTION
Clarify that the reference letters can be sent after the application is submitted, but the review process only starts after at least 2 reference letters are received.