### PR TITLE
Add BIP 158 topic page

### DIFF
--- a/data/topics/bip-158.mdx
+++ b/data/topics/bip-158.mdx
@@ -9,7 +9,7 @@ BIP 158 defines the compact block filter. For each block, a node builds a small 
 
 The filter uses Golomb-coded sets, which give a compact on-disk representation at a controlled false-positive rate. The filter for a typical block is on the order of a few kilobytes, against the block's full one to two megabytes.
 
-BIP 158 is the filter format. [BIP 157](/topics/bip-157) is the peer-to-peer protocol for requesting the filters. Together, they power privacy-preserving SPV in modern Bitcoin wallets like Neutrino, LDK Node, and Nakamoto.
+BIP 158 is the filter format. [BIP 157](/topics/bip-157) is the peer-to-peer protocol for requesting the filters. Together, they power privacy-preserving SPV in modern Bitcoin wallets like Neutrino, [LDK](/topics/ldk) Node, and Nakamoto.
 
 ## References
 

--- a/data/topics/bip-158.mdx
+++ b/data/topics/bip-158.mdx
@@ -1,0 +1,19 @@
+---
+title: 'BIP 158'
+summary: 'The compact block filter format for Bitcoin. A small Golomb-coded set built per block that light clients can test locally to find relevant transactions.'
+category: 'Bitcoin'
+aliases: ['compact block filters', 'Golomb-coded set filter', 'block filter format']
+---
+
+BIP 158 defines the compact block filter. For each block, a node builds a small probabilistic filter over the scripts spent and created in that block. A light client that knows which scripts belong to its wallet can test each filter locally. If the filter says the block is irrelevant, the client skips it. If it says the block might contain a match, the client fetches the full block and checks directly.
+
+The filter uses Golomb-coded sets, which give a compact on-disk representation at a controlled false-positive rate. The filter for a typical block is on the order of a few kilobytes, against the block's full one to two megabytes.
+
+BIP 158 is the filter format. [BIP 157](/topics/bip-157) is the peer-to-peer protocol for requesting the filters. Together, they power privacy-preserving SPV in modern Bitcoin wallets like Neutrino, LDK Node, and Nakamoto.
+
+## References
+
+- [BIP 158](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki)
+- [BIP 157](https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki)
+- [Golomb coding (Wikipedia)](https://en.wikipedia.org/wiki/Golomb_coding)
+- [Bitcoin Optech: Compact block filters](https://bitcoinops.org/en/topics/compact-block-filters/)


### PR DESCRIPTION
Adds a BIP 158 topic page to the topics section. The page describes the compact block filter format for Bitcoin: a small Golomb-coded set that light clients can test locally against each block.

- Adds `data/topics/bip-158.mdx` covering Golomb-coded sets, false-positive behavior, and how BIP 158 pairs with BIP 157
- Cross-links to the bip-157 and ldk topics
- References BIP 158, BIP 157, Golomb coding, and Bitcoin Optech

Closes https://github.com/OpenSats/content/issues/55

---

Build preview:
- [/topics/bip-158](https://os-website-git-content-add-topic-bip-158-opensats.vercel.app/topics/bip-158)