### PR TITLE
Improve grant application flow and reference guidance

### DIFF
--- a/components/ClosedNotice.tsx
+++ b/components/ClosedNotice.tsx
@@ -1,0 +1,44 @@
+import Link from './Link'
+
+const ClosedNotice = () => {
+  return (
+    <div
+      className="rounded-b border-t-4 border-orange-500 bg-yellow-100 px-4 py-3 text-yellow-900 shadow-md"
+      role="alert"
+    >
+      <div className="flex">
+        <div className="py-1">
+          <svg
+            className="mr-4 h-6 w-6 fill-current text-orange-500"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+          >
+            <path d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zm12.73-1.41A8 8 0 1 0 4.34 4.34a8 8 0 0 0 11.32 11.32zM9 11V9h2v6H9v-4zm0-6h2v2H9V5z" />
+          </svg>
+        </div>
+        <div>
+          <p className="font-bold">Applications are currently closed!</p>
+          <p className="text-sm">
+            Grant applications are currently closed as per our{' '}
+            <Link href="/faq#when-is-the-best-time-to-apply">
+              quarterly schedule
+            </Link>
+            . Please have a look at{' '}
+            <Link href="/blog/2025-year-in-review">last year's report</Link> to
+            see what kind of projects we support.
+          </p>
+          <p className="text-sm">
+            If you want to prepare a submission, please get familiar with our{' '}
+            <Link href="/apply#criteria">application criteria</Link> as well as
+            our <Link href="/selection">grant selection process</Link>.
+          </p>
+          <p className="text-sm">
+            We will re-open applications on the 1st week of next month.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ClosedNotice

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -2,8 +2,10 @@ import { useRef, useState } from 'react'
 import { useRouter } from 'next/router'
 import { useForm } from 'react-hook-form'
 import { fetchPostJSON } from '../utils/api-helpers'
+import { GENERAL_GRANT_OPEN } from '../config'
 import StepIndicator from './grant-application/StepIndicator'
 import StepNavigation from './grant-application/StepNavigation'
+import ClosedNotice from './ClosedNotice'
 import Prerequisites from './grant-application/steps/Prerequisites'
 import ApplicantDetails from './grant-application/steps/ApplicantDetails'
 import ProjectDetails from './grant-application/steps/ProjectDetails'
@@ -12,6 +14,7 @@ import Timeline from './grant-application/steps/Timeline'
 import Budget from './grant-application/steps/Budget'
 import ReferencesReview from './grant-application/steps/ReferencesReview'
 import AnythingElse from './grant-application/steps/AnythingElse'
+import Review from './grant-application/steps/Review'
 import { FormValues } from './grant-application/types'
 
 const STEPS = [
@@ -66,6 +69,11 @@ const STEPS = [
     title: 'Final',
     fields: ['no_vibed_garbage', 'human_in_charge', 'discipline_and_agency'],
   },
+  {
+    id: 'review',
+    title: 'Review',
+    fields: [],
+  },
 ] as const
 
 export default function ApplicationForm() {
@@ -102,11 +110,14 @@ export default function ApplicationForm() {
   }
 
   const handleBack = () => {
+    if (loading) return
+    setFailureReason(undefined)
     setCurrentStep((s) => s - 1)
     scrollToTop()
   }
 
   const handleStepClick = (step: number) => {
+    if (loading) return
     if (step < currentStep) {
       setCurrentStep(step)
       scrollToTop()
@@ -115,6 +126,7 @@ export default function ApplicationForm() {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const onSubmit = async (data: any) => {
+    if (currentStep !== STEPS.length - 1) return
     setLoading(true)
     const submissionData = { ...data, formLoadedAt }
 
@@ -152,7 +164,7 @@ export default function ApplicationForm() {
   return (
     <form
       ref={formRef}
-      onSubmit={handleSubmit(onSubmit)}
+      onSubmit={(e) => e.preventDefault()}
       className="apply flex max-w-2xl flex-col gap-4"
     >
       <input type="hidden" {...register('general_fund', { value: true })} />
@@ -173,16 +185,21 @@ export default function ApplicationForm() {
       {currentStep === 5 && <Timeline {...stepProps} />}
       {currentStep === 6 && <Budget {...stepProps} />}
       {currentStep === 7 && <AnythingElse {...stepProps} />}
+      {currentStep === 8 && <Review watch={watch} />}
+
+      {!GENERAL_GRANT_OPEN && currentStep === 0 && <ClosedNotice />}
 
       <StepNavigation
         currentStep={currentStep}
         totalSteps={STEPS.length}
         onBack={handleBack}
         onNext={handleNext}
+        onSubmit={handleSubmit(onSubmit)}
         loading={loading}
+        disabled={!GENERAL_GRANT_OPEN}
       />
 
-      {!!failureReason && (
+      {!!failureReason && currentStep === STEPS.length - 1 && (
         <p className="rounded bg-red-500 p-4 text-white">
           Something went wrong! {failureReason}
         </p>

--- a/components/LTSApplicationForm.tsx
+++ b/components/LTSApplicationForm.tsx
@@ -3,8 +3,10 @@ import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { fetchPostJSON } from '../utils/api-helpers'
 import FormButton from '@/components/FormButton'
+import ClosedNotice from './ClosedNotice'
 import * as EmailValidator from 'email-validator'
 import CustomLink from './Link'
+import { LTS_GRANT_OPEN } from '../config'
 
 export default function ApplicationForm() {
   const [loading, setLoading] = useState(false)
@@ -70,6 +72,8 @@ export default function ApplicationForm() {
         {...register('timelines', { value: 'Ongoing work (LTS Grant).' })}
       />
       <input type="hidden" {...register('LTS', { value: true })} />
+
+      {!LTS_GRANT_OPEN && <ClosedNotice />}
 
       <hr />
       <h2>Who Are You?</h2>
@@ -273,9 +277,9 @@ export default function ApplicationForm() {
       </div>
 
       <FormButton
-        variant={isFLOSS ? 'enabled' : 'disabled'}
+        variant={isFLOSS && LTS_GRANT_OPEN ? 'enabled' : 'disabled'}
         type="submit"
-        disabled={loading}
+        disabled={loading || !LTS_GRANT_OPEN}
       >
         Submit LTS Application
       </FormButton>

--- a/components/grant-application/StepNavigation.tsx
+++ b/components/grant-application/StepNavigation.tsx
@@ -3,7 +3,9 @@ interface StepNavigationProps {
   totalSteps: number
   onBack: () => void
   onNext: () => void
+  onSubmit: () => void
   loading: boolean
+  disabled?: boolean
 }
 
 export default function StepNavigation({
@@ -11,7 +13,9 @@ export default function StepNavigation({
   totalSteps,
   onBack,
   onNext,
+  onSubmit,
   loading,
+  disabled,
 }: StepNavigationProps) {
   const isLast = currentStep === totalSteps - 1
 
@@ -21,7 +25,12 @@ export default function StepNavigation({
         <button
           type="button"
           onClick={onBack}
-          className="rounded-md border border-gray-300 bg-white px-5 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+          disabled={loading}
+          className={`rounded-md border border-gray-300 bg-white px-5 py-2 text-sm font-medium text-gray-700 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 ${
+            loading
+              ? 'cursor-not-allowed opacity-50'
+              : 'hover:bg-gray-50 dark:hover:bg-gray-700'
+          }`}
         >
           Back
         </button>
@@ -31,21 +40,25 @@ export default function StepNavigation({
 
       {isLast ? (
         <button
-          type="submit"
-          disabled={loading}
+          type="button"
+          onClick={onSubmit}
+          disabled={loading || disabled}
           className={`rounded-md bg-orange-500 px-6 py-2 text-sm font-semibold text-white hover:bg-orange-600 ${
-            loading ? 'cursor-not-allowed opacity-50' : ''
+            loading || disabled ? 'cursor-not-allowed opacity-50' : ''
           }`}
         >
-          Submit Grant Application
+          {loading ? 'Submitting...' : 'Submit Grant Application'}
         </button>
       ) : (
         <button
           type="button"
           onClick={onNext}
-          className="rounded-md bg-orange-500 px-6 py-2 text-sm font-semibold text-white hover:bg-orange-600"
+          disabled={disabled}
+          className={`rounded-md bg-orange-500 px-6 py-2 text-sm font-semibold text-white hover:bg-orange-600 ${
+            disabled ? 'cursor-not-allowed opacity-50' : ''
+          }`}
         >
-          Continue
+          {currentStep === totalSteps - 2 ? 'Review Application' : 'Continue'}
         </button>
       )}
     </div>

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -54,17 +54,17 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
           {...register('has_references', { required: true })}
         />
         <span>
-          I have two or more{' '}
+          I understand that at least two{' '}
           <CustomLink href="/faq/application#what-are-you-looking-for-in-terms-of-references">
             written reference letters
           </CustomLink>{' '}
-          from people familiar with my work
+          from people familiar with my work are required
         </span>
       </label>
       <FieldError
         errors={errors}
         name="has_references"
-        message="Please prepare your reference letters before continuing. Reference letters can be included as part of your application or emailed to support@opensats.org once your application is submitted. The evaluation of your application will not start until we have two references."
+        message="Please prepare your reference letters before continuing. Reference letters can be included as part of your application or emailed to references@opensats.org once your application is submitted. The evaluation of your application will not start until we have two references."
       />
 
       <label className="inline-flex items-start gap-2">

--- a/components/grant-application/steps/ReferencesReview.tsx
+++ b/components/grant-application/steps/ReferencesReview.tsx
@@ -8,7 +8,7 @@ export default function ReferencesReview({
 }: StepProps) {
   const applicantName = watch?.('your_name') || '[Applicant Name]'
   const projectName = watch?.('project_name') || '[Project Name]'
-  const suggestedSubject = `Reference Letter for ${projectName} by ${applicantName}`
+  const suggestedSubject = `Reference Letter for ${projectName} for ${applicantName}`
 
   return (
     <>

--- a/components/grant-application/steps/Review.tsx
+++ b/components/grant-application/steps/Review.tsx
@@ -1,0 +1,174 @@
+import { UseFormWatch } from 'react-hook-form'
+import { FormValues } from '../types'
+
+interface ReviewProps {
+  watch: UseFormWatch<FormValues>
+}
+
+function ReviewField({
+  label,
+  value,
+}: {
+  label: string
+  value: string | undefined
+}) {
+  if (!value) return null
+  return (
+    <div>
+      <dt className="font-medium text-gray-900 dark:text-white">{label}</dt>
+      <dd className="mt-1 whitespace-pre-wrap">{value}</dd>
+    </div>
+  )
+}
+
+function ReviewSection({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <section>
+      <h3 className="mb-3 text-lg font-semibold">{title}</h3>
+      <dl className="space-y-3">{children}</dl>
+    </section>
+  )
+}
+
+export default function Review({ watch }: ReviewProps) {
+  const values = watch()
+
+  return (
+    <>
+      <div className="rounded-b border-t-4 border-orange-500 bg-yellow-100 px-4 py-3 text-yellow-900 shadow-md">
+        <p className="text-sm font-medium">
+          Please review your application carefully before submitting.
+        </p>
+      </div>
+
+      <div className="space-y-6">
+        <ReviewSection title="Applicant">
+          <ReviewField label="Name" value={values.your_name as string} />
+          <ReviewField label="Email" value={values.email as string} />
+          <ReviewField
+            label="Personal GitHub"
+            value={values.personal_github as string}
+          />
+          <ReviewField
+            label="Other Contact Details"
+            value={values.other_contact as string}
+          />
+          <ReviewField
+            label="Lead Developer"
+            value={
+              values.are_you_lead
+                ? 'I am the lead developer or maintainer'
+                : (values.other_lead as string) || undefined
+            }
+          />
+        </ReviewSection>
+
+        <hr />
+
+        <ReviewSection title="Project">
+          <ReviewField label="Main Focus" value={values.main_focus as string} />
+          <ReviewField
+            label="Project Name"
+            value={values.project_name as string}
+          />
+          <ReviewField
+            label="Project Description"
+            value={values.short_description as string}
+          />
+          <ReviewField
+            label="Potential Impact"
+            value={values.potential_impact as string}
+          />
+        </ReviewSection>
+
+        <hr />
+
+        <ReviewSection title="Written References">
+          <ReviewField label="References" value={values.references as string} />
+          <ReviewField
+            label="Prior Contributions"
+            value={values.bios as string}
+          />
+          <ReviewField
+            label="Years of Developer Experience"
+            value={values.years_experience as string}
+          />
+        </ReviewSection>
+
+        <hr />
+
+        <ReviewSection title="Source Code">
+          <ReviewField label="Repository" value={values.github as string} />
+          <ReviewField label="License" value={values.license as string} />
+          <ReviewField
+            label="Project Website"
+            value={values.website as string}
+          />
+          <ReviewField
+            label="Screenshots / Videos"
+            value={values.screenshots_videos as string}
+          />
+        </ReviewSection>
+
+        <hr />
+
+        <ReviewSection title="Timeline">
+          <ReviewField label="Duration" value={values.duration as string} />
+          <ReviewField
+            label="Time Commitment"
+            value={values.commitment as string}
+          />
+          <ReviewField label="Milestones" value={values.timelines as string} />
+        </ReviewSection>
+
+        <hr />
+
+        <ReviewSection title="Budget">
+          <ReviewField
+            label="Costs & Proposed Budget"
+            value={values.proposed_budget as string}
+          />
+          <ReviewField
+            label="Prior Funding"
+            value={
+              values.has_received_funding === 'yes'
+                ? (values.what_funding as string)
+                : values.has_received_funding === 'no'
+                ? 'No'
+                : undefined
+            }
+          />
+          <ReviewField
+            label="Additional Funding Sources"
+            value={
+              values.has_additional_funding === 'yes'
+                ? (values.additional_funding as string)
+                : values.has_additional_funding === 'no'
+                ? 'No'
+                : undefined
+            }
+          />
+        </ReviewSection>
+
+        <hr />
+
+        <ReviewSection title="Anything Else">
+          <ReviewField
+            label="Video Application"
+            value={values.video_application as string}
+          />
+          <ReviewField
+            label="Anything Else"
+            value={values.anything_else as string}
+          />
+        </ReviewSection>
+      </div>
+    </>
+  )
+}

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,3 +1,7 @@
+// Grant application availability — flip these when opening/closing each quarter
+export const GENERAL_GRANT_OPEN = true
+export const LTS_GRANT_OPEN = true
+
 export const CURRENCY = 'usd'
 // Set your amount limits: Use float for decimal currencies and
 // Integer for zero-decimal currencies: https://stripe.com/docs/currencies#zero-decimal.

--- a/data/pages/faq-application.mdx
+++ b/data/pages/faq-application.mdx
@@ -150,8 +150,15 @@ A strong reference will address things like:
 
 References from well-known contributors to other open-source projects
 carry extra weight, but what matters most is that the person can speak credibly
-about your work and that we can reach out to them. The evaluation of your
-application will not start until we have two written references.
+about your work and that we can reach out to them. Please include the email address of each
+reference so we can reach out to verify. Cryptographically signed references
+(e.g. using PGP or Nostr) are a plus.
+
+References can be included as part of your application or emailed directly to
+[references@opensats.org](mailto:references@opensats.org) using the subject
+line "Reference Letter for [Project Name] for [Applicant Name]". The
+evaluation of your application will not start until we have two written
+references.
 
 ### If my application is rejected, can I reapply?
 

--- a/public/static/opensats-grant-application-template.md
+++ b/public/static/opensats-grant-application-template.md
@@ -30,7 +30,12 @@ Please provide at least 2 written reference letters from people in the Bitcoin
 community or open-source space who are familiar with you or your project.
 Include the email address of each reference so we can reach out to verify.
 Cryptographically signed references, e.g. using PGP or Nostr, are a plus.
-References can also be sent directly to references@opensats.org.
+References can be included as part of your application or can also be sent
+directly to references@opensats.org using the subject line "Reference Letter
+for [Project Name] for [Applicant Name]".
+
+The evaluation of your application will not start until we have two written
+references.
 
 ### Prior Contributions
 


### PR DESCRIPTION
### Why

While applying for a grant this year, I ran into a few rough edges in the new application flow and offered to open a PR to address them.

The main issues I noticed were:

* when applications were closed, I could not see the general grant process early and prepare ahead of time
* the FAQ and offline template were missing some useful reference-letter guidance that appeared in the form
* the “Before You Begin” wording made it sound like references needed to be submitted before the application itself
* the suggested reference email subject line felt awkward
* there was no final review step before submission
* while I was reviewing my application, I hit confusing submit behavior on the last step and the application appeared to submit unexpectedly without me having pressed submit

This PR is intended to make that flow clearer and safer without changing how the application data is submitted.

### What changed

* Added `GENERAL_GRANT_OPEN` and `LTS_GRANT_OPEN` flags in `config/index.ts` so grant application open/closed status can be managed in one place.
* Updated `/apply` so it always links to `/apply/grant` and `/apply/lts`, instead of being the place where applications are closed. 
* When the general grant is closed, `/apply/grant` still shows the process and preparation resources, along with the existing closed notice, while preventing applicants from continuing.
* When LTS is closed, `/apply/lts` shows the existing closed notice and prevents submission.
* Updated the prerequisites references wording so it no longer implies references must already have been submitted before applying.
* Made the reference submission guidance more consistent, using references@opensats.org
* Brought the form, FAQ, and offline template into better alignment on:
  * sending written references directly by email
  * including reference email addresses for verification
  * cryptographically signed references being a plus
  * suggested subject line guidance
* Added a final review step to the general grant flow so applicants can preview their answers before submitting.
* Moved final submission to an explicit action on the review step only.
* Updated submission UX so the button shows `Submitting...`, prevents duplicate clicks, and prevents navigation away during submission.
* Reworked the submit flow so the application is only submitted when the user explicitly clicks Submit on the review step, avoiding the accidental submission behavior I ran into while reviewing my own application.

### Files changed

* `config/index.ts`
* `components/ClosedNotice.tsx`
* `components/GrantApplicationForm.tsx`
* `components/LTSApplicationForm.tsx`
* `components/grant-application/StepNavigation.tsx`
* `components/grant-application/steps/Review.tsx`
* `components/grant-application/steps/Prerequisites.tsx`
* `components/grant-application/steps/ReferencesReview.tsx`
* `data/pages/faq-application.mdx`
* `public/static/opensats-grant-application-template.md`