### PR TITLE
Update contact page and link to media kit

### DIFF
--- a/data/pages/contact.mdx
+++ b/data/pages/contact.mdx
@@ -19,10 +19,10 @@ will answer some of the questions you might have.
 
 ## Press Inquiries
 
-If you're a journalist or podcaster looking to cover OpenSats, our [media
-kit](/media-kit) has logos and brand assets you can use freely. We're happy
+If you're a journalist or podcaster looking to cover OpenSats, we're happy
 to help with interview requests or any fact-checking you might need before
-publishing.
+publishing. You can also grab logos and brand assets from our [media
+kit](/media-kit).
 
 Reach out to us at press@opensats.org
 

--- a/data/pages/contact.mdx
+++ b/data/pages/contact.mdx
@@ -38,8 +38,7 @@ Please send us your proposal at partnerships@opensats.org
 
 ## Want to Help?
 
-You can join our growing [team of
-volunteers](/about#volunteers) to help us provide an
+You can join our growing team of volunteers to help us provide an
 ecosystem of sustainable funding for Bitcoin, nostr, and related freedom tech.
 There are plenty of things to do, and _many hands make light work_, as the
 saying goes. Interested?

--- a/data/pages/contact.mdx
+++ b/data/pages/contact.mdx
@@ -19,12 +19,12 @@ will answer some of the questions you might have.
 
 ## Press Inquiries
 
-Are you a journalist, podcaster, or content creator looking to cover OpenSats?
-Do you need logos, brand assets, or background information for an upcoming
-story? Have a look at our [media kit](/media-kit) for downloadable assets and
-brand guidelines.
+If you're a journalist or podcaster looking to cover OpenSats, our [media
+kit](/media-kit) has logos and brand assets you can use freely. We're happy
+to help with interview requests or any fact-checking you might need before
+publishing.
 
-For interviews, quotes, or other media requests, please reach out to press@opensats.org
+Reach out to us at press@opensats.org
 
 ## Partnerships
 

--- a/data/pages/contact.mdx
+++ b/data/pages/contact.mdx
@@ -17,15 +17,6 @@ sometimes flooded with requests for support and applications. We hope that [our
 reports](/transparency) and [FAQ](/faq)
 will answer some of the questions you might have.
 
-## OpenSats Design Initiative
-
-Are you an open-source developer in need of design guidance? Do you need help
-with reviewing the UX of your software? Are you working on something that could
-benefit from [#nostrdesign](https://nostrdesign.org/) or the [Bitcoin Design
-Community](/projects/bitcoindesign)?
-
-Don't hesitate to reach out to design@opensats.org
-
 ## Partnerships
 
 Are you interested in partnering with OpenSats? Do you provide services that

--- a/data/pages/contact.mdx
+++ b/data/pages/contact.mdx
@@ -17,6 +17,15 @@ sometimes flooded with requests for support and applications. We hope that [our
 reports](/transparency) and [FAQ](/faq)
 will answer some of the questions you might have.
 
+## Press Inquiries
+
+Are you a journalist, podcaster, or content creator looking to cover OpenSats?
+Do you need logos, brand assets, or background information for an upcoming
+story? Have a look at our [media kit](/media-kit) for downloadable assets and
+brand guidelines.
+
+For interviews, quotes, or other media requests, please reach out to press@opensats.org
+
 ## Partnerships
 
 Are you interested in partnering with OpenSats? Do you provide services that

--- a/data/pages/contact.mdx
+++ b/data/pages/contact.mdx
@@ -44,3 +44,7 @@ There are plenty of things to do, and _many hands make light work_, as the
 saying goes. Interested?
 
 Send a short motivational letter to volunteer@opensats.org
+
+---
+
+<NewsletterSignup />

--- a/data/pages/contact.mdx
+++ b/data/pages/contact.mdx
@@ -9,7 +9,7 @@ Want to get in touch? Please reach out to:
 
 - support@opensats.org - for general inquiries & support
 - donate@opensats.org - if you need help with [making a donation](/donate)
-- press@opensats.org - for any media inquiries
+- press@opensats.org - for any press inquiries
 
 We will do our best to answer all questions and respond in a reasonable
 timeframe. That said, please remember that our operational team is small and


### PR DESCRIPTION
Updates the `/contact` page by replacing the outdated design section with a new `Press Inquiries` section that points journalists and podcasters at our `/media-kit` page, plus a few small wording and link cleanups.

---
**Build preview:**

- [/contact](https://os-website-git-contact-page-updates-opensats.vercel.app/contact)
