### PR TITLE
Rename /topics/splicing to /topics/channel-splicing

### DIFF
--- a/data/topics/channel-splicing.mdx
+++ b/data/topics/channel-splicing.mdx
@@ -1,11 +1,11 @@
 ---
-title: 'Splicing'
+title: 'Channel splicing'
 summary: 'Resizing a Lightning channel without closing it by adding or removing funds in a single on-chain transaction.'
 category: 'Lightning'
-aliases: ['splice-in', 'splice-out']
+aliases: ['splicing', 'splice-in', 'splice-out']
 ---
 
-Splicing lets two Lightning peers change the capacity of an existing channel in place. A splice-in adds new funds from an on-chain UTXO. A splice-out sends funds out of the channel to an on-chain address. Either way, the channel stays open and routing history is preserved.
+Channel splicing lets two Lightning peers change the capacity of an existing channel in place. A splice-in adds new funds from an on-chain UTXO. A splice-out sends funds out of the channel to an on-chain address. Either way, the channel stays open and routing history is preserved.
 
 Without splicing, a user who wants to top up a channel has to close it and open a new one. That costs two on-chain transactions, fragments liquidity, and resets reputation in pathfinding heuristics. Splicing does the same job with one transaction.
 

--- a/data/topics/gossip.mdx
+++ b/data/topics/gossip.mdx
@@ -9,7 +9,7 @@ Gossip is how Lightning nodes learn about the network. When a public channel ope
 
 Without gossip, a sender would have no way of knowing which nodes are connected or what they charge. With it, a wallet or routing node can compute a path from one pubkey to another and build a multi-hop payment. [Blinded paths](/topics/blinded-paths) provide an alternative for payment addressing that lets a recipient stay private even when senders do not have full graph information.
 
-The weakness is size. The full graph runs into hundreds of megabytes and grows as more channels open. [Splicing](/topics/splicing) adds its own gossip updates when channel capacity changes. Gossip v1 is specified in BOLT 7. Work on a more efficient successor is ongoing, with the main ideas being to fetch only the parts of the graph a node actually needs and to replace flooding with a set-reconciliation protocol.
+The weakness is size. The full graph runs into hundreds of megabytes and grows as more channels open. [Channel splicing](/topics/channel-splicing) adds its own gossip updates when channel capacity changes. Gossip v1 is specified in BOLT 7. Work on a more efficient successor is ongoing, with the main ideas being to fetch only the parts of the graph a node actually needs and to replace flooding with a set-reconciliation protocol.
 
 ## References
 

--- a/next.config.js
+++ b/next.config.js
@@ -116,6 +116,11 @@ module.exports = () => {
           permanent: true,
         },
         {
+          source: '/topics/splicing',
+          destination: '/topics/channel-splicing',
+          permanent: true,
+        },
+        {
           source: '/faq/grantees',
           destination: '/faq/grantee',
           permanent: true,


### PR DESCRIPTION
Renames the splicing topic to `/topics/channel-splicing` so it no longer collides with `/projects/splicing`. "Channel splicing" is the precise Lightning term and reads naturally when linked inline.

## Changes

- `git mv data/topics/splicing.mdx data/topics/channel-splicing.mdx`.
- Retitle the page to "Channel splicing" and add `splicing` to the aliases so search still matches the short form.
- Update the inline link in `data/topics/gossip.mdx` from `[Splicing](/topics/splicing)` to `[Channel splicing](/topics/channel-splicing)`.
- Add a permanent redirect `/topics/splicing` → `/topics/channel-splicing` in `next.config.js`.

## Cross-links

- `/projects/splicing` (Dusty Daemon's implementation work) stays unchanged and is still referenced from the topic body.
- `/topics/gossip` now links to the renamed topic.

## References

- Existing references in the topic (Lisa Neigut's 2018 proposal, BOLT PR 1160, Phoenix splicing update) carry over unchanged.