### PR TITLE
Add NIP-44 topic page

### DIFF
--- a/data/topics/nip-44.mdx
+++ b/data/topics/nip-44.mdx
@@ -1,0 +1,18 @@
+---
+title: 'NIP-44'
+summary: "Nostr's current versioned encryption scheme for direct messages and other private payloads, using ChaCha20 with HMAC-SHA256 and padded ciphertext."
+category: 'Nostr'
+aliases: ['versioned encryption', 'NIP-44 v2', 'Nostr encryption']
+---
+
+NIP-44 is Nostr's current encryption scheme for direct messages and other private payloads. It uses ChaCha20 for encryption with HMAC-SHA256 for authentication and derives the shared key via Elliptic-Curve Diffie-Hellman on the secp256k1 curve. The payload is padded so the ciphertext length does not leak the plaintext length.
+
+NIP-44 replaces the original NIP-04, which had several well-known weaknesses. NIP-04 used AES-CBC without proper authentication, leaked message length, and let an attacker tamper with the ciphertext without being detected. NIP-44 fixes those problems while keeping the same underlying key material: the user's existing Nostr keypair.
+
+NIP-44 is rarely used on its own. In practice, clients wrap NIP-44 ciphertext in the [Private DMs](/topics/private-dms) gift-wrap construction (NIP-17 and NIP-59) so that relays cannot see who is talking to whom.
+
+## References
+
+- [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md)
+- [NIP-17](https://github.com/nostr-protocol/nips/blob/master/17.md)
+- [NIP-59: Gift Wrap](https://github.com/nostr-protocol/nips/blob/master/59.md)

--- a/data/topics/nip-44.mdx
+++ b/data/topics/nip-44.mdx
@@ -5,7 +5,7 @@ category: 'Nostr'
 aliases: ['versioned encryption', 'NIP-44 v2', 'Nostr encryption']
 ---
 
-NIP-44 is Nostr's current encryption scheme for direct messages and other private payloads. It uses ChaCha20 for encryption with HMAC-SHA256 for authentication and derives the shared key via Elliptic-Curve Diffie-Hellman on the secp256k1 curve. The payload is padded so the ciphertext length does not leak the plaintext length.
+NIP-44 is [Nostr's](/topics/nostr) current encryption scheme for direct messages and other private payloads. It uses ChaCha20 for encryption with HMAC-SHA256 for authentication and derives the shared key via Elliptic-Curve Diffie-Hellman on the secp256k1 curve. The payload is padded so the ciphertext length does not leak the plaintext length.
 
 NIP-44 replaces the original NIP-04, which had several well-known weaknesses. NIP-04 used AES-CBC without proper authentication, leaked message length, and let an attacker tamper with the ciphertext without being detected. NIP-44 fixes those problems while keeping the same underlying key material: the user's existing Nostr keypair.
 

--- a/data/topics/nip-44.mdx
+++ b/data/topics/nip-44.mdx
@@ -15,4 +15,4 @@ NIP-44 is rarely used on its own. In practice, clients wrap NIP-44 ciphertext in
 
 - [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md)
 - [NIP-17](https://github.com/nostr-protocol/nips/blob/master/17.md)
-- [NIP-59: Gift Wrap](https://github.com/nostr-protocol/nips/blob/master/59.md)
+- [NIP-59](https://github.com/nostr-protocol/nips/blob/master/59.md)


### PR DESCRIPTION
Adds a NIP-44 topic page to the topics section. The page describes Nostr's current versioned encryption scheme for direct messages: ChaCha20 with HMAC-SHA256 and padded ciphertext.

- Adds `data/topics/nip-44.mdx` covering the cryptographic construction, the weaknesses of NIP-04 it fixes, and how clients combine NIP-44 with gift-wrap
- Cross-links to the nostr and private-dms topics
- References NIP-44, NIP-17, and NIP-59

Closes https://github.com/OpenSats/content/issues/57

---

Build preview:
- [/topics/nip-44](https://os-website-git-content-add-topic-nip-44-opensats.vercel.app/topics/nip-44)