### PR TITLE
feat: add project Open Graph images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ public/sitemap.xml
 
 # search
 /public/search.json
+/public/static/images/projects/og/
 
 # misc
 .DS_Store

--- a/components/SEO.tsx
+++ b/components/SEO.tsx
@@ -68,6 +68,12 @@ interface PageSEOProps {
   description: string
 }
 
+interface ProjectSEOProps {
+  title: string
+  description: string
+  slug: string
+}
+
 export const PageSEO = ({ title, description }: PageSEOProps) => {
   const ogImageUrl = siteMetadata.siteUrl + siteMetadata.socialBanner
   const twImageUrl = siteMetadata.siteUrl + siteMetadata.socialBanner
@@ -78,6 +84,21 @@ export const PageSEO = ({ title, description }: PageSEOProps) => {
       ogType="website"
       ogImage={ogImageUrl}
       twImage={twImageUrl}
+    />
+  )
+}
+
+export const ProjectSEO = ({ title, description, slug }: ProjectSEOProps) => {
+  const ogImagePath = `/static/images/projects/og/${slug}.png`
+  const ogImageUrl = siteMetadata.siteUrl + ogImagePath
+
+  return (
+    <CommonSEO
+      title={title}
+      description={description}
+      ogType="website"
+      ogImage={ogImageUrl}
+      twImage={ogImageUrl}
     />
   )
 }

--- a/data/projects/bitcoindesign.mdx
+++ b/data/projects/bitcoindesign.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Bitcoin Design Community'
 dateAdded: '2023-03-10'
-summary: 'A free, open-source community resource for designers, developers, and others working on non-custodial bitcoin products.'
+summary: 'Design resources for teams building better bitcoin products.'
 nym: 'Christoph Ono'
 website: 'https://bitcoin.design/'
 donationLink: 'https://opencollective.com/bitcoin-design-foundation'

--- a/data/projects/grapheneos.mdx
+++ b/data/projects/grapheneos.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'GrapheneOS'
 dateAdded: '2022-12-24'
-summary: 'GrapheneOS is a private and secure mobile operating system with a high level of usability comparable to mainstream Android devices.'
+summary: 'A hardened mobile operating system focused on privacy and security.'
 nym: 'GrapheneOS Foundation'
 website: 'https://grapheneos.org/'
 donationLink: 'https://grapheneos.org/donate'

--- a/data/projects/soapbox.mdx
+++ b/data/projects/soapbox.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Soapbox'
 dateAdded: '2023-07-08'
-summary: 'An open-source social media frontend for nostr and the fediverse, the Ditto self-hosted server, and the Mostr bridge.'
+summary: 'Open-source social software for nostr and the fediverse, including the Ditto server and Mostr bridge.'
 nym: 'Alex Gleason'
 website: 'https://soapbox.pub/'
 coverImage: '/static/images/projects/soapbox.svg'

--- a/data/projects/splicing.mdx
+++ b/data/projects/splicing.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Splicing'
 dateAdded: '2023-03-10'
-summary: 'Splicing is the ability to resize Lightning channels on-the-fly, giving users of the Lightning Network many additional benefits that were not intuitively obvious at first.'
+summary: 'A Lightning upgrade for resizing channels without closing them.'
 nym: 'Dusty Daemon'
 website: 'https://lightningsplice.com/'
 coverImage: '/static/images/projects/splicing.jpg'

--- a/data/projects/summerofbitcoin.mdx
+++ b/data/projects/summerofbitcoin.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Summer of Bitcoin'
 dateAdded: '2023-04-20'
-summary: 'Summer of Bitcoin is a global summer internship program focused on introducing university students to bitcoin open-source development and design. Till date, Summer of Bitcoin has funded 124 students from 15 countries to contribute to over 29 open-source bitcoin projects.'
+summary: 'A global internship program for student bitcoin contributors.'
 nym: 'Adi Shankara'
 website: 'https://www.summerofbitcoin.org/'
 donationLink: 'https://geyser.fund/project/summerofbitcoin'

--- a/data/projects/tor.mdx
+++ b/data/projects/tor.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'The Tor Project'
 dateAdded: '2022-12-30'
-summary: 'The Tor Project advances human rights and defends your privacy online through free software and open networks.'
+summary: 'Free software and open networks that defend privacy online.'
 nym: 'The Tor Project'
 website: 'https://www.torproject.org/'
 donationLink: 'https://donate.torproject.org/'

--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -1,6 +1,16 @@
 // @ts-check
 
 /** @type {import("pliny/config").PlinyConfig } */
