### PR TITLE
fix(topics): correct Nostr internal links (/topics/nostr)

### DIFF
--- a/data/topics/relays.mdx
+++ b/data/topics/relays.mdx
@@ -5,7 +5,7 @@ category: 'Nostr'
 aliases: ['Nostr relay']
 ---
 
-A relay is a WebSocket server that accepts, stores, and serves [Nostr](/topic/nostr) events. Clients connect to several relays at once. Writing a note means sending the same signed event to each of them. Reading a feed means subscribing to filters on each of them and merging the results.
+A relay is a WebSocket server that accepts, stores, and serves [Nostr](/topics/nostr) events. Clients connect to several relays at once. Writing a note means sending the same signed event to each of them. Reading a feed means subscribing to filters on each of them and merging the results.
 
 Relays do not need to know about each other. They do not need to trust each other. Each one is independently replaceable. A user who does not like a relay's policy can drop it and pick another without losing their identity or their history, as long as some other relay has a copy of the events they care about.
 

--- a/data/topics/remote-signing.mdx
+++ b/data/topics/remote-signing.mdx
@@ -5,7 +5,7 @@ category: 'Nostr'
 aliases: ['NIP-46', 'bunker', 'nsecBunker', 'Nostr Connect']
 ---
 
-NIP-46 defines a protocol for signing [Nostr](/topic/nostr) events with a key that lives on a different device or service than the one composing the event. A user's private key stays in a dedicated signer, often an Android app like Amber or a hosted bunker, and every client talks to that signer over Nostr relays to request signatures.
+NIP-46 defines a protocol for signing [Nostr](/topics/nostr) events with a key that lives on a different device or service than the one composing the event. A user's private key stays in a dedicated signer, often an Android app like Amber or a hosted bunker, and every client talks to that signer over Nostr relays to request signatures.
 
 The signer shows each request to the user, who approves or rejects it. A good signer also stores per-app permissions, so a client that the user trusts to publish short notes does not automatically get permission to send private messages or spend from a wallet. The client never sees the private key.
 

--- a/data/topics/zaps.mdx
+++ b/data/topics/zaps.mdx
@@ -5,7 +5,7 @@ category: 'Nostr'
 aliases: ['NIP-57', 'Lightning zaps', 'zap']
 ---
 
-A zap is a public Lightning payment attached to a [Nostr](/topic/nostr) event. A user who likes a note, a profile, or a reply can send sats to the author. The payment then surfaces on Nostr as a "zap receipt": a signed Nostr event that proves the Lightning invoice was paid. Other clients render the zap under the original note, so everyone sees who tipped whom and how much.
+A zap is a public Lightning payment attached to a [Nostr](/topics/nostr) event. A user who likes a note, a profile, or a reply can send sats to the author. The payment then surfaces on Nostr as a "zap receipt": a signed Nostr event that proves the Lightning invoice was paid. Other clients render the zap under the original note, so everyone sees who tipped whom and how much.
 
 The mechanism is defined in NIP-57. The receiver advertises a zap endpoint, such as a LNURL, in their profile. The sender asks the endpoint for a Lightning invoice that references the target event. After payment, the endpoint publishes the zap receipt to the same relays that carry the original event.
 


### PR DESCRIPTION
Topic pages linked to `/topic/nostr`, which does not exist. Use `/topics/nostr` so in-page Nostr links resolve to the Nostr topic page.

Updated: `remote-signing.mdx`, `relays.mdx`, `zaps.mdx`.