### PR TITLE
Note ongoing debate over Erlay's future on the Erlay topic page

### DIFF
--- a/data/topics/erlay.mdx
+++ b/data/topics/erlay.mdx
@@ -11,9 +11,12 @@ Erlay breaks the relay into two stages. Nodes still flood transactions to a smal
 
 The practical result is that a well-connected node can keep many more peers without a big jump in bandwidth. That in turn makes the network more resistant to eclipse attacks. Erlay is specified in BIP 330, with implementation work in Bitcoin Core tracked across several pull requests.
 
+Whether Erlay is worth shipping is still an open question. As of early 2026, Bitcoin Core developers are re-evaluating its trade-offs and goals in [bitcoin/bitcoin#34542](https://github.com/bitcoin/bitcoin/issues/34542), so the design described here may yet change or be dropped.
+
 ## References
 
 - [BIP 330](https://github.com/bitcoin/bips/blob/master/bip-0330.mediawiki)
 - [Erlay paper (Naumenko, Maxwell, Wuille, Fedorova, Beschastnikh, 2019)](https://arxiv.org/abs/1905.10518)
 - [bitcoin-core/minisketch](https://github.com/bitcoin-core/minisketch)
 - [Bitcoin Optech: Erlay](https://bitcoinops.org/en/topics/erlay/)
+- [RFC: Erlay Conceptual Discussion (bitcoin/bitcoin#34542)](https://github.com/bitcoin/bitcoin/issues/34542)


### PR DESCRIPTION
Follow-up to #653 to address @jonatack's [review comment](https://github.com/OpenSats/website/pull/653#pullrequestreview-4164034438) pointing out that Erlay's viability and future are currently being debated upstream.

- Adds a short paragraph noting that as of early 2026, Bitcoin Core developers are re-evaluating Erlay's trade-offs in bitcoin/bitcoin#34542, and that the design may yet change or be dropped
- Adds the RFC issue to the references section

---

Build preview:
- [/topics/erlay](https://os-website-git-content-erlay-uncertainty-note-opensats.vercel.app/topics/erlay)