### PR TITLE
fix: stabilize RSS feed GUIDs across deploys

### DIFF
--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -1,15 +1,5 @@
 // @ts-check
 
-const rawSiteUrl =
-  process.env.NEXT_PUBLIC_SITE_URL ||
-  process.env.SITE_URL ||
-  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null) ||
-  'https://opensats.org'
-
-const siteUrl = rawSiteUrl.startsWith('http')
-  ? rawSiteUrl.replace(/\/$/, '')
-  : `https://${rawSiteUrl.replace(/\/$/, '')}`
-
 /** @type {import("pliny/config").PlinyConfig } */
 const siteMetadata = {
   title: 'OpenSats',
@@ -19,7 +9,11 @@ const siteMetadata = {
     'OpenSats is a 501(c)(3) public charity that aims to support and maintain a sustainable ecosystem of funding for free and open-source projects and contributors, especially bitcoin-related projects and projects that help bitcoin flourish.',
   language: 'en-us',
   theme: 'system', // system, dark or light
-  siteUrl,
+  // Must be the canonical production URL: it backs RSS <guid>s, sitemap
+  // entries, and og:url tags, all of which need to be stable across
+  // deploys. Do not derive this from VERCEL_URL — that value is unique
+  // per deployment and would change every release.
+  siteUrl: 'https://opensats.org',
   siteRepo: 'https://github.com/OpenSats/website/',
   siteLogo: '/static/images/logo.png',
   image: '/static/images/avatar.png',


### PR DESCRIPTION
The RSS feed has been minting new `<guid>` values on every Vercel deploy because `siteUrl` in `data/siteMetadata.js` was wired up to fall back to `process.env.VERCEL_URL`, which is the per-deployment hostname (e.g. `os-website-<hash>-opensats.vercel.app`). 

Pliny's RSS generator builds each item's `<guid>` from `siteUrl`, so every release produced a fresh set of GUIDs and feed readers correctly treated every post as new. This restores `siteUrl` to the canonical `https://opensats.org`.

- Reverts the dynamic `siteUrl` introduced in #622 to a hardcoded canonical URL with an inline comment explaining why it must stay stable.
- Subscribers will see one final "everything is new" event after this ships, then GUIDs will be permanent going forward.
- Refs OpenSats/content#61.
