### PR TITLE
Curate /funds project showcase

### DIFF
--- a/data/projects/0xchat.mdx
+++ b/data/projects/0xchat.mdx
@@ -10,7 +10,6 @@ git: 'https://github.com/0xchat-app'
 nostr: 'npub10td4yrp6cl9kmjp9x5yd7r8pm96a5j07lk5mtj2kw39qf8frpt8qm9x2wl'
 zapstore: 'https://zapstore.dev/apps/com.oxchat.nostr'
 tags: ['Nostr', 'Mobile', 'iOS', 'Android', 'Desktop']
-showcase: true
 fund: nostr
 announcementLink: '/blog/nostr-grants-october-2023#0xchat'
 ---

--- a/data/projects/amber.mdx
+++ b/data/projects/amber.mdx
@@ -9,7 +9,6 @@ git: 'https://github.com/greenart7c3/Amber'
 nostr: 'npub1w4uswmv6lu9yel005l3qgheysmr7tk9uvwluddznju3nuxalevvs2d0jr5'
 zapstore: 'https://zapstore.dev/apps/com.greenart7c3.nostrsigner'
 tags: ['Nostr', 'Signing', 'Mobile', 'Android']
-showcase: true
 fund: nostr
 announcementLink: '/blog/greenart7c3-receives-lts-grant'
 ---

--- a/data/projects/applesauce.mdx
+++ b/data/projects/applesauce.mdx
@@ -7,7 +7,6 @@ website: 'https://applesauce.build/'
 coverImage: '/static/images/projects/applesauce.png'
 git: 'https://github.com/hzrd149/applesauce'
 tags: ['Nostr', 'TypeScript', 'Library', 'SDK']
-showcase: true
 fund: nostr
 announcementLink: '/blog/hzrd149-receives-lts-grant'
 ---

--- a/data/projects/bdk.mdx
+++ b/data/projects/bdk.mdx
@@ -8,6 +8,7 @@ coverImage: '/img/project/bdk.jpeg'
 git: 'https://github.com/bitcoindevkit'
 twitter: 'bitcoindevkit'
 tags: ['Bitcoin', 'Library']
+showcase: true
 fund: general
 announcementLink: '/blog/bitcoin-and-nostr-grants-august-2023#bdk'
 ---

--- a/data/projects/bitcoindesign.mdx
+++ b/data/projects/bitcoindesign.mdx
@@ -12,7 +12,6 @@ nostr: 'npub13s5mxgws70rpxsug96jfvglggackjrxs2ehypwg0prjaxsek42sqd9l03e'
 twitter: 'bitcoin_design'
 personalTwitter: 'GBKS'
 tags: ['Bitcoin', 'Design', 'UX']
-showcase: true
 fund: general
 announcementLink: '/blog/bitcoin-grants-december-2023#bitcoin-core-app'
 ---

--- a/data/projects/blitz-wallet.mdx
+++ b/data/projects/blitz-wallet.mdx
@@ -10,7 +10,6 @@ twitter: 'BlitzWalletApp'
 nostr: 'npub14l69mauhjyu9j8pgmhj04vjqauzq43ch9yp9g2yx9j9tc4n8xh8s5l9dz2'
 zapstore: 'https://zapstore.dev/apps/com.blitzwallet'
 tags: ['Bitcoin', 'Lightning', 'Wallet']
-showcase: true
 fund: general
 announcementLink: '/blog/bitcoin-grants-july-2024-6th-wave#blitz-wallet'
 ---

--- a/data/projects/blixt.mdx
+++ b/data/projects/blixt.mdx
@@ -11,7 +11,6 @@ donationLink: 'https://github.com/sponsors/hsjoberg'
 nostr: 'npub1v4v57fu60zvc9d2uq23cey4fnwvxlzga9q2vta2n6xalu03rs57s0mxwu8'
 zapstore: 'https://zapstore.dev/apps/com.blixtwallet'
 tags: ['Bitcoin', 'Lightning', 'Wallet']
