### PR TITLE
Add BOLT 11 and Web of Trust topic pages

### DIFF
--- a/data/topics/bolt11.mdx
+++ b/data/topics/bolt11.mdx
@@ -1,0 +1,19 @@
+---
+title: 'BOLT 11'
+summary: 'The original Lightning invoice format: a bech32-encoded string a payer scans once to send a fixed amount to a fixed pubkey before the invoice expires.'
+category: 'Lightning'
+aliases: ['BOLT11', 'Lightning invoice', 'lnbc']
+---
+
+BOLT 11 is the invoice format that has carried almost every Lightning payment since the network went live. The receiver generates an invoice for a specific amount, signs it with the node's key, and shares the resulting string (which always starts with `lnbc` on mainnet) as text or a QR code. The payer's wallet decodes the invoice, finds a route to the destination, and pays it before it expires.
+
+Each invoice is one-shot. It encodes a payment hash that the receiver chose, an optional amount, an expiry, an optional memo, and routing hints for nodes behind unannounced channels. Once the payer settles the preimage of that hash, the invoice cannot be paid again. Asking for a fresh invoice per payment is why BOLT 11 wallets typically rely on a side channel like LNURL or a web server to hand out new strings on demand.
+
+[BOLT 12](/topics/bolt12) was designed to remove that round trip: a single offer can be paid many times, fetches the invoice over the Lightning network itself using onion messages, and supports recurring payments and refunds. BOLT 11 invoices remain the lowest common denominator that every wallet and node can read, and they continue to be the default for one-off payments.
+
+## References
+
+- [BOLT 11 specification](https://github.com/lightning/bolts/blob/master/11-payment-encoding.md)
+- [BIP 173 (bech32)](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)
+- [Bitcoin Optech: BOLT 11 invoice](https://bitcoinops.org/en/topics/bolt11/)
+- [LND: Add an invoice](https://docs.lightning.engineering/the-lightning-network/payment-channels/payment-flow)

--- a/data/topics/web-of-trust.mdx
+++ b/data/topics/web-of-trust.mdx
@@ -1,0 +1,19 @@
+---
+title: 'Web of Trust'
+summary: 'A client-side filter on Nostr that derives reputation from the social graph: events from people you follow, and people they follow, are surfaced; the rest is muted.'
+category: 'Nostr'
+aliases: ['WoT', 'web-of-trust', 'NIP-85', 'trust rank']
+---
+
+Web of trust on [Nostr](/topics/nostr) is the practice of using the social graph to decide which events a client shows. Every user already publishes a follow list as a signed event. A client can read the follow lists of the people you follow, score every other pubkey by how close it sits in that graph, and apply the score as a filter: notes, replies, zaps, and DMs from accounts inside your circle pass through, while accounts outside it get muted or downranked.
+
+The result is per-user moderation that needs no central authority. Two people reading the same [relays](/topics/relays) see different feeds because their graphs are different. A spammer who buys ten thousand fake follows still cannot reach a user whose own contacts have not vouched for any of them. There is no list to game, and no operator to lobby.
+
+[NIP-85](https://github.com/nostr-protocol/nips/blob/master/85.md) standardizes published trust-rank events so that a client does not have to recompute the graph itself: a service can publish ranked pubkey lists as nostr events, and any client can subscribe to one or more services it considers trustworthy. Clients are also free to compute their own scores locally. WoT-based filtering ships in [Amethyst](/projects/amethyst), [Damus](/projects/damus), [Coracle](/projects/coracle), [NDK](/projects/ndk), and other clients, and is one of the main reasons spam on nostr has stayed manageable without a content team.
+
+## References
+
+- [NIP-02: Contact lists](https://github.com/nostr-protocol/nips/blob/master/02.md)
+- [NIP-85: Trusted Assertions](https://github.com/nostr-protocol/nips/blob/master/85.md)
+- [NIP-51: Lists](https://github.com/nostr-protocol/nips/blob/master/51.md)
+- [Web of Trust (Wikipedia)](https://en.wikipedia.org/wiki/Web_of_trust)


### PR DESCRIPTION
Adds two topic pages from the umbrella issue OpenSats/content#64.

- Adds `data/topics/bolt11.mdx` covering the original Lightning invoice format: bech32 encoding, one-shot semantics, and why a fresh invoice is needed per payment. Cross-links to the existing BOLT 12 page.
- Adds `data/topics/web-of-trust.mdx` covering client-side WoT filtering on nostr: per-user moderation derived from the social graph, NIP-85 trusted assertions, and the clients that ship it (Amethyst, Damus, Coracle, NDK).

BOLT 12 (OpenSats/content#66) already has a page from the initial topics PR (#644), so this PR closes that issue alongside the others.

Closes OpenSats/content#65
Closes OpenSats/content#66
Closes OpenSats/content#67
Closes OpenSats/content#64

---

Build preview:
- [/topics/bolt11](https://os-website-git-content-add-topics-bolt11-wot-opensats.vercel.app/topics/bolt11)
- [/topics/web-of-trust](https://os-website-git-content-add-topics-bolt11-wot-opensats.vercel.app/topics/web-of-trust)