### PR TITLE
Cashu project page: apply feedback from Calle & thesimplekid

### DIFF
--- a/data/projects/cashu.mdx
+++ b/data/projects/cashu.mdx
@@ -32,8 +32,7 @@ The protocol is defined by a set of specifications called
 Client libraries exist in
 [Python](https://github.com/cashubtc/nutshell),
 [TypeScript](https://github.com/cashubtc/cashu-ts),
-[Rust](https://github.com/cashubtc/cdk),
-[Go](https://github.com/elnosh/gonuts), and
+[Rust](https://github.com/cashubtc/cdk), and
 [Kotlin](https://github.com/cashubtc/cdk-kotlin). The reference mint
 implementation is [Nutshell](https://github.com/cashubtc/nutshell), and
 [Cashu.me](https://cashu.me/) is the main web wallet. Other wallets include

--- a/data/projects/cashu.mdx
+++ b/data/projects/cashu.mdx
@@ -2,7 +2,7 @@
 title: 'Cashu'
 dateAdded: '2023-04-20'
 summary: 'A Chaumian ecash protocol built for Bitcoin that brings near-perfect privacy to custodial payments.'
-nym: 'Calle'
+nym: 'Cashu Contributors'
 website: 'https://cashu.space/'
 donationLink: 'https://docs.cashu.space/contribute'
 coverImage: '/static/images/projects/cashu.jpeg'
@@ -46,9 +46,9 @@ cached responses ([NUT-19](https://github.com/cashubtc/nuts/blob/main/19.md)),
 shared custody via `SIG_ALL`
 ([NUT-11](https://github.com/cashubtc/nuts/blob/main/11.md)), and payment
 requests ([NUT-18](https://github.com/cashubtc/nuts/blob/main/18.md)) that work
-over HTTP and nostr. Calle also built a mint auditor for verifying reserves and the
-[Cashu Decoder](https://github.com/callebtc/cashu-decoder) for inspecting
-tokens.
+over HTTP and nostr. Other tools include a mint auditor for verifying reserves
+and the [Cashu Decoder](https://github.com/callebtc/cashu-decoder) for
+inspecting tokens.
 
 ## Why fund it?
 
@@ -63,9 +63,8 @@ reference mint, the web wallet, and ecosystem coordination all depend on grants.
 
 OpenSats has been supporting Cashu since the
 [first wave of Bitcoin grants](/blog/bitcoin-grants-july-2023#cashu) in July
-2023. Calle received a
-[long-term support grant](/blog/cashu-calle-receives-lts-grant) in June 2024.
-Separate grants went to
+2023. A [long-term support grant](/blog/cashu-calle-receives-lts-grant) followed
+in June 2024. Separate grants went to
 [Nutshell](/blog/8th-wave-of-bitcoin-grants#cashu-nutshell) (8th wave),
 [Nutstash](/blog/ninth-wave-of-bitcoin-grants#nutstash) (9th wave), and
 [OpenCash](/projects/opencash) for broader ecosystem coordination.
@@ -77,10 +76,6 @@ expanded test coverage. Keyset V2 derivation is rolling out across
 implementations. Bolt12 support for [Cashu.me](https://cashu.me/) is close to
 done, and security audits across the Cashu ecosystem are a priority for the
 coming months.
-
-Calle is also working on the Android version of [Bitchat](https://github.com/permissionlesstech/bitchat-android),
-a mesh networking project that lets mobile devices communicate over Bluetooth
-and Wi-Fi without internet access.
 
 For a detailed look at recent progress, see the
 [Advancements in Ecash](/blog/advancements-in-ecash#cashu) impact report.


### PR DESCRIPTION
This updates the `Cashu` project page based on feedback from Calle and thesimplekid.

- removes the stale `elnosh/gonuts` client reference
- rewrites the page around `Cashu` and `Cashu Contributors` instead of a single person
- build preview: https://vercel.com/opensats/os-website/DFuzp6bkxxfM1zt2aKJ8u4aRSKGJ