-showcase: true
 fund: general
 announcementLink: '/blog/bitcoin-grants-july-2023#blixt-wallet'
 ---

--- a/data/projects/cdk.mdx
+++ b/data/projects/cdk.mdx
@@ -9,7 +9,6 @@ coverImage: '/static/images/projects/cdk.svg'
 git: 'https://github.com/cashubtc/cdk'
 nostr: 'npub1qjgcmlpkeyl8mdkvp4s0xls4ytcux6my606tgfx9xttut907h0zs76lgjw'
 tags: ['Bitcoin', 'Lightning', 'ecash', 'Library']
-showcase: true
 fund: general
 announcementLink: '/blog/thirteenth-wave-of-bitcoin-grants#cdk--sats-app'
 ---

--- a/data/projects/citrine.mdx
+++ b/data/projects/citrine.mdx
@@ -9,7 +9,6 @@ git: 'https://github.com/greenart7c3/Citrine'
 nostr: 'npub1w4uswmv6lu9yel005l3qgheysmr7tk9uvwluddznju3nuxalevvs2d0jr5'
 zapstore: 'https://zapstore.dev/apps/com.greenart7c3.citrine'
 tags: ['Nostr', 'Relay', 'Mobile', 'Android']
-showcase: true
 fund: nostr
 announcementLink: '/blog/greenart7c3-receives-lts-grant'
 ---

--- a/data/projects/damus.mdx
+++ b/data/projects/damus.mdx
@@ -9,7 +9,6 @@ coverImage: '/static/images/projects/damus.png'
 git: 'https://github.com/damus-io/damus'
 nostr: 'npub1xtscya34g58tk0z605fvr788k263gsu6cy9x0mhnm87echrgufzsevkk5s'
 tags: ['Nostr', 'Mobile', 'iOS']
-showcase: true
 fund: nostr
 announcementLink: '/blog/nostr-grants-july-2023#damus'
 ---

--- a/data/projects/damus.mdx
+++ b/data/projects/damus.mdx
@@ -9,6 +9,7 @@ coverImage: '/static/images/projects/damus.png'
 git: 'https://github.com/damus-io/damus'
 nostr: 'npub1xtscya34g58tk0z605fvr788k263gsu6cy9x0mhnm87echrgufzsevkk5s'
 tags: ['Nostr', 'Mobile', 'iOS']
+showcase: true
 fund: nostr
 announcementLink: '/blog/nostr-grants-july-2023#damus'
 ---

--- a/data/projects/floresta.mdx
+++ b/data/projects/floresta.mdx
@@ -7,7 +7,6 @@ website: 'https://getfloresta.org/'
 coverImage: '/static/images/projects/floresta.png'
 git: 'https://github.com/getfloresta/Floresta'
 tags: ['Bitcoin', 'Core']
-showcase: true
 fund: general
 announcementLink: '/blog/bitcoin-grants-september-2024-7th-wave#floresta'
 ---

--- a/data/projects/flotilla.mdx
+++ b/data/projects/flotilla.mdx
@@ -8,7 +8,6 @@ coverImage: '/static/images/projects/flotilla.png'
 git: 'https://gitea.coracle.social/coracle/flotilla'
 nostr: 'npub1jlrs53pkdfjnts29kveljul2sm0actt6n8dxrrzqcersttvcuv3qdjynqn'
 tags: ['Nostr', 'Communities', 'Chat']
-showcase: true
 fund: nostr
 announcementLink: '/blog/hodlbod-receives-lts-grant'
 ---

--- a/data/projects/frostr.mdx
+++ b/data/projects/frostr.mdx
@@ -7,7 +7,6 @@ website: 'https://frostr.org/'
 coverImage: '/static/images/projects/frostr.png'
 git: 'https://github.com/FROSTR-ORG'
 tags: ['Nostr', 'Signing']
-showcase: true
 fund: nostr
 announcementLink: '/blog/twelfth-wave-of-nostr-grants#frostr'
 ---