+const rawSiteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  process.env.SITE_URL ||
+  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null) ||
+  'https://opensats.org'
+
+const siteUrl = rawSiteUrl.startsWith('http')
+  ? rawSiteUrl.replace(/\/$/, '')
+  : `https://${rawSiteUrl.replace(/\/$/, '')}`
+
 const siteMetadata = {
   title: 'OpenSats',
   author: 'OpenSats',
@@ -9,7 +19,7 @@ const siteMetadata = {
     'OpenSats is a 501(c)(3) public charity that aims to support and maintain a sustainable ecosystem of funding for free and open-source projects and contributors, especially bitcoin-related projects and projects that help bitcoin flourish.',
   language: 'en-us',
   theme: 'system', // system, dark or light
-  siteUrl: 'https://opensats.org',
+  siteUrl,
   siteRepo: 'https://github.com/OpenSats/website/',
   siteLogo: '/static/images/logo.png',
   image: '/static/images/avatar.png',

--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-/** @type {import("pliny/config").PlinyConfig } */
 const rawSiteUrl =
   process.env.NEXT_PUBLIC_SITE_URL ||
   process.env.SITE_URL ||
@@ -11,6 +10,7 @@ const siteUrl = rawSiteUrl.startsWith('http')
   ? rawSiteUrl.replace(/\/$/, '')
   : `https://${rawSiteUrl.replace(/\/$/, '')}`
 
+/** @type {import("pliny/config").PlinyConfig } */
 const siteMetadata = {
   title: 'OpenSats',
   author: 'OpenSats',

--- a/layouts/ProjectLayout.tsx
+++ b/layouts/ProjectLayout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 import type { Project } from 'contentlayer/generated'
-import { PageSEO } from '@/components/SEO'
+import { ProjectSEO } from '@/components/SEO'
 import SocialIcon from '@/components/social-icons'
 import { CoreContent } from 'pliny/utils/contentlayer'
 import PageHeading from '@/components/PageHeading'
@@ -12,11 +12,24 @@ interface Props {
 }
 
 export default function PageLayout({ children, content }: Props) {
-  const { title, summary, coverImage, website, twitter, git, nostr, zapstore } =
-    content
+  const {
+    title,
+    summary,
+    slug,
+    coverImage,
+    website,
+    twitter,
+    git,
+    nostr,
+    zapstore,
+  } = content
   return (
     <>
-      <PageSEO title={`${title} - OpenSats`} description={`${summary}`} />
+      <ProjectSEO
+        title={`${title} - OpenSats`}
+        description={`${summary}`}
+        slug={slug}
+      />
       <div className="divide-y divide-gray-200 dark:divide-gray-700">
         <PageHeading title={title}>
           <div className="flex flex-col items-center space-x-2 pt-8 xl:block">

--- a/layouts/ProjectLayout.tsx
+++ b/layouts/ProjectLayout.tsx
@@ -26,7 +26,7 @@ export default function PageLayout({ children, content }: Props) {
   return (
     <>
       <ProjectSEO
-        title={`${title} - OpenSats`}
+        title={`${title} - funded by OpenSats`}
         description={`${summary}`}
         slug={slug}
       />

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "unist-util-visit": "^4.1.0"
       },
       "devDependencies": {
+        "@resvg/resvg-js": "^2.6.2",
         "@svgr/webpack": "^6.3.1",
         "@tailwindcss/aspect-ratio": "^0.4.2",
         "@testing-library/jest-dom": "^6.6.3",
@@ -5335,6 +5336,234 @@
       "resolved": "https://registry.npmjs.org/@reach/observe-rect/-/observe-rect-1.2.0.tgz",
       "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ==",
       "license": "MIT"
+    },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "start": "next dev",
     "dev": "cross-env INIT_CWD=$PWD next dev",
-    "build": "npx contentlayer build && cross-env INIT_CWD=$PWD next build && node -r esbuild-register ./scripts/postbuild.mjs",
+    "build": "npx contentlayer build && node ./scripts/generate-project-og.mjs && cross-env INIT_CWD=$PWD next build && node -r esbuild-register ./scripts/postbuild.mjs",
     "serve": "next start",
     "analyze": "cross-env ANALYZE=true next build",
+    "generate:project-og": "node ./scripts/generate-project-og.mjs",
     "lint": "next lint --fix --dir pages --dir components --dir lib --dir layouts --dir scripts",
     "test": "jest"
   },
@@ -65,6 +66,7 @@
     "unist-util-visit": "^4.1.0"
   },
   "devDependencies": {
+    "@resvg/resvg-js": "^2.6.2",
     "@svgr/webpack": "^6.3.1",
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@testing-library/jest-dom": "^6.6.3",

--- a/scripts/generate-project-og.mjs
+++ b/scripts/generate-project-og.mjs
@@ -143,7 +143,7 @@ function renderSvg(project, coverImage) {
           <rect x="84" y="140" width="600" height="220" />
         </clipPath>
         <clipPath id="summary-clip">
-          <rect x="84" y="370" width="600" height="150" />
+          <rect x="84" y="348" width="600" height="150" />
         </clipPath>
       </defs>
 
@@ -159,13 +159,13 @@ function renderSvg(project, coverImage) {
         ${titleSvg}
       </text>
 
-      <text x="84" y="408" fill="#d4d4d8" font-size="30" font-family="Arial, Helvetica, sans-serif" clip-path="url(#summary-clip)">
+      <text x="84" y="386" fill="#d4d4d8" font-size="30" font-family="Arial, Helvetica, sans-serif" clip-path="url(#summary-clip)">
         ${summarySvg}
       </text>
 
-      <rect x="84" y="520" width="560" height="1" fill="#3f3f46" />
-      <text x="84" y="560" fill="#a1a1aa" font-size="24" font-family="Arial, Helvetica, sans-serif">${kicker}</text>
-      <text x="84" y="596" fill="#71717a" font-size="20" font-family="Arial, Helvetica, sans-serif">${projectUrl}</text>
+      <rect x="84" y="498" width="560" height="1" fill="#3f3f46" />
+      <text x="84" y="536" fill="#a1a1aa" font-size="24" font-family="Arial, Helvetica, sans-serif">${kicker}</text>
+      <text x="84" y="570" fill="#71717a" font-size="20" font-family="Arial, Helvetica, sans-serif">${projectUrl}</text>
 
       <rect x="736" y="84" width="408" height="408" rx="36" fill="#111827" stroke="#27272a" stroke-width="2" />
       ${coverSvg}

--- a/scripts/generate-project-og.mjs
+++ b/scripts/generate-project-og.mjs
@@ -1,0 +1,221 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { Resvg } from '@resvg/resvg-js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const root = path.resolve(__dirname, '..')
+const outputDir = path.join(
+  root,
+  'public',
+  'static',
+  'images',
+  'projects',
+  'og'
+)
+const projectsIndexPath = path.join(
+  root,
+  '.contentlayer',
+  'generated',
+  'Project',
+  '_index.json'
+)
+
+const WIDTH = 1200
+const HEIGHT = 630
+
+const mimeTypes = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+}
+
+function escapeXml(value = '') {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+}
+
+function clampText(text = '', maxLength) {
+  const normalized = text.replace(/\s+/g, ' ').trim()
+  if (normalized.length <= maxLength) {
+    return normalized
+  }
+
+  return `${normalized.slice(0, maxLength - 1).trimEnd()}…`
+}
+
+function wrapText(text, maxCharsPerLine, maxLines) {
+  const words = clampText(text, maxCharsPerLine * maxLines + maxLines).split(
+    ' '
+  )
+  const lines = []
+  let current = ''
+
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word
+    if (candidate.length <= maxCharsPerLine) {
+      current = candidate
+      continue
+    }
+
+    if (current) {
+      lines.push(current)
+      if (lines.length === maxLines) {
+        return lines
+      }
+    }
+
+    current = word
+  }
+
+  if (current && lines.length < maxLines) {
+    lines.push(current)
+  }
+
+  if (lines.length > maxLines) {
+    return lines.slice(0, maxLines)
+  }
+
+  return lines
+}
+
+async function toDataUri(publicPath) {
+  const filePath = path.join(root, 'public', publicPath.replace(/^\//, ''))
+  const extension = path.extname(filePath).toLowerCase()
+  const mimeType = mimeTypes[extension]
+
+  if (!mimeType) {
+    return null
+  }
+
+  const buffer = await fs.readFile(filePath)
+  return `data:${mimeType};base64,${buffer.toString('base64')}`
+}
+
+function renderSvg(project, coverImage) {
+  const titleLines = wrapText(project.title, 20, 3)
+  const summaryLines = wrapText(project.summary, 42, 4)
+  const kicker = escapeXml(project.nym)
+  const projectUrl = escapeXml(`opensats.org/projects/${project.slug}`)
+
+  const titleSvg = titleLines
+    .map(
+      (line, index) =>
+        `<tspan x="84" dy="${index === 0 ? 0 : 72}">${escapeXml(line)}</tspan>`
+    )
+    .join('')
+
+  const summarySvg = summaryLines
+    .map(
+      (line, index) =>
+        `<tspan x="84" dy="${index === 0 ? 0 : 38}">${escapeXml(line)}</tspan>`
+    )
+    .join('')
+
+  const coverSvg = coverImage
+    ? `<image href="${coverImage}" x="764" y="112" width="352" height="352" preserveAspectRatio="xMidYMid slice" clip-path="url(#cover-clip)" />`
+    : `<rect x="764" y="112" width="352" height="352" rx="28" fill="#18181b" />
+       <text x="940" y="300" text-anchor="middle" fill="#a1a1aa" font-size="28" font-family="Arial, Helvetica, sans-serif">OpenSats Project</text>`
+
+  return `
+    <svg width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
+          <stop stop-color="#09090b" />
+          <stop offset="1" stop-color="#171717" />
+        </linearGradient>
+        <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+          <stop stop-color="#f97316" />
+          <stop offset="1" stop-color="#fb923c" />
+        </linearGradient>
+        <clipPath id="cover-clip">
+          <rect x="764" y="112" width="352" height="352" rx="28" />
+        </clipPath>
+      </defs>
+
+      <rect width="1200" height="630" fill="url(#bg)" />
+      <circle cx="1110" cy="92" r="180" fill="#f97316" fill-opacity="0.08" />
+      <circle cx="1035" cy="540" r="140" fill="#f97316" fill-opacity="0.06" />
+
+      <rect x="84" y="72" width="188" height="38" rx="19" fill="#1f2937" />
+      <circle cx="110" cy="91" r="6" fill="url(#accent)" />
+      <text x="128" y="98" fill="#e5e7eb" font-size="20" font-family="Arial, Helvetica, sans-serif">OpenSats Project</text>
+
+      <text x="84" y="192" fill="#fafaf9" font-size="60" font-weight="700" font-family="Arial, Helvetica, sans-serif">
+        ${titleSvg}
+      </text>
+
+      <text x="84" y="408" fill="#d4d4d8" font-size="30" font-family="Arial, Helvetica, sans-serif">
+        ${summarySvg}
+      </text>
+
+      <rect x="84" y="520" width="560" height="1" fill="#3f3f46" />
+      <text x="84" y="560" fill="#a1a1aa" font-size="24" font-family="Arial, Helvetica, sans-serif">${kicker}</text>
+      <text x="84" y="596" fill="#71717a" font-size="20" font-family="Arial, Helvetica, sans-serif">${projectUrl}</text>
+
+      <rect x="736" y="84" width="408" height="408" rx="36" fill="#111827" stroke="#27272a" stroke-width="2" />
+      ${coverSvg}
+      <rect x="764" y="486" width="352" height="38" rx="19" fill="#18181b" />
+      <text x="940" y="512" text-anchor="middle" fill="#f4f4f5" font-size="18" font-family="Arial, Helvetica, sans-serif">${escapeXml(
+        project.title
+      )}</text>
+    </svg>
+  `
+}
+
+async function ensureOutputDir() {
+  await fs.rm(outputDir, { recursive: true, force: true })
+  await fs.mkdir(outputDir, { recursive: true })
+}
+
+async function loadProjects() {
+  const file = await fs.readFile(projectsIndexPath, 'utf8')
+  return JSON.parse(file)
+}
+
+async function writeProjectImage(project) {
+  let coverImage = null
+
+  try {
+    coverImage = await toDataUri(project.coverImage)
+  } catch (error) {
+    console.warn(`Skipping cover image for ${project.slug}: ${error.message}`)
+  }
+
+  const svg = renderSvg(project, coverImage)
+  const resvg = new Resvg(svg, {
+    fitTo: {
+      mode: 'width',
+      value: WIDTH,
+    },
+  })
+
+  const pngData = resvg.render().asPng()
+  const outputPath = path.join(outputDir, `${project.slug}.png`)
+  await fs.mkdir(path.dirname(outputPath), { recursive: true })
+  await fs.writeFile(outputPath, pngData)
+}
+
+async function main() {
+  const allProjects = await loadProjects()
+  await ensureOutputDir()
+
+  for (const project of allProjects) {
+    await writeProjectImage(project)
+  }
+
+  console.log(`Generated ${allProjects.length} project OG images.`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/generate-project-og.mjs
+++ b/scripts/generate-project-og.mjs
@@ -101,8 +101,8 @@ async function toDataUri(publicPath) {
 }
 
 function renderSvg(project, coverImage) {
-  const titleLines = wrapText(project.title, 20, 3)
-  const summaryLines = wrapText(project.summary, 42, 4)
+  const titleLines = wrapText(project.title, 18, 3)
+  const summaryLines = wrapText(project.summary, 34, 4)
   const kicker = escapeXml(project.nym)
   const projectUrl = escapeXml(`opensats.org/projects/${project.slug}`)
 
@@ -139,6 +139,12 @@ function renderSvg(project, coverImage) {
         <clipPath id="cover-clip">
           <rect x="764" y="112" width="352" height="352" rx="28" />
         </clipPath>
+        <clipPath id="title-clip">
+          <rect x="84" y="140" width="600" height="220" />
+        </clipPath>
+        <clipPath id="summary-clip">
+          <rect x="84" y="370" width="600" height="150" />
+        </clipPath>
       </defs>
 
       <rect width="1200" height="630" fill="url(#bg)" />
@@ -149,11 +155,11 @@ function renderSvg(project, coverImage) {
       <circle cx="110" cy="91" r="6" fill="url(#accent)" />
       <text x="128" y="98" fill="#e5e7eb" font-size="20" font-family="Arial, Helvetica, sans-serif">OpenSats funded</text>
 
-      <text x="84" y="192" fill="#fafaf9" font-size="60" font-weight="700" font-family="Arial, Helvetica, sans-serif">
+      <text x="84" y="192" fill="#fafaf9" font-size="60" font-weight="700" font-family="Arial, Helvetica, sans-serif" clip-path="url(#title-clip)">
         ${titleSvg}
       </text>
 
-      <text x="84" y="408" fill="#d4d4d8" font-size="30" font-family="Arial, Helvetica, sans-serif">
+      <text x="84" y="408" fill="#d4d4d8" font-size="30" font-family="Arial, Helvetica, sans-serif" clip-path="url(#summary-clip)">
         ${summarySvg}
       </text>
 

--- a/scripts/generate-project-og.mjs
+++ b/scripts/generate-project-og.mjs
@@ -102,7 +102,7 @@ async function toDataUri(publicPath) {
 
 function renderSvg(project, coverImage) {
   const titleLines = wrapText(project.title, 18, 3)
-  const summaryLines = wrapText(project.summary, 34, 4)
+  const summaryLines = wrapText(project.summary, 36, 3)
   const kicker = escapeXml(project.nym)
   const projectUrl = escapeXml(`opensats.org/projects/${project.slug}`)
 
@@ -143,7 +143,7 @@ function renderSvg(project, coverImage) {
           <rect x="84" y="140" width="600" height="220" />
         </clipPath>
         <clipPath id="summary-clip">
-          <rect x="84" y="348" width="600" height="150" />
+          <rect x="84" y="348" width="600" height="118" />
         </clipPath>
       </defs>
 

--- a/scripts/generate-project-og.mjs
+++ b/scripts/generate-project-og.mjs
@@ -114,6 +114,14 @@ function renderSvg(project, coverImage) {
   const summaryStartY = titleBottomY + 56
   const summaryClipY = summaryStartY - 30
   const summaryClipHeight = separatorY - summaryClipY - 24
+  const coverInsetBySlug = {
+    grapheneos: 8,
+    opencash: 12,
+  }
+  const coverInset = coverInsetBySlug[project.slug] ?? 0
+  const coverX = 790 + coverInset
+  const coverY = 138 + coverInset
+  const coverSize = 300 - coverInset * 2
 
   const titleSvg = titleLines
     .map(
@@ -130,8 +138,9 @@ function renderSvg(project, coverImage) {
     .join('')
 
   const coverSvg = coverImage
-    ? `<image href="${coverImage}" x="764" y="112" width="352" height="352" preserveAspectRatio="xMidYMid slice" clip-path="url(#cover-clip)" />`
-    : `<rect x="764" y="112" width="352" height="352" rx="28" fill="#18181b" />
+    ? `<rect x="${coverX}" y="${coverY}" width="${coverSize}" height="${coverSize}" rx="28" fill="#0b1220" />
+       <image href="${coverImage}" x="${coverX}" y="${coverY}" width="${coverSize}" height="${coverSize}" preserveAspectRatio="xMidYMid meet" clip-path="url(#cover-clip)" />`
+    : `<rect x="${coverX}" y="${coverY}" width="${coverSize}" height="${coverSize}" rx="28" fill="#18181b" />
        <text x="940" y="300" text-anchor="middle" fill="#a1a1aa" font-size="28" font-family="Arial, Helvetica, sans-serif">OpenSats funded</text>`
 
   return `
@@ -146,7 +155,7 @@ function renderSvg(project, coverImage) {
           <stop offset="1" stop-color="#fb923c" />
         </linearGradient>
         <clipPath id="cover-clip">
-          <rect x="764" y="112" width="352" height="352" rx="28" />
+          <rect x="${coverX}" y="${coverY}" width="${coverSize}" height="${coverSize}" rx="28" />
         </clipPath>
         <clipPath id="title-clip">
           <rect x="84" y="140" width="${titleClipWidth}" height="220" />

--- a/scripts/generate-project-og.mjs
+++ b/scripts/generate-project-og.mjs
@@ -123,7 +123,7 @@ function renderSvg(project, coverImage) {
   const coverSvg = coverImage
     ? `<image href="${coverImage}" x="764" y="112" width="352" height="352" preserveAspectRatio="xMidYMid slice" clip-path="url(#cover-clip)" />`
     : `<rect x="764" y="112" width="352" height="352" rx="28" fill="#18181b" />
-       <text x="940" y="300" text-anchor="middle" fill="#a1a1aa" font-size="28" font-family="Arial, Helvetica, sans-serif">OpenSats Project</text>`
+       <text x="940" y="300" text-anchor="middle" fill="#a1a1aa" font-size="28" font-family="Arial, Helvetica, sans-serif">OpenSats funded</text>`
 
   return `
     <svg width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -147,7 +147,7 @@ function renderSvg(project, coverImage) {
 
       <rect x="84" y="72" width="188" height="38" rx="19" fill="#1f2937" />
       <circle cx="110" cy="91" r="6" fill="url(#accent)" />
-      <text x="128" y="98" fill="#e5e7eb" font-size="20" font-family="Arial, Helvetica, sans-serif">OpenSats Project</text>
+      <text x="128" y="98" fill="#e5e7eb" font-size="20" font-family="Arial, Helvetica, sans-serif">OpenSats funded</text>
 
       <text x="84" y="192" fill="#fafaf9" font-size="60" font-weight="700" font-family="Arial, Helvetica, sans-serif">
         ${titleSvg}

--- a/scripts/generate-project-og.mjs
+++ b/scripts/generate-project-og.mjs
@@ -106,17 +106,19 @@ function renderSvg(project, coverImage) {
   const kicker = escapeXml(project.nym)
   const projectUrl = escapeXml(`opensats.org/projects/${project.slug}`)
   const titleStartY = 192
-  const titleLineHeight = 72
+  const titleFontSize = titleLines.length > 1 ? 52 : 56
+  const titleLineHeight = titleLines.length > 1 ? 60 : 66
+  const titleClipWidth = 624
   const separatorY = 498
   const titleBottomY = titleStartY + (titleLines.length - 1) * titleLineHeight
-  const summaryStartY = titleBottomY + 64
+  const summaryStartY = titleBottomY + 56
   const summaryClipY = summaryStartY - 30
   const summaryClipHeight = separatorY - summaryClipY - 24
 
   const titleSvg = titleLines
     .map(
       (line, index) =>
-        `<tspan x="84" dy="${index === 0 ? 0 : 72}">${escapeXml(line)}</tspan>`
+        `<tspan x="84" dy="${index === 0 ? 0 : titleLineHeight}">${escapeXml(line)}</tspan>`
     )
     .join('')
 
@@ -147,7 +149,7 @@ function renderSvg(project, coverImage) {
           <rect x="764" y="112" width="352" height="352" rx="28" />
         </clipPath>
         <clipPath id="title-clip">
-          <rect x="84" y="140" width="600" height="220" />
+          <rect x="84" y="140" width="${titleClipWidth}" height="220" />
         </clipPath>
         <clipPath id="summary-clip">
           <rect x="84" y="${summaryClipY}" width="600" height="${summaryClipHeight}" />
@@ -162,7 +164,7 @@ function renderSvg(project, coverImage) {
       <circle cx="110" cy="91" r="6" fill="#22c55e" />
       <text x="128" y="98" fill="#e5e7eb" font-size="20" font-family="Arial, Helvetica, sans-serif">OpenSats funded</text>
 
-      <text x="84" y="${titleStartY}" fill="#fafaf9" font-size="60" font-weight="700" font-family="Arial, Helvetica, sans-serif" clip-path="url(#title-clip)">
+      <text x="84" y="${titleStartY}" fill="#fafaf9" font-size="${titleFontSize}" font-weight="700" font-family="Arial, Helvetica, sans-serif" clip-path="url(#title-clip)">
         ${titleSvg}
       </text>
 

--- a/scripts/generate-project-og.mjs
+++ b/scripts/generate-project-og.mjs
@@ -151,7 +151,7 @@ function renderSvg(project, coverImage) {
       <circle cx="1110" cy="92" r="180" fill="#f97316" fill-opacity="0.08" />
       <circle cx="1035" cy="540" r="140" fill="#f97316" fill-opacity="0.06" />
 
-      <rect x="84" y="72" width="188" height="38" rx="19" fill="#1f2937" />
+      <rect x="84" y="72" width="236" height="38" rx="19" fill="#1f2937" />
       <circle cx="110" cy="91" r="6" fill="url(#accent)" />
       <text x="128" y="98" fill="#e5e7eb" font-size="20" font-family="Arial, Helvetica, sans-serif">OpenSats funded</text>
 

--- a/scripts/generate-project-og.mjs
+++ b/scripts/generate-project-og.mjs
@@ -159,7 +159,7 @@ function renderSvg(project, coverImage) {
       <circle cx="1035" cy="540" r="140" fill="#f97316" fill-opacity="0.06" />
 
       <rect x="84" y="72" width="236" height="38" rx="19" fill="#1f2937" />
-      <circle cx="110" cy="91" r="6" fill="url(#accent)" />
+      <circle cx="110" cy="91" r="6" fill="#22c55e" />
       <text x="128" y="98" fill="#e5e7eb" font-size="20" font-family="Arial, Helvetica, sans-serif">OpenSats funded</text>
 
       <text x="84" y="${titleStartY}" fill="#fafaf9" font-size="60" font-weight="700" font-family="Arial, Helvetica, sans-serif" clip-path="url(#title-clip)">

--- a/scripts/generate-project-og.mjs
+++ b/scripts/generate-project-og.mjs
@@ -115,8 +115,10 @@ function renderSvg(project, coverImage) {
   const summaryClipY = summaryStartY - 30
   const summaryClipHeight = separatorY - summaryClipY - 24
   const coverInsetBySlug = {
-    grapheneos: 8,
-    opencash: 12,
+    cdk: 14,
+    grapheneos: 20,
+    opencash: 20,
+    tor: 20,
   }
   const coverInset = coverInsetBySlug[project.slug] ?? 0
   const coverX = 790 + coverInset

--- a/scripts/generate-project-og.mjs
+++ b/scripts/generate-project-og.mjs
@@ -105,6 +105,13 @@ function renderSvg(project, coverImage) {
   const summaryLines = wrapText(project.summary, 36, 3)
   const kicker = escapeXml(project.nym)
   const projectUrl = escapeXml(`opensats.org/projects/${project.slug}`)
+  const titleStartY = 192
+  const titleLineHeight = 72
+  const separatorY = 498
+  const titleBottomY = titleStartY + (titleLines.length - 1) * titleLineHeight
+  const summaryStartY = titleBottomY + 64
+  const summaryClipY = summaryStartY - 30
+  const summaryClipHeight = separatorY - summaryClipY - 24
 
   const titleSvg = titleLines
     .map(
@@ -143,7 +150,7 @@ function renderSvg(project, coverImage) {
           <rect x="84" y="140" width="600" height="220" />
         </clipPath>
         <clipPath id="summary-clip">
-          <rect x="84" y="348" width="600" height="118" />
+          <rect x="84" y="${summaryClipY}" width="600" height="${summaryClipHeight}" />
         </clipPath>
       </defs>
 
@@ -155,15 +162,15 @@ function renderSvg(project, coverImage) {
       <circle cx="110" cy="91" r="6" fill="url(#accent)" />
       <text x="128" y="98" fill="#e5e7eb" font-size="20" font-family="Arial, Helvetica, sans-serif">OpenSats funded</text>
 
-      <text x="84" y="192" fill="#fafaf9" font-size="60" font-weight="700" font-family="Arial, Helvetica, sans-serif" clip-path="url(#title-clip)">
+      <text x="84" y="${titleStartY}" fill="#fafaf9" font-size="60" font-weight="700" font-family="Arial, Helvetica, sans-serif" clip-path="url(#title-clip)">
         ${titleSvg}
       </text>
 
-      <text x="84" y="386" fill="#d4d4d8" font-size="30" font-family="Arial, Helvetica, sans-serif" clip-path="url(#summary-clip)">
+      <text x="84" y="${summaryStartY}" fill="#d4d4d8" font-size="30" font-family="Arial, Helvetica, sans-serif" clip-path="url(#summary-clip)">
         ${summarySvg}
       </text>
 
-      <rect x="84" y="498" width="560" height="1" fill="#3f3f46" />
+      <rect x="84" y="${separatorY}" width="560" height="1" fill="#3f3f46" />
       <text x="84" y="536" fill="#a1a1aa" font-size="24" font-family="Arial, Helvetica, sans-serif">${kicker}</text>
       <text x="84" y="570" fill="#71717a" font-size="20" font-family="Arial, Helvetica, sans-serif">${projectUrl}</text>
 


### PR DESCRIPTION
Adds build-time generation for project-specific social preview images and wires project pages to use them for `og:image` and Twitter cards. This replaces the default site banner on `/projects/*` pages with per-project images generated from project metadata and artwork.

- adds a build script that renders one OG image per project into `public/static/images/projects/og`
- updates project SEO to point `/projects/*` pages at the generated images
- ignores generated image output in git

Closes OpenSats/content#26

Build preview:
- [/projects/splicing](https://os-website-git-feat-project-og-images-opensats.vercel.app/projects/splicing)

OpenGraph checks:
- [`amethyst`](https://www.opengraph.xyz/url/https%3A%2F%2Fos-website-git-feat-project-og-images-opensats.vercel.app%2Fprojects%2Famethyst)
- [`bdk`](https://www.opengraph.xyz/url/https%3A%2F%2Fos-website-git-feat-project-og-images-opensats.vercel.app%2Fprojects%2Fbdk)
- [`bitcoin-core`](https://www.opengraph.xyz/url/https%3A%2F%2Fos-website-git-feat-project-og-images-opensats.vercel.app%2Fprojects%2Fbitcoin-core)
- [`bitcoindesign`](https://www.opengraph.xyz/url/https%3A%2F%2Fos-website-git-feat-project-og-images-opensats.vercel.app%2Fprojects%2Fbitcoindesign)
- [`blixt`](https://www.opengraph.xyz/url/https%3A%2F%2Fos-website-git-feat-project-og-images-opensats.vercel.app%2Fprojects%2Fblixt)
- [`btcpayserver`](https://www.opengraph.xyz/url/https%3A%2F%2Fos-website-git-feat-project-og-images-opensats.vercel.app%2Fprojects%2Fbtcpayserver)
- [`cashu`](https://www.opengraph.xyz/url/https%3A%2F%2Fos-website-git-feat-project-og-images-opensats.vercel.app%2Fprojects%2Fcashu)
- [`cdk`](https://www.opengraph.xyz/url/https%3A%2F%2Fos-website-git-feat-project-og-images-opensats.vercel.app%2Fprojects%2Fcdk)
- [`coracle`](https://www.opengraph.xyz/url/https%3A%2F%2Fos-website-git-feat-project-og-images-opensats.vercel.app%2Fprojects%2Fcoracle)
- [`cove`](https://www.opengraph.xyz/url/https%3A%2F%2Fos-website-git-feat-project-og-images-opensats.vercel.app%2Fprojects%2Fcove)
- [`damus`](https://www.opengraph.xyz/url/https%3A%2F%2Fos-website-git-feat-project-og-images-opensats.vercel.app%2Fprojects%2Fdamus)
- [`grapheneos`](https://www.opengraph.xyz/url/https%3A%2F%2Fos-website-git-feat-project-og-images-opensats.vercel.app%2Fprojects%2Fgrapheneos)
- [`opencash`](https://www.opengraph.xyz/url/https%3A%2F%2Fos-website-git-feat-project-og-images-opensats.vercel.app%2Fprojects%2Fopencash)
- [`soapbox`](https://www.opengraph.xyz/url/https%3A%2F%2Fos-website-git-feat-project-og-images-opensats.vercel.app%2Fprojects%2Fsoapbox)
- [`splicing`](https://www.opengraph.xyz/url/https%3A%2F%2Fos-website-git-feat-project-og-images-opensats.vercel.app%2Fprojects%2Fsplicing)
- [`stratumv2`](https://www.opengraph.xyz/url/https%3A%2F%2Fos-website-git-feat-project-og-images-opensats.vercel.app%2Fprojects%2Fstratumv2)
- [`summerofbitcoin`](https://www.opengraph.xyz/url/https%3A%2F%2Fos-website-git-feat-project-og-images-opensats.vercel.app%2Fprojects%2Fsummerofbitcoin)
- [`tor`](https://www.opengraph.xyz/url/https%3A%2F%2Fos-website-git-feat-project-og-images-opensats.vercel.app%2Fprojects%2Ftor)
