### PR TITLE
Add mempool topic page

### DIFF
--- a/data/topics/mempool.mdx
+++ b/data/topics/mempool.mdx
@@ -13,4 +13,6 @@ The mempool is where soft congestion shows up first: when demand for block space
 
 ## References
 
-- [Bitcoin Wiki: mempool](https://en.bitcoin.it/wiki/Mempool)
+- [Bitcoin Core RPC: `getmempoolinfo`](https://developer.bitcoin.org/reference/rpc/getmempoolinfo.html)
+- [Bitcoin Core RPC: `getrawmempool`](https://developer.bitcoin.org/reference/rpc/getrawmempool.html)
+- [Bitcoin Optech: Package relay](https://bitcoinops.org/en/topics/package-relay/)

--- a/data/topics/mempool.mdx
+++ b/data/topics/mempool.mdx
@@ -16,4 +16,4 @@ The mempool is where soft congestion shows up first: when demand for block space
 - [Bitcoin Core RPC: `getmempoolinfo`](https://developer.bitcoin.org/reference/rpc/getmempoolinfo.html)
 - [Bitcoin Core RPC: `getrawmempool`](https://developer.bitcoin.org/reference/rpc/getrawmempool.html)
 - [Bitcoin Optech: Package relay](https://bitcoinops.org/en/topics/package-relay/)
-- [mempool.space FAQ: What is a mempool explorer?](https://mempool.space/docs/faq#what-is-a-mempool-explorer)
+- [mempool.space FAQ: What is a mempool?](https://mempool.space/docs/faq#what-is-a-mempool)

--- a/data/topics/mempool.mdx
+++ b/data/topics/mempool.mdx
@@ -14,4 +14,3 @@ The mempool is where soft congestion shows up first: when demand for block space
 ## References
 
 - [Bitcoin Wiki: mempool](https://en.bitcoin.it/wiki/Mempool)
-- [Bitcoin Optech: mempool](https://bitcoinops.org/en/topics/mempool/)

--- a/data/topics/mempool.mdx
+++ b/data/topics/mempool.mdx
@@ -1,0 +1,17 @@
+---
+title: 'Mempool'
+summary: 'The set of valid but unconfirmed transactions each full node keeps in memory, from which miners and fee estimators pull candidates.'
+category: 'Bitcoin'
+aliases: ['memory pool', 'transaction pool', 'tx pool']
+---
+
+Every Bitcoin full node validates transactions it hears on the network and keeps accepted, non-conflicting ones in its **mempool** until they confirm in a block or expire under local policy. There is no global mempool: each peer maintains its own view based on what it saw, in which order, and which feerate rules it applies. Wallets ask their node (or a service like [mempool.space](https://mempool.space)) for a snapshot of that view when they estimate fees or when they show "pending" activity to a user.
+
+Miners and mining pools pull work from their own mempool (or from a pool template builder) when they assemble candidate blocks. [Stratum V2](/topics/stratum-v2) discussions often assume miners can see enough of the fee market to pick transactions with less blind trust in the pool operator. Policy changes such as package relay and feerate-based eviction adjust how those candidates enter and leave the set without changing consensus rules for confirmed blocks.
+
+The mempool is where soft congestion shows up first: when demand for block space spikes, the same mempool data is what drives rising feerates for the next confirmations.
+
+## References
+
+- [Bitcoin Wiki: mempool](https://en.bitcoin.it/wiki/Mempool)
+- [Bitcoin Optech: mempool](https://bitcoinops.org/en/topics/mempool/)

--- a/data/topics/mempool.mdx
+++ b/data/topics/mempool.mdx
@@ -16,3 +16,4 @@ The mempool is where soft congestion shows up first: when demand for block space
 - [Bitcoin Core RPC: `getmempoolinfo`](https://developer.bitcoin.org/reference/rpc/getmempoolinfo.html)
 - [Bitcoin Core RPC: `getrawmempool`](https://developer.bitcoin.org/reference/rpc/getrawmempool.html)
 - [Bitcoin Optech: Package relay](https://bitcoinops.org/en/topics/package-relay/)
+- [mempool.space FAQ: What is a mempool explorer?](https://mempool.space/docs/faq#what-is-a-mempool-explorer)


### PR DESCRIPTION
Adds a mempool topic page to the topics section. The page describes the per-node set of valid but unconfirmed transactions that drives fee estimation and block construction.

- Adds `data/topics/mempool.mdx` covering the per-node nature of the mempool, how miners and wallets pull work from it, and how policy changes such as package relay and feerate-based eviction shape what enters and leaves
- Cross-links to the existing [Stratum V2](/topics/stratum-v2) topic page and to `mempool.space`
- References Bitcoin Core RPC docs for `getmempoolinfo` and `getrawmempool`, Bitcoin Optech's package relay topic, and the mempool.space FAQ

Closes OpenSats/content#78

---

Build preview:
- [/topics/mempool](https://os-website-git-topic-mempool-opensats.vercel.app/topics/mempool)