--- a/data/projects/lnbits.mdx
+++ b/data/projects/lnbits.mdx
@@ -8,7 +8,6 @@ coverImage: '/static/images/projects/lnbits.svg'
 git: 'https://github.com/lnbits/lnbits'
 twitter: 'lnbits'
 tags: ['Bitcoin', 'Lightning', 'Wallet', 'Infrastructure']
-showcase: true
 fund: general
 announcementLink: '/blog/bitcoin-and-nostr-grants-august-2023#lnbits'
 ---

--- a/data/projects/minibits.mdx
+++ b/data/projects/minibits.mdx
@@ -8,7 +8,6 @@ coverImage: '/static/images/projects/minibits.png'
 git: 'https://github.com/minibits-cash/minibits_wallet'
 zapstore: 'https://zapstore.dev/apps/com.minibits_wallet'
 tags: ['Bitcoin', 'Lightning', 'ecash', 'Mobile']
-showcase: true
 fund: general
 announcementLink: '/blog/bitcoin-grants-september-2024-7th-wave#minibits'
 ---

--- a/data/projects/mostro.mdx
+++ b/data/projects/mostro.mdx
@@ -11,7 +11,6 @@ zapstore: 'https://zapstore.dev/apps/network.mostro.app'
 twitter: 'MostroP2P'
 nostr: 'npub1m0str0d7z2ww8rdh20t2n9lx520xjwhaq24p68umqp06wwrwtsnqen40un'
 tags: ['Bitcoin', 'Lightning', 'Nostr']
-showcase: true
 fund: nostr
 announcementLink: '/blog/nostr-grants-july-2024#mostro'
 ---

--- a/data/projects/ndk.mdx
+++ b/data/projects/ndk.mdx
@@ -8,7 +8,6 @@ coverImage: '/static/images/projects/ndk.svg'
 git: 'https://github.com/nostr-dev-kit/ndk'
 nostr: 'npub1l2vyh47mk2p0qlsku7hg0vn29faehy9hy34ygaclpn66ukqp3afqutajft'
 tags: ['Nostr', 'TypeScript', 'Library', 'SDK']
-showcase: true
 fund: nostr
 announcementLink: '/blog/nostr-grants-july-2023#ndk'
 ---

--- a/data/projects/ngit.mdx
+++ b/data/projects/ngit.mdx
@@ -8,6 +8,7 @@ coverImage: '/static/images/projects/ngit.svg'
 git: 'https://github.com/DanConwayDev/ngit-cli'
 nostr: 'npub15qydau2hjma6ngxkl2cyar74wzyjshvl65za5k5rl69264ar2exs5cyejr'
 tags: ['Nostr', 'Git', 'Developer Tools']
+showcase: true
 fund: nostr
 announcementLink: '/blog/nostr-grants-july-2023#code-collaboration-over-nostr'
 ---

--- a/data/projects/ngit.mdx
+++ b/data/projects/ngit.mdx
@@ -8,7 +8,6 @@ coverImage: '/static/images/projects/ngit.svg'
 git: 'https://github.com/DanConwayDev/ngit-cli'
 nostr: 'npub15qydau2hjma6ngxkl2cyar74wzyjshvl65za5k5rl69264ar2exs5cyejr'
 tags: ['Nostr', 'Git', 'Developer Tools']
-showcase: true
 fund: nostr
 announcementLink: '/blog/nostr-grants-july-2023#code-collaboration-over-nostr'
 ---

--- a/data/projects/opencash.mdx
+++ b/data/projects/opencash.mdx
@@ -7,7 +7,6 @@ website: 'https://opencash.dev/'
 donationLink: 'https://opencash.dev/'
 coverImage: '/static/images/projects/opencash.png'
 tags: ['Bitcoin', 'Lightning', 'ecash']
-showcase: true
 fund: general
 announcementLink: '/blog/let-a-thousand-flowers-bloom#opencash'
 ---

--- a/data/projects/soapbox.mdx
+++ b/data/projects/soapbox.mdx
@@ -11,7 +11,6 @@ donationLink: 'https://github.com/sponsors/soapbox-pub'
 nostr: 'npub108pv4cg5ag52nq082kd5leu9ffrn2gdg6g4xdwatn73y36uzplmq9uyev6'
 zapstore: 'https://zapstore.dev/apps/pub.ditto.app'
 tags: ['Nostr']
