### PR TITLE
Add BIP 329 topic page

### DIFF
--- a/data/topics/bip-329.mdx
+++ b/data/topics/bip-329.mdx
@@ -5,7 +5,7 @@ category: 'Bitcoin'
 aliases: ['wallet labels export', 'transaction labels', 'jsonl labels']
 ---
 
-BIP 329 is a portable format for wallet labels. Labels are the notes a user attaches to transactions, addresses, public keys, and UTXOs. They are private metadata. Wallets have stored them for years, but each wallet used its own proprietary format, so switching wallets meant losing the notes.
+BIP 329 is a portable format for wallet labels. Labels are the notes a user attaches to transactions, addresses, public keys, and [UTXOs](/topics/utxo). They are private metadata. Wallets have stored them for years, but each wallet used its own proprietary format, so switching wallets meant losing the notes.
 
 The format is JSON Lines: one JSON object per line, each with a `type`, a `ref`, a `label`, and optional fields like `origin` and `spendable`. A wallet exports its labels to a `.jsonl` file, the user imports that file into another wallet, and the labels reattach to the same objects on the new side.
 
@@ -13,6 +13,6 @@ Support exists in Sparrow, BlueWallet, Nunchuk, Bitcoin Safe, and other wallets.
 
 ## References
 
-- [BIP 329](https://github.com/bitcoin/bips/blob/master/bip-0329.md)
+- [BIP 329](https://github.com/bitcoin/bips/blob/master/bip-0329.mediawiki)
+- [bips.dev: BIP 329 rendered](https://bips.dev/329)
 - [JSON Lines](https://jsonlines.org/)
-- [Sparrow: labels](https://sparrowwallet.com/docs/quick-start.html#labels)

--- a/data/topics/bip-329.mdx
+++ b/data/topics/bip-329.mdx
@@ -1,0 +1,18 @@
+---
+title: 'BIP 329'
+summary: 'A portable JSON Lines format for wallet labels on Bitcoin: the private notes attached to transactions, addresses, public keys, and UTXOs.'
+category: 'Bitcoin'
+aliases: ['wallet labels export', 'transaction labels', 'jsonl labels']
+---
+
+BIP 329 is a portable format for wallet labels. Labels are the notes a user attaches to transactions, addresses, public keys, and UTXOs. They are private metadata. Wallets have stored them for years, but each wallet used its own proprietary format, so switching wallets meant losing the notes.
+
+The format is JSON Lines: one JSON object per line, each with a `type`, a `ref`, a `label`, and optional fields like `origin` and `spendable`. A wallet exports its labels to a `.jsonl` file, the user imports that file into another wallet, and the labels reattach to the same objects on the new side.
+
+Support exists in Sparrow, BlueWallet, Nunchuk, Bitcoin Safe, and other wallets. Because the format is plain text, users can edit it by hand or back it up alongside their seed phrase without any additional tooling.
+
+## References
+
+- [BIP 329](https://github.com/bitcoin/bips/blob/master/bip-0329.md)
+- [JSON Lines](https://jsonlines.org/)
+- [Sparrow: labels](https://sparrowwallet.com/docs/quick-start.html#labels)


### PR DESCRIPTION
Adds a BIP 329 topic page to the topics section. The page describes a portable JSON Lines format for exporting wallet labels (transaction, address, pubkey, and UTXO notes) between wallets.

- Adds `data/topics/bip-329.mdx` covering the JSON Lines schema, the required and optional fields, and wallet support
- Cross-links to the utxo topic
- References BIP 329, bips.dev, and jsonlines.org

Closes https://github.com/OpenSats/content/issues/59

---

Build preview:
- [/topics/bip-329](https://os-website-git-content-add-topic-bip-329-opensats.vercel.app/topics/bip-329)