### PR TITLE
Add UTXO topic page

### DIFF
--- a/data/topics/utxo.mdx
+++ b/data/topics/utxo.mdx
@@ -14,5 +14,5 @@ The UTXO set grows with adoption. Keeping it on disk and keeping lookups fast ar
 ## References
 
 - [bitcoin.org glossary: unspent transaction output](https://bitcoin.org/en/glossary/unspent-transaction-output)
-- [Mastering Bitcoin: transactions](https://github.com/bitcoinbook/bitcoinbook/blob/develop/ch06.asciidoc)
+- [Mastering Bitcoin: transactions](https://github.com/bitcoinbook/bitcoinbook/blob/develop/ch06_transactions.adoc)
 - [en.bitcoin.it: UTXO](https://en.bitcoin.it/wiki/UTXO)

--- a/data/topics/utxo.mdx
+++ b/data/topics/utxo.mdx
@@ -1,0 +1,18 @@
+---
+title: 'UTXO'
+summary: "Bitcoin's accounting model: a wallet's balance is the sum of every output addressed to it that has not yet been spent."
+category: 'Bitcoin'
+aliases: ['Unspent Transaction Output', 'UTXOs', 'UTXO set', 'UTXO model']
+---
+
+UTXO stands for Unspent Transaction Output. It is Bitcoin's accounting model. A wallet's balance is not a single number stored in a ledger. It is the sum of every output addressed to that wallet that has not yet been used as input to a later transaction.
+
+Every Bitcoin transaction consumes one or more UTXOs and creates one or more new outputs. The old ones are destroyed in the process. Full nodes track the entire set of currently unspent outputs, called the UTXO set, and check each new transaction against it. This model makes parallel validation straightforward, since two transactions that spend different UTXOs do not depend on each other.
+
+The UTXO set grows with adoption. Keeping it on disk and keeping lookups fast are ongoing concerns for full-node software. Features like [AssumeUTXO](/topics/assumeutxo) and pruning exist to manage how nodes load, store, and verify the set.
+
+## References
+
+- [bitcoin.org glossary: unspent transaction output](https://bitcoin.org/en/glossary/unspent-transaction-output)
+- [Mastering Bitcoin: transactions](https://github.com/bitcoinbook/bitcoinbook/blob/develop/ch06.asciidoc)
+- [en.bitcoin.it: UTXO](https://en.bitcoin.it/wiki/UTXO)

--- a/data/topics/utxo.mdx
+++ b/data/topics/utxo.mdx
@@ -5,9 +5,9 @@ category: 'Bitcoin'
 aliases: ['Unspent Transaction Output', 'UTXOs', 'UTXO set', 'UTXO model']
 ---
 
-UTXO stands for Unspent Transaction Output. It is Bitcoin's accounting model. A wallet's balance is not a single number stored in a ledger. It is the sum of every output addressed to that wallet that has not yet been used as input to a later transaction.
+UTXO stands for Unspent Transaction Output. It is Bitcoin's accounting model. A wallet's balance is the sum of every output addressed to that wallet that has not yet been used as input to a later transaction. There is no account with a running balance stored anywhere.
 
-Every Bitcoin transaction consumes one or more UTXOs and creates one or more new outputs. The old ones are destroyed in the process. Full nodes track the entire set of currently unspent outputs, called the UTXO set, and check each new transaction against it. This model makes parallel validation straightforward, since two transactions that spend different UTXOs do not depend on each other.
+Every Bitcoin transaction consumes one or more UTXOs and creates one or more new outputs. The old ones are destroyed in the process. Full nodes track the entire set of currently unspent outputs, called the UTXO set, and check each new transaction against it. This model makes parallel validation straightforward, since two transactions that spend different UTXOs do not depend on each other. Protocols like [Silent Payments](/topics/silent-payments) and tools like [PSBTs](/topics/psbt) are built on top of this same model.
 
 The UTXO set grows with adoption. Keeping it on disk and keeping lookups fast are ongoing concerns for full-node software. Features like [AssumeUTXO](/topics/assumeutxo) and pruning exist to manage how nodes load, store, and verify the set.
 

--- a/data/topics/utxo.mdx
+++ b/data/topics/utxo.mdx
@@ -13,6 +13,6 @@ The UTXO set grows with adoption. Keeping it on disk and keeping lookups fast ar
 
 ## References
 
-- [bitcoin.org glossary: unspent transaction output](https://bitcoin.org/en/glossary/unspent-transaction-output)
+- [Learn Me A Bitcoin: UTXO](https://learnmeabitcoin.com/technical/transaction/utxo/)
 - [Mastering Bitcoin: transactions](https://github.com/bitcoinbook/bitcoinbook/blob/develop/ch06_transactions.adoc)
 - [en.bitcoin.it: UTXO](https://en.bitcoin.it/wiki/UTXO)


### PR DESCRIPTION
Adds a UTXO topic page to the topics section. The page explains Bitcoin's UTXO accounting model, how transactions consume and create outputs, and how full nodes manage the UTXO set.

- Adds `data/topics/utxo.mdx` covering the UTXO model, parallel validation, and scaling concerns like AssumeUTXO and pruning
- Cross-links to the silent-payments, psbt, and assumeutxo topics
- References the bitcoin.org glossary, Mastering Bitcoin, and en.bitcoin.it

Closes https://github.com/OpenSats/content/issues/47

---

Build preview:
- [/topics/utxo](https://os-website-git-content-add-topic-utxo-opensats.vercel.app/topics/utxo)