### PR TITLE
Add NIP-96 topic page

### DIFF
--- a/data/topics/nip-96.mdx
+++ b/data/topics/nip-96.mdx
@@ -1,0 +1,18 @@
+---
+title: 'NIP-96'
+summary: 'An HTTP API for file storage servers that Nostr clients can upload to and then reference by URL from events, without bloating relays.'
+category: 'Nostr'
+aliases: ['Nostr file storage', 'NIP-96 servers', 'media upload']
+---
+
+NIP-96 defines an HTTP API for file storage servers that [Nostr](/topics/nostr) clients can talk to. A user uploads an image or a video to a NIP-96 server and gets back a URL that is safe to reference from a Nostr event. The server keeps the file. The relay only stores the URL and a hash.
+
+Authentication uses NIP-98, a signed HTTP authorization header built from the user's Nostr keypair. A client signs each request, the server verifies the signature, and rate-limits or charges based on the authenticated pubkey. There is no email signup and no separate account system.
+
+NIP-96 is what makes Nostr clients able to post images and video without bloating relays. Public servers that implement it include nostr.build, nostrcheck.me, and Satellite CDN. Blossom (BUD-01/BUD-02) is a newer spec that covers similar ground and is supported by many of the same servers.
+
+## References
+
+- [NIP-96](https://github.com/nostr-protocol/nips/blob/master/96.md)
+- [NIP-98: HTTP Auth](https://github.com/nostr-protocol/nips/blob/master/98.md)
+- [nostr.build](https://nostr.build/)

--- a/data/topics/nip-96.mdx
+++ b/data/topics/nip-96.mdx
@@ -5,7 +5,7 @@ category: 'Nostr'
 aliases: ['Nostr file storage', 'NIP-96 servers', 'media upload']
 ---
 
-NIP-96 defines an HTTP API for file storage servers that [Nostr](/topics/nostr) clients can talk to. A user uploads an image or a video to a NIP-96 server and gets back a URL that is safe to reference from a Nostr event. The server keeps the file. The relay only stores the URL and a hash.
+NIP-96 defines an HTTP API for file storage servers that [Nostr](/topics/nostr) clients can talk to. A user uploads an image or a video to a NIP-96 server and gets back a URL that is safe to reference from a Nostr event. The server keeps the file. The [relay](/topics/relays) only stores the URL and a hash.
 
 Authentication uses NIP-98, a signed HTTP authorization header built from the user's Nostr keypair. A client signs each request, the server verifies the signature, and rate-limits or charges based on the authenticated pubkey. There is no email signup and no separate account system.
 


### PR DESCRIPTION
Adds a NIP-96 topic page to the topics section. The page describes an HTTP API for file storage servers that Nostr clients can upload to, so media can be referenced from events by URL without bloating relays.

- Adds `data/topics/nip-96.mdx` covering the upload flow, NIP-98 authentication, the relationship with Blossom, and common public servers
- Cross-links to the nostr and relays topics
- References NIP-96, NIP-98, and nostr.build

Closes https://github.com/OpenSats/content/issues/58

---

Build preview:
- [/topics/nip-96](https://os-website-git-content-add-topic-nip-96-opensats.vercel.app/topics/nip-96)