### PR TITLE
Add Coinswap topic page

### DIFF
--- a/data/topics/coinswap.mdx
+++ b/data/topics/coinswap.mdx
@@ -1,0 +1,18 @@
+---
+title: 'Coinswap'
+summary: 'Atomic multi-hop swaps that move coins through intermediate keys so the spender of an input is not obviously the receiver of the final output.'
+category: 'Privacy'
+aliases: ['CoinSwap', 'coin swap', 'atomic coin swap']
+---
+
+A coinswap protocol routes value through one or more intermediate transactions so the entity spending an early UTXO is not obviously the same as the entity receiving the later one. Greg Maxwell [outlined the idea on Bitcointalk in 2013](https://bitcointalk.org/index.php?topic=321228.0); later work turned it into concrete client and server software, including the open [specification and implementation](https://github.com/citadel-tech/coinswap) advanced by groups such as Citadel Tech with support from OpenSats (see our [on-chain privacy impact report](/blog/developing-advancements-in-onchain-privacy#coinswap)).
+
+A [CoinJoin](/topics/coinjoin) usually batches many inputs into one co-signed transaction. [Payjoin](/topics/payjoin) has the receiver add their own input to a two-party payment. Coinswap chains separate transactions so each hop can look like a normal spend, which pushes back on heuristics that equate one transaction with one ownership hop.
+
+Coinswap still costs block space and coordination time, and wallet support is thinner than for simpler tools. When it works, it trades extra hops for a break in the direct graph link between source and destination outputs.
+
+## References
+
+- [Bitcoin Optech: Coinswap](https://bitcoinops.org/en/topics/coinswap/)
+- [Greg Maxwell, CoinSwap: Transaction graph disjointing (2013)](https://bitcointalk.org/index.php?topic=321228.0)
+- [Citadel Tech coinswap repository](https://github.com/citadel-tech/coinswap)

--- a/data/topics/coinswap.mdx
+++ b/data/topics/coinswap.mdx
@@ -5,14 +5,15 @@ category: 'Privacy'
 aliases: ['CoinSwap', 'coin swap', 'atomic coin swap']
 ---
 
-A coinswap protocol routes value through one or more intermediate transactions so the entity spending an early UTXO is not obviously the same as the entity receiving the later one. Greg Maxwell [outlined the idea on Bitcointalk in 2013](https://bitcointalk.org/index.php?topic=321228.0); later work turned it into concrete client and server software, including the open [specification and implementation](https://github.com/citadel-tech/coinswap) advanced by groups such as Citadel Tech with support from OpenSats (see our [on-chain privacy impact report](/blog/developing-advancements-in-onchain-privacy#coinswap)).
+A coinswap protocol routes value through one or more intermediate transactions so the entity spending an early UTXO is not obviously the same as the entity receiving the later one. Greg Maxwell [outlined the idea on Bitcointalk in 2013](https://bitcointalk.org/index.php?topic=321228.0). Later work turned the sketch into a client-and-server protocol with atomic escrow, so no intermediary can steal funds mid-swap even if every hop is run by a different party.
 
 A [CoinJoin](/topics/coinjoin) usually batches many inputs into one co-signed transaction. [Payjoin](/topics/payjoin) has the receiver add their own input to a two-party payment. Coinswap chains separate transactions so each hop can look like a normal spend, which pushes back on heuristics that equate one transaction with one ownership hop.
 
-Coinswap still costs block space and coordination time, and wallet support is thinner than for simpler tools. When it works, it trades extra hops for a break in the direct graph link between source and destination outputs.
+Coinswap costs block space and coordination time, and wallet support is thinner than for simpler tools. When it works, it trades extra hops for a break in the direct graph link between source and destination outputs. A reference implementation lives in the [citadel-tech/coinswap](https://github.com/citadel-tech/coinswap) repository.
 
 ## References
 
-- [Bitcoin Optech: Coinswap](https://bitcoinops.org/en/topics/coinswap/)
 - [Greg Maxwell, CoinSwap: Transaction graph disjointing (2013)](https://bitcointalk.org/index.php?topic=321228.0)
-- [Citadel Tech coinswap repository](https://github.com/citadel-tech/coinswap)
+- [Coinswap Protocol Specification v1](https://github.com/citadel-tech/Coinswap-Protocol-Specification)
+- [Bitcoin Optech: Coinswap](https://bitcoinops.org/en/topics/coinswap/)
+- [OpenSats on-chain privacy impact report: Coinswap](/blog/developing-advancements-in-onchain-privacy#coinswap)

--- a/data/topics/coinswap.mdx
+++ b/data/topics/coinswap.mdx
@@ -9,7 +9,7 @@ A coinswap protocol routes value through one or more intermediate transactions s
 
 A [CoinJoin](/topics/coinjoin) usually batches many inputs into one co-signed transaction. [Payjoin](/topics/payjoin) has the receiver add their own input to a two-party payment. Coinswap chains separate transactions so each hop can look like a normal spend, which pushes back on heuristics that equate one transaction with one ownership hop.
 
-Coinswap costs block space and coordination time, and wallet support is thinner than for simpler tools. When it works, it trades extra hops for a break in the direct graph link between source and destination outputs. A reference implementation lives in the [citadel-tech/coinswap](https://github.com/citadel-tech/coinswap) repository.
+Coinswap trades a break in the direct graph link between source and destination outputs for extra hops, block space, and coordination time.  A reference implementation lives in the [citadel-tech/coinswap](https://github.com/citadel-tech/coinswap) repository.
 
 ## References
 


### PR DESCRIPTION
Adds a Coinswap topic page to the topics section. The page describes the atomic multi-hop swap technique for on-chain privacy, contrasted with CoinJoin and Payjoin, and scoped to the protocol (so a future `/projects/coinswap` page can carry the Citadel Tech grantee story).

- Adds `data/topics/coinswap.mdx` covering Greg Maxwell's 2013 sketch, the client-and-server protocol with atomic escrow, and the trade-off of extra hops against a break in the source-to-destination graph link
- Cross-links to the existing [CoinJoin](/topics/coinjoin) and [Payjoin](/topics/payjoin) topic pages, and to the [on-chain privacy impact report](/blog/developing-advancements-in-onchain-privacy#coinswap)
- References the 2013 Bitcointalk post, the Coinswap Protocol Specification v1, Bitcoin Optech, and the `citadel-tech/coinswap` reference implementation

Closes OpenSats/content#77

---

Build preview:
- [/topics/coinswap](https://os-website-git-topic-coinswap-opensats.vercel.app/topics/coinswap)