### PR TITLE
Add output descriptors topic page

### DIFF
--- a/data/topics/output-descriptors.mdx
+++ b/data/topics/output-descriptors.mdx
@@ -5,7 +5,7 @@ category: 'Bitcoin'
 aliases: ['output descriptor', 'descriptor', 'descriptors', 'BIP 380', 'wpkh', 'wsh', 'tr()']
 ---
 
-An output descriptor is a notation for the scripts a wallet produces. A descriptor like `wpkh([d34db33f/84h/0h/0h]xpub.../0/*)` reads as: derive native SegWit P2WPKH addresses from this extended public key, at derivation path `0/i`, starting at `i=0`, and remember that the key originated from fingerprint `d34db33f` at path `m/84h/0h/0h`. Imported into any descriptor-aware wallet, that one string scans and spends the same UTXOs as the wallet that exported it, with no ambiguity about script type or derivation.
+An output descriptor is a notation for the scripts a wallet produces. A descriptor like `wpkh([d34db33f/84h/0h/0h]xpub.../0/*)` reads as: derive native [SegWit](/topics/segwit) P2WPKH addresses from this extended public key, at derivation path `0/i`, starting at `i=0`, and remember that the key originated from fingerprint `d34db33f` at path `m/84h/0h/0h`. Imported into any descriptor-aware wallet, that one string scans and spends the same UTXOs as the wallet that exported it, with no ambiguity about script type or derivation.
 
 Before descriptors, sharing a wallet across tools required out-of-band conventions. Two wallets could agree on the same master seed and then disagree on which derivation path to scan or which script type to expect. Descriptors fold every piece of that information into one string. A checksum at the end catches accidental edits, and the key-origin fields (`[fingerprint/path]`) tell a hardware signer which of its child keys should sign a given input.
 

--- a/data/topics/output-descriptors.mdx
+++ b/data/topics/output-descriptors.mdx
@@ -1,0 +1,22 @@
+---
+title: 'Output descriptors'
+summary: 'A compact text format that describes exactly how a wallet derives its addresses and scripts from a given set of keys. A single descriptor string captures the script type, the key origin, and the derivation path so any compatible wallet can import the wallet without guessing.'
+category: 'Bitcoin'
+aliases: ['output descriptor', 'descriptor', 'descriptors', 'BIP 380', 'wpkh', 'wsh', 'tr()']
+---
+
+An output descriptor is a notation for the scripts a wallet produces. A descriptor like `wpkh([d34db33f/84h/0h/0h]xpub.../0/*)` reads as: derive native SegWit P2WPKH addresses from this extended public key, at derivation path `0/i`, starting at `i=0`, and remember that the key originated from fingerprint `d34db33f` at path `m/84h/0h/0h`. Imported into any descriptor-aware wallet, that one string scans and spends the same UTXOs as the wallet that exported it, with no ambiguity about script type or derivation.
+
+Before descriptors, sharing a wallet across tools required out-of-band conventions. Two wallets could agree on the same master seed and then disagree on which derivation path to scan or which script type to expect. Descriptors fold every piece of that information into one string. A checksum at the end catches accidental edits, and the key-origin fields (`[fingerprint/path]`) tell a hardware signer which of its child keys should sign a given input.
+
+Descriptors compose. `sh(wpkh(...))` wraps a SegWit key inside a P2SH output for legacy compatibility. `wsh(multi(2,key1,key2,key3))` produces a 2-of-3 multisig under a native SegWit output. `tr(internal,{script1,script2})` produces a [Taproot](/topics/taproot) output with an internal key and a script tree. The fragments nest the same way the underlying Bitcoin scripts do, which makes descriptors a clean pair with [Miniscript](/topics/miniscript) for spending policies that go beyond single-key wallets.
+
+Descriptors are standardized across [BIPs 380 to 386](https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki). Bitcoin Core adopted them for its wallet format, and they are now the default for newly created wallets. [BDK](/projects/bdk), `rust-bitcoin`, and descriptor-based wallets such as Bitcoin Safe, Liana, and Sparrow use them as the primary wallet format, and hardware signers increasingly accept descriptors for multisig coordination.
+
+## References
+
+- [BIP 380: Output Script Descriptors](https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki)
+- [BIP 381: Non-segwit descriptors](https://github.com/bitcoin/bips/blob/master/bip-0381.mediawiki)
+- [BIP 382: Segwit descriptors](https://github.com/bitcoin/bips/blob/master/bip-0382.mediawiki)
+- [BIP 386: tr() descriptors](https://github.com/bitcoin/bips/blob/master/bip-0386.mediawiki)
+- [Bitcoin Core: doc/descriptors.md](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md)


### PR DESCRIPTION
Adds an output descriptors topic page to the topics section. The page describes the BIP 380 family: a compact text format that captures script type, key origin, and derivation path in one self-describing string.

- Adds `data/topics/output-descriptors.mdx` covering descriptor anatomy (`wpkh`, `wsh(multi(...))`, `tr(...)`), nesting, the checksum, and how descriptors pair with Miniscript and the Bitcoin Core descriptor-wallet format
- Cross-links to the existing [Taproot](/topics/taproot), [Miniscript](/topics/miniscript), and [BDK](/projects/bdk) pages
- References BIPs 380, 381, 382, and 386, and `doc/descriptors.md` in Bitcoin Core

Closes OpenSats/content#80

---

Build preview:
- [/topics/output-descriptors](https://os-website-git-topic-output-descriptors-opensats.vercel.app/topics/output-descriptors)