### PR TITLE
Add BIP 353 topic page

### DIFF
--- a/data/topics/bip-353.mdx
+++ b/data/topics/bip-353.mdx
@@ -1,0 +1,18 @@
+---
+title: 'BIP 353'
+summary: 'Human-readable Bitcoin payment instructions published as DNSSEC-signed TXT records, so a wallet can resolve `name@domain` to an on-chain address or BOLT 12 offer.'
+category: 'Bitcoin'
+aliases: ['DNS payment instructions', 'human-readable Bitcoin payments', 'bitcoin@domain']
+---
+
+BIP 353 defines human-readable Bitcoin payment instructions that live in DNS. A recipient publishes a DNS TXT record at `name.user._bitcoin-payment.example.com` that contains a BIP 21 URI: an on-chain address, a BOLT 12 offer, a Lightning address, or any combination of those. A sender types `₿name@example.com`, the wallet fetches the TXT record over DNSSEC, and reads off the payment methods the recipient supports.
+
+DNSSEC matters because the sender does not want to trust the recipient's resolver. Every response is signed by the domain's DNSSEC key, so a middleman on an untrusted network cannot rewrite the payment address. Wallets that plan to support BIP 353 include LDK Node and Blink, along with research implementations driven by Matt Corallo.
+
+The goal is a single identifier that looks like email and works across payment rails. The recipient can change or add payment methods without each sender's wallet hard-coding which one to use.
+
+## References
+
+- [BIP 353](https://github.com/bitcoin/bips/blob/master/bip-0353.md)
+- [BIP 21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki)
+- [bitcoinpaymentinstructions.org](https://bitcoinpaymentinstructions.org/)

--- a/data/topics/bip-353.mdx
+++ b/data/topics/bip-353.mdx
@@ -7,6 +7,8 @@ aliases: ['DNS payment instructions', 'human-readable Bitcoin payments', 'bitcoi
 
 BIP 353 defines human-readable Bitcoin payment instructions that live in DNS. A recipient publishes a DNS TXT record at `name.user._bitcoin-payment.example.com` that contains a BIP 21 URI: an on-chain address, a [BOLT 12](/topics/bolt12) offer, a Lightning address, or any combination of those. A sender types `₿name@example.com`, the wallet fetches the TXT record over DNSSEC, and reads off the payment methods the recipient supports.
 
+BIP 21 has since been superseded by [BIP 321](https://github.com/bitcoin/bips/blob/master/bip-0321.mediawiki), which generalizes the URI format to support multiple payment methods in a single URI. BIP 353 still references BIP 21 directly, so wallets implementing BIP 353 today read the TXT record as a BIP 21 URI in practice.
+
 DNSSEC matters because the sender does not want to trust the recipient's resolver. Every response is signed by the domain's DNSSEC key, so a middleman on an untrusted network cannot rewrite the payment address. Wallets that have announced support include [LDK](/topics/ldk) Node and Blink, along with research implementations driven by Matt Corallo.
 
 The goal is a single identifier that looks like email and works across payment rails. The recipient can change or add payment methods without each sender's wallet hard-coding which one to use.
@@ -14,5 +16,6 @@ The goal is a single identifier that looks like email and works across payment r
 ## References
 
 - [BIP 353](https://github.com/bitcoin/bips/blob/master/bip-0353.mediawiki)
+- [BIP 321](https://github.com/bitcoin/bips/blob/master/bip-0321.mediawiki)
 - [BIP 21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki)
 - [bips.dev: BIP 353 rendered](https://bips.dev/353)

--- a/data/topics/bip-353.mdx
+++ b/data/topics/bip-353.mdx
@@ -5,14 +5,14 @@ category: 'Bitcoin'
 aliases: ['DNS payment instructions', 'human-readable Bitcoin payments', 'bitcoin@domain']
 ---
 
-BIP 353 defines human-readable Bitcoin payment instructions that live in DNS. A recipient publishes a DNS TXT record at `name.user._bitcoin-payment.example.com` that contains a BIP 21 URI: an on-chain address, a BOLT 12 offer, a Lightning address, or any combination of those. A sender types `₿name@example.com`, the wallet fetches the TXT record over DNSSEC, and reads off the payment methods the recipient supports.
+BIP 353 defines human-readable Bitcoin payment instructions that live in DNS. A recipient publishes a DNS TXT record at `name.user._bitcoin-payment.example.com` that contains a BIP 21 URI: an on-chain address, a [BOLT 12](/topics/bolt12) offer, a Lightning address, or any combination of those. A sender types `₿name@example.com`, the wallet fetches the TXT record over DNSSEC, and reads off the payment methods the recipient supports.
 
-DNSSEC matters because the sender does not want to trust the recipient's resolver. Every response is signed by the domain's DNSSEC key, so a middleman on an untrusted network cannot rewrite the payment address. Wallets that plan to support BIP 353 include LDK Node and Blink, along with research implementations driven by Matt Corallo.
+DNSSEC matters because the sender does not want to trust the recipient's resolver. Every response is signed by the domain's DNSSEC key, so a middleman on an untrusted network cannot rewrite the payment address. Wallets that have announced support include [LDK](/topics/ldk) Node and Blink, along with research implementations driven by Matt Corallo.
 
 The goal is a single identifier that looks like email and works across payment rails. The recipient can change or add payment methods without each sender's wallet hard-coding which one to use.
 
 ## References
 
-- [BIP 353](https://github.com/bitcoin/bips/blob/master/bip-0353.md)
+- [BIP 353](https://github.com/bitcoin/bips/blob/master/bip-0353.mediawiki)
 - [BIP 21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki)
-- [bitcoinpaymentinstructions.org](https://bitcoinpaymentinstructions.org/)
+- [bips.dev: BIP 353 rendered](https://bips.dev/353)


### PR DESCRIPTION
Adds a BIP 353 topic page to the topics section. The page describes human-readable Bitcoin payment instructions served from DNSSEC-signed TXT records, resolving `₿name@example.com` to an on-chain address, a BOLT 12 offer, or a Lightning address.

- Adds `data/topics/bip-353.mdx` covering the TXT record format, the role of DNSSEC, and early wallet support
- Cross-links to the bolt12 and ldk topics
- References BIP 353, BIP 21, and bips.dev

Closes https://github.com/OpenSats/content/issues/50

---

Build preview:
- [/topics/bip-353](https://os-website-git-content-add-topic-bip-353-opensats.vercel.app/topics/bip-353)