### PR TITLE
fix(funds): make in-content fund donate button a monthly CTA

### DIFF
--- a/data/funds/general.mdx
+++ b/data/funds/general.mdx
@@ -21,7 +21,7 @@ Bitcoin-related free and open source projects and contributors. The fund is made
 up of donations from individuals and organizations.
 
 <center>
-  <DonateToGeneralFundButton />
+  <DonateRecurringButton label="Give Monthly to the General Fund" />
 </center>
 
 Projects that are eligible for funding from the General Fund must meet the

--- a/data/funds/nostr.mdx
+++ b/data/funds/nostr.mdx
@@ -20,7 +20,7 @@ improvement of the Nostr protocol and related software. The fund is made up of
 donations from individuals and organizations.
 
 <center>
-  <DonateToNostrFundButton />
+  <DonateRecurringButton designation="nostr" label="Give Monthly to The Nostr Fund" />
 </center>
 
 The fund is used to support projects that make Nostr more accessible, secure,

--- a/data/funds/ops.mdx
+++ b/data/funds/ops.mdx
@@ -33,5 +33,5 @@ page or head over to the [About Us](/about) page to learn more about the
 organization and our efforts.
 
 <center>
-  <DonateToOperationsButton />
+  <DonateRecurringButton designation="ops" label="Give Monthly to Operations" />
 </center>


### PR DESCRIPTION
Addresses #640 by repurposing the duplicated in-content donate button on each fund page as a "Give Monthly" CTA that preselects the correct fund, while the aside keeps its one-time "Donate Now!" button.

- `data/funds/nostr.mdx`: use `<DonateRecurringButton designation="nostr" />`
- `data/funds/ops.mdx`: use `<DonateRecurringButton designation="ops" />`
- `data/funds/general.mdx`: use `<DonateRecurringButton />` (default General Fund page)