-showcase: true
 fund: nostr
 announcementLink: '/blog/nostr-grants-july-2023#soapbox'
 ---

--- a/data/projects/splicing.mdx
+++ b/data/projects/splicing.mdx
@@ -11,7 +11,6 @@ twitter: 'dusty_daemon'
 personalTwitter: 'dusty_daemon'
 nostr: 'npub1fuk7q4y0wzqw7vjrg7xeuuva79pg7ctg69a53zsxq6gepksufrrst9mzly'
 tags: ['Lightning', 'Protocol']
-showcase: true
 fund: general
 announcementLink: '/blog/bitcoin-grants-july-2023#splicing'
 ---

--- a/data/projects/vls.mdx
+++ b/data/projects/vls.mdx
@@ -7,7 +7,6 @@ website: 'https://vls.tech/'
 coverImage: '/static/images/projects/vls.png'
 git: 'https://gitlab.com/lightning-signer/validating-lightning-signer'
 tags: ['Bitcoin', 'Lightning']
-showcase: true
 fund: general
 announcementLink: '/blog/bitcoin-grants-december-2023#validating-lightning-signer'
 ---

--- a/data/projects/zapstore.mdx
+++ b/data/projects/zapstore.mdx
@@ -7,7 +7,6 @@ website: 'https://zapstore.dev/'
 coverImage: '/static/images/projects/zapstore.png'
 git: 'https://github.com/zapstore/zapstore'
 tags: ['Nostr', 'Android', 'Mobile']
-showcase: true
 fund: nostr
 announcementLink: '/blog/10th-wave-of-nostr-grants#zapstore'
 ---

--- a/data/projects/zapstore.mdx
+++ b/data/projects/zapstore.mdx
@@ -7,6 +7,7 @@ website: 'https://zapstore.dev/'
 coverImage: '/static/images/projects/zapstore.png'
 git: 'https://github.com/zapstore/zapstore'
 tags: ['Nostr', 'Android', 'Mobile']
+showcase: true
 fund: nostr
 announcementLink: '/blog/10th-wave-of-nostr-grants#zapstore'
 ---

--- a/pages/funds/index.tsx
+++ b/pages/funds/index.tsx
@@ -15,7 +15,10 @@ const AllProjects: NextPage<{ projects: Project[]; funds: Fund[] }> = ({
 
   useEffect(() => {
     setShowcaseProjects(
-      projects.filter(isShowcaseProject).sort(() => 0.5 - Math.random())
+      projects
+        .filter(isShowcaseProject)
+        .sort(() => 0.5 - Math.random())
+        .slice(0, 12)
     )
     setOpenSatsFunds(funds.sort((a, b) => a.title.localeCompare(b.title)))
   }, [projects, funds])


### PR DESCRIPTION
The `/funds` page used to render every project carrying `showcase: true`, which was effectively the whole catalog. This narrows the page to a curated set of 15 featured projects and caps the visible grid at 12 so the layout renders cleanly. The full project list remains available at `/projects/showcase`.

- Sets `showcase: true` on the curated 15 in `data/projects/`: Bitcoin Core, BDK, BTCPay Server, Stratum V2, Cashu, Amethyst, Damus, Tor, GrapheneOS, Payjoin Dev Kit, Satoshi Nakamoto Institute, Cove, Summer of Bitcoin, Coracle, and Zapstore.
- Removes `showcase: true` from the 20 non-featured projects so they no longer appear on `/funds`.
- Adds `.slice(0, 12)` after the random shuffle in `pages/funds/index.tsx` so 12 of the 15 render per visit, keeping a rotating buffer.

---

Build preview:
- [/funds](https://os-website-git-project-showcase-opensats.vercel.app/funds)
- [/projects/showcase](https://os-website-git-project-showcase-opensats.vercel.app/projects/showcase)
