### PR TITLE
Redesign funds and project showcase pages

### DIFF
--- a/components/FundOverviewCard.tsx
+++ b/components/FundOverviewCard.tsx
@@ -1,4 +1,5 @@
 import type { Fund } from 'contentlayer/generated'
+import type { ReactNode } from 'react'
 import Image from '@/components/Image'
 import CustomLink from '@/components/Link'
 import {
@@ -9,61 +10,49 @@ import {
 import type { Project } from 'contentlayer/generated'
 
 type Props = {
+  id?: string
   fund: Fund
   projects: Project[]
+  children?: ReactNode
 }
 
-export default function FundOverviewCard({ fund, projects }: Props) {
+export default function FundOverviewCard({
+  id,
+  fund,
+  projects,
+  children,
+}: Props) {
   const fundCopy = getFundPageCopy(fund.slug)
   const projectCount = countProjectsForFund(projects, fund.slug)
 
   return (
-    <article className="grid gap-6 border-t border-gray-200 py-8 dark:border-gray-800 md:grid-cols-[minmax(0,1fr)_96px]">
-      <div>
+    <article
+      id={id}
+      className="grid gap-8 border-t border-gray-200 py-10 dark:border-gray-800 md:grid-cols-[220px_minmax(0,1fr)]"
+    >
+      <div className="space-y-4">
         <p
           className={`text-xs font-semibold uppercase tracking-[0.18em] ${fundCopy.eyebrowClassName}`}
         >
           {fundCopy.eyebrow}
         </p>
-        <div className="mt-3">
+        <div className="flex items-start gap-4">
+          <div className="flex h-14 w-14 shrink-0 items-center justify-center border border-gray-200 p-3 dark:border-gray-800">
+            <Image
+              alt={fund.title}
+              src={fund.coverImage}
+              width={112}
+              height={112}
+              className="h-full w-full object-contain"
+            />
+          </div>
+
           <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
             {fund.title}
           </h2>
-          <p className="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">
-            {fund.summary}
-          </p>
         </div>
 
-        <p className="mt-5 text-sm leading-6 text-gray-600 dark:text-gray-300">
-          {fundCopy.helper}
-        </p>
-
-        <dl className="mt-6 grid gap-x-8 gap-y-4 text-sm sm:grid-cols-2">
-          <div>
-            <dt className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
-              Directory coverage
-            </dt>
-            <dd className="mt-1 font-semibold text-gray-900 dark:text-gray-100">
-              {projectCount > 0
-                ? `${projectCount} listed project${
-                    projectCount === 1 ? '' : 's'
-                  }`
-                : 'OpenSats operating costs'}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
-              Best used for
-            </dt>
-            <dd className="mt-1 font-semibold text-gray-900 dark:text-gray-100">
-              {fund.slug === 'ops'
-                ? 'Keeping the organization running'
-                : 'Routing donations by mission area'}
-            </dd>
-          </div>
-        </dl>
-
-        <div className="mt-6 flex flex-wrap gap-x-6 gap-y-2 text-sm font-semibold">
+        <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm font-semibold">
           <CustomLink
             href={`/funds/${fund.slug}`}
             className="text-gray-900 underline decoration-gray-300 underline-offset-4 hover:text-primary-500 dark:text-gray-100 dark:decoration-gray-700 dark:hover:text-primary-400"
@@ -77,16 +66,32 @@ export default function FundOverviewCard({ fund, projects }: Props) {
             Give monthly
           </CustomLink>
         </div>
+
+        <dl className="grid gap-y-3 text-sm">
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Directory coverage
+            </dt>
+            <dd className="mt-1 font-semibold text-gray-900 dark:text-gray-100">
+              {projectCount > 0
+                ? `${projectCount} listed project${
+                    projectCount === 1 ? '' : 's'
+                  }`
+                : 'OpenSats operating costs'}
+            </dd>
+          </div>
+        </dl>
       </div>
 
-      <div className="flex h-24 w-24 items-center justify-center self-start border border-gray-200 p-4 dark:border-gray-800">
-        <Image
-          alt={fund.title}
-          src={fund.coverImage}
-          width={160}
-          height={160}
-          className="h-full w-full object-contain"
-        />
+      <div className="space-y-5">
+        <p className="text-base leading-7 text-gray-900 dark:text-gray-100">
+          {fund.summary}
+        </p>
+        <p className="text-sm leading-7 text-gray-600 dark:text-gray-300">
+          {fundCopy.helper}
+        </p>
+
+        {children}
       </div>
     </article>
   )

--- a/components/FundOverviewCard.tsx
+++ b/components/FundOverviewCard.tsx
@@ -1,0 +1,92 @@
+import type { Fund } from 'contentlayer/generated'
+import Image from '@/components/Image'
+import CustomLink from '@/components/Link'
+import {
+  countProjectsForFund,
+  getFundDonateUrl,
+  getFundPageCopy,
+} from '@/utils/projectShowcase'
+import type { Project } from 'contentlayer/generated'
+
+type Props = {
+  fund: Fund
+  projects: Project[]
+}
+
+export default function FundOverviewCard({ fund, projects }: Props) {
+  const fundCopy = getFundPageCopy(fund.slug)
+  const projectCount = countProjectsForFund(projects, fund.slug)
+
+  return (
+    <article className="flex h-full flex-col rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-stone-900">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-3">
+          <span
+            className={`inline-flex rounded-full px-3 py-1 text-xs font-semibold ${fundCopy.badgeClassName}`}
+          >
+            {fundCopy.eyebrow}
+          </span>
+          <div>
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              {fund.title}
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">
+              {fund.summary}
+            </p>
+          </div>
+        </div>
+        <div className="flex h-20 w-20 shrink-0 items-center justify-center rounded-2xl bg-stone-50 p-3 dark:bg-stone-950">
+          <Image
+            alt={fund.title}
+            src={fund.coverImage}
+            width={160}
+            height={160}
+            className="h-full w-full object-contain"
+          />
+        </div>
+      </div>
+
+      <p className="mt-5 text-sm leading-6 text-gray-600 dark:text-gray-300">
+        {fundCopy.helper}
+      </p>
+
+      <dl className="mt-6 grid grid-cols-1 gap-4 border-t border-gray-200 pt-6 text-sm dark:border-gray-800 sm:grid-cols-2">
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            Directory coverage
+          </dt>
+          <dd className="mt-1 font-semibold text-gray-900 dark:text-gray-100">
+            {projectCount > 0
+              ? `${projectCount} listed project${projectCount === 1 ? '' : 's'}`
+              : 'OpenSats operating costs'}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            Best used for
+          </dt>
+          <dd className="mt-1 font-semibold text-gray-900 dark:text-gray-100">
+            {fund.slug === 'ops'
+              ? 'Keeping the organization running'
+              : 'Routing donations by mission area'}
+          </dd>
+        </div>
+      </dl>
+
+      <div className="mt-6 flex flex-wrap gap-3">
+        <CustomLink
+          href={`/funds/${fund.slug}`}
+          className="inline-flex rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-900 hover:border-primary-500 hover:text-primary-500 dark:border-gray-700 dark:text-gray-100 dark:hover:border-primary-400 dark:hover:text-primary-400"
+        >
+          Read fund page
+        </CustomLink>
+        <CustomLink
+          href={getFundDonateUrl(fund.slug)}
+          className="inline-flex rounded-full bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-500 dark:bg-white dark:text-black dark:hover:bg-primary-400"
+        >
+          Give monthly
+        </CustomLink>
+      </div>
+    </article>
+  )
+}

--- a/components/FundOverviewCard.tsx
+++ b/components/FundOverviewCard.tsx
@@ -18,74 +18,75 @@ export default function FundOverviewCard({ fund, projects }: Props) {
   const projectCount = countProjectsForFund(projects, fund.slug)
 
   return (
-    <article className="flex h-full flex-col rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-stone-900">
-      <div className="flex items-start justify-between gap-4">
-        <div className="space-y-3">
-          <span
-            className={`inline-flex rounded-full px-3 py-1 text-xs font-semibold ${fundCopy.badgeClassName}`}
-          >
-            {fundCopy.eyebrow}
-          </span>
-          <div>
-            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-              {fund.title}
-            </h2>
-            <p className="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">
-              {fund.summary}
-            </p>
-          </div>
+    <article className="grid gap-6 border-t border-gray-200 py-8 dark:border-gray-800 md:grid-cols-[minmax(0,1fr)_96px]">
+      <div>
+        <p
+          className={`text-xs font-semibold uppercase tracking-[0.18em] ${fundCopy.eyebrowClassName}`}
+        >
+          {fundCopy.eyebrow}
+        </p>
+        <div className="mt-3">
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            {fund.title}
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">
+            {fund.summary}
+          </p>
         </div>
-        <div className="flex h-20 w-20 shrink-0 items-center justify-center rounded-2xl bg-stone-50 p-3 dark:bg-stone-950">
-          <Image
-            alt={fund.title}
-            src={fund.coverImage}
-            width={160}
-            height={160}
-            className="h-full w-full object-contain"
-          />
+
+        <p className="mt-5 text-sm leading-6 text-gray-600 dark:text-gray-300">
+          {fundCopy.helper}
+        </p>
+
+        <dl className="mt-6 grid gap-x-8 gap-y-4 text-sm sm:grid-cols-2">
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Directory coverage
+            </dt>
+            <dd className="mt-1 font-semibold text-gray-900 dark:text-gray-100">
+              {projectCount > 0
+                ? `${projectCount} listed project${
+                    projectCount === 1 ? '' : 's'
+                  }`
+                : 'OpenSats operating costs'}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Best used for
+            </dt>
+            <dd className="mt-1 font-semibold text-gray-900 dark:text-gray-100">
+              {fund.slug === 'ops'
+                ? 'Keeping the organization running'
+                : 'Routing donations by mission area'}
+            </dd>
+          </div>
+        </dl>
+
+        <div className="mt-6 flex flex-wrap gap-x-6 gap-y-2 text-sm font-semibold">
+          <CustomLink
+            href={`/funds/${fund.slug}`}
+            className="text-gray-900 underline decoration-gray-300 underline-offset-4 hover:text-primary-500 dark:text-gray-100 dark:decoration-gray-700 dark:hover:text-primary-400"
+          >
+            Read fund page
+          </CustomLink>
+          <CustomLink
+            href={getFundDonateUrl(fund.slug)}
+            className="text-gray-900 underline decoration-gray-300 underline-offset-4 hover:text-primary-500 dark:text-gray-100 dark:decoration-gray-700 dark:hover:text-primary-400"
+          >
+            Give monthly
+          </CustomLink>
         </div>
       </div>
 
-      <p className="mt-5 text-sm leading-6 text-gray-600 dark:text-gray-300">
-        {fundCopy.helper}
-      </p>
-
-      <dl className="mt-6 grid grid-cols-1 gap-4 border-t border-gray-200 pt-6 text-sm dark:border-gray-800 sm:grid-cols-2">
-        <div>
-          <dt className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
-            Directory coverage
-          </dt>
-          <dd className="mt-1 font-semibold text-gray-900 dark:text-gray-100">
-            {projectCount > 0
-              ? `${projectCount} listed project${projectCount === 1 ? '' : 's'}`
-              : 'OpenSats operating costs'}
-          </dd>
-        </div>
-        <div>
-          <dt className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
-            Best used for
-          </dt>
-          <dd className="mt-1 font-semibold text-gray-900 dark:text-gray-100">
-            {fund.slug === 'ops'
-              ? 'Keeping the organization running'
-              : 'Routing donations by mission area'}
-          </dd>
-        </div>
-      </dl>
-
-      <div className="mt-6 flex flex-wrap gap-3">
-        <CustomLink
-          href={`/funds/${fund.slug}`}
-          className="inline-flex rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-900 hover:border-primary-500 hover:text-primary-500 dark:border-gray-700 dark:text-gray-100 dark:hover:border-primary-400 dark:hover:text-primary-400"
-        >
-          Read fund page
-        </CustomLink>
-        <CustomLink
-          href={getFundDonateUrl(fund.slug)}
-          className="inline-flex rounded-full bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-500 dark:bg-white dark:text-black dark:hover:bg-primary-400"
-        >
-          Give monthly
-        </CustomLink>
+      <div className="flex h-24 w-24 items-center justify-center self-start border border-gray-200 p-4 dark:border-gray-800">
+        <Image
+          alt={fund.title}
+          src={fund.coverImage}
+          width={160}
+          height={160}
+          className="h-full w-full object-contain"
+        />
       </div>
     </article>
   )

--- a/components/ProjectDirectoryCard.tsx
+++ b/components/ProjectDirectoryCard.tsx
@@ -1,0 +1,85 @@
+import type { Project } from 'contentlayer/generated'
+import Image from '@/components/Image'
+import CustomLink from '@/components/Link'
+import { getFundPageCopy } from '@/utils/projectShowcase'
+
+type Props = {
+  project: Project
+}
+
+export default function ProjectDirectoryCard({ project }: Props) {
+  const fundCopy = project.fund ? getFundPageCopy(project.fund) : null
+  const tags = project.tags?.slice(0, 3) || []
+
+  return (
+    <article className="flex h-full flex-col rounded-3xl border border-gray-200 bg-white p-5 shadow-sm transition-colors hover:border-primary-500 dark:border-gray-800 dark:bg-stone-900">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="mb-3 flex flex-wrap gap-2">
+            {fundCopy && (
+              <span
+                className={`inline-flex rounded-full px-3 py-1 text-xs font-semibold ${fundCopy.badgeClassName}`}
+              >
+                {project.fund === 'nostr' ? 'Nostr Fund' : 'General Fund'}
+              </span>
+            )}
+            {project.showcase && (
+              <span className="inline-flex rounded-full bg-stone-100 px-3 py-1 text-xs font-semibold text-stone-700 dark:bg-stone-800 dark:text-stone-200">
+                Highlighted
+              </span>
+            )}
+          </div>
+          <h3 className="text-xl font-bold leading-7 text-gray-900 dark:text-gray-100">
+            <CustomLink
+              href={`/projects/${project.slug}`}
+              className="hover:text-primary-500"
+            >
+              {project.title}
+            </CustomLink>
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            by {project.nym}
+          </p>
+        </div>
+        <div className="flex h-20 w-20 shrink-0 items-center justify-center rounded-2xl bg-stone-50 p-3 dark:bg-stone-950">
+          <Image
+            alt={project.title}
+            src={project.coverImage}
+            darkSrc={project.darkCoverImage}
+            width={160}
+            height={160}
+            className={`h-full w-full object-contain ${
+              project.invertDarkImage ? 'dark:invert' : ''
+            }`}
+          />
+        </div>
+      </div>
+
+      <p className="mt-4 flex-1 text-sm leading-6 text-gray-600 dark:text-gray-300">
+        {project.summary}
+      </p>
+
+      {tags.length > 0 && (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {tags.map((tag) => (
+            <span
+              key={tag}
+              className="rounded-full bg-stone-100 px-3 py-1 text-xs font-medium text-stone-700 dark:bg-stone-800 dark:text-stone-200"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-5">
+        <CustomLink
+          href={`/projects/${project.slug}`}
+          className="text-sm font-semibold text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+        >
+          View project &rarr;
+        </CustomLink>
+      </div>
+    </article>
+  )
+}

--- a/components/ProjectDirectoryCard.tsx
+++ b/components/ProjectDirectoryCard.tsx
@@ -1,5 +1,4 @@
 import type { Project } from 'contentlayer/generated'
-import Image from '@/components/Image'
 import CustomLink from '@/components/Link'
 import { getFundPageCopy } from '@/utils/projectShowcase'
 
@@ -20,7 +19,7 @@ export default function ProjectDirectoryCard({ project }: Props) {
   ].filter(Boolean)
 
   return (
-    <article className="grid gap-5 py-6 md:grid-cols-[minmax(0,1fr)_88px] md:gap-6">
+    <article className="grid gap-4 py-5 md:grid-cols-[220px_minmax(0,1fr)] md:gap-8">
       <div className="min-w-0">
         {meta.length > 0 && fundCopy && (
           <p
@@ -40,38 +39,27 @@ export default function ProjectDirectoryCard({ project }: Props) {
         <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
           by {project.nym}
         </p>
+      </div>
 
-        <p className="mt-4 text-sm leading-6 text-gray-600 dark:text-gray-300">
+      <div>
+        <p className="text-sm leading-6 text-gray-600 dark:text-gray-300">
           {project.summary}
         </p>
 
-        {tags.length > 0 && (
-          <p className="mt-3 text-xs uppercase tracking-[0.14em] text-gray-500 dark:text-gray-400">
-            {tags.join(' · ')}
-          </p>
-        )}
+        <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-sm">
+          {tags.length > 0 && (
+            <p className="text-xs uppercase tracking-[0.14em] text-gray-500 dark:text-gray-400">
+              {tags.join(' · ')}
+            </p>
+          )}
 
-        <div className="mt-4 text-sm font-semibold">
           <CustomLink
             href={`/projects/${project.slug}`}
-            className="text-gray-900 underline decoration-gray-300 underline-offset-4 hover:text-primary-500 dark:text-gray-100 dark:decoration-gray-700 dark:hover:text-primary-400"
+            className="font-semibold text-gray-900 underline decoration-gray-300 underline-offset-4 hover:text-primary-500 dark:text-gray-100 dark:decoration-gray-700 dark:hover:text-primary-400"
           >
             View project
           </CustomLink>
         </div>
-      </div>
-
-      <div className="flex h-20 w-20 items-center justify-center self-start border border-gray-200 p-3 dark:border-gray-800">
-        <Image
-          alt={project.title}
-          src={project.coverImage}
-          darkSrc={project.darkCoverImage}
-          width={160}
-          height={160}
-          className={`h-full w-full object-contain ${
-            project.invertDarkImage ? 'dark:invert' : ''
-          }`}
-        />
       </div>
     </article>
   )

--- a/components/ProjectDirectoryCard.tsx
+++ b/components/ProjectDirectoryCard.tsx
@@ -10,75 +10,68 @@ type Props = {
 export default function ProjectDirectoryCard({ project }: Props) {
   const fundCopy = project.fund ? getFundPageCopy(project.fund) : null
   const tags = project.tags?.slice(0, 3) || []
+  const meta = [
+    project.fund === 'nostr'
+      ? 'Nostr Fund'
+      : project.fund === 'general'
+      ? 'General Fund'
+      : null,
+    project.showcase ? 'Highlighted' : null,
+  ].filter(Boolean)
 
   return (
-    <article className="flex h-full flex-col rounded-3xl border border-gray-200 bg-white p-5 shadow-sm transition-colors hover:border-primary-500 dark:border-gray-800 dark:bg-stone-900">
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0 flex-1">
-          <div className="mb-3 flex flex-wrap gap-2">
-            {fundCopy && (
-              <span
-                className={`inline-flex rounded-full px-3 py-1 text-xs font-semibold ${fundCopy.badgeClassName}`}
-              >
-                {project.fund === 'nostr' ? 'Nostr Fund' : 'General Fund'}
-              </span>
-            )}
-            {project.showcase && (
-              <span className="inline-flex rounded-full bg-stone-100 px-3 py-1 text-xs font-semibold text-stone-700 dark:bg-stone-800 dark:text-stone-200">
-                Highlighted
-              </span>
-            )}
-          </div>
-          <h3 className="text-xl font-bold leading-7 text-gray-900 dark:text-gray-100">
-            <CustomLink
-              href={`/projects/${project.slug}`}
-              className="hover:text-primary-500"
-            >
-              {project.title}
-            </CustomLink>
-          </h3>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            by {project.nym}
+    <article className="grid gap-5 py-6 md:grid-cols-[minmax(0,1fr)_88px] md:gap-6">
+      <div className="min-w-0">
+        {meta.length > 0 && fundCopy && (
+          <p
+            className={`text-xs font-semibold uppercase tracking-[0.18em] ${fundCopy.eyebrowClassName}`}
+          >
+            {meta.join(' · ')}
           </p>
-        </div>
-        <div className="flex h-20 w-20 shrink-0 items-center justify-center rounded-2xl bg-stone-50 p-3 dark:bg-stone-950">
-          <Image
-            alt={project.title}
-            src={project.coverImage}
-            darkSrc={project.darkCoverImage}
-            width={160}
-            height={160}
-            className={`h-full w-full object-contain ${
-              project.invertDarkImage ? 'dark:invert' : ''
-            }`}
-          />
+        )}
+        <h3 className="mt-2 text-xl font-bold leading-7 text-gray-900 dark:text-gray-100">
+          <CustomLink
+            href={`/projects/${project.slug}`}
+            className="hover:text-primary-500"
+          >
+            {project.title}
+          </CustomLink>
+        </h3>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          by {project.nym}
+        </p>
+
+        <p className="mt-4 text-sm leading-6 text-gray-600 dark:text-gray-300">
+          {project.summary}
+        </p>
+
+        {tags.length > 0 && (
+          <p className="mt-3 text-xs uppercase tracking-[0.14em] text-gray-500 dark:text-gray-400">
+            {tags.join(' · ')}
+          </p>
+        )}
+
+        <div className="mt-4 text-sm font-semibold">
+          <CustomLink
+            href={`/projects/${project.slug}`}
+            className="text-gray-900 underline decoration-gray-300 underline-offset-4 hover:text-primary-500 dark:text-gray-100 dark:decoration-gray-700 dark:hover:text-primary-400"
+          >
+            View project
+          </CustomLink>
         </div>
       </div>
 
-      <p className="mt-4 flex-1 text-sm leading-6 text-gray-600 dark:text-gray-300">
-        {project.summary}
-      </p>
-
-      {tags.length > 0 && (
-        <div className="mt-4 flex flex-wrap gap-2">
-          {tags.map((tag) => (
-            <span
-              key={tag}
-              className="rounded-full bg-stone-100 px-3 py-1 text-xs font-medium text-stone-700 dark:bg-stone-800 dark:text-stone-200"
-            >
-              {tag}
-            </span>
-          ))}
-        </div>
-      )}
-
-      <div className="mt-5">
-        <CustomLink
-          href={`/projects/${project.slug}`}
-          className="text-sm font-semibold text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
-        >
-          View project &rarr;
-        </CustomLink>
+      <div className="flex h-20 w-20 items-center justify-center self-start border border-gray-200 p-3 dark:border-gray-800">
+        <Image
+          alt={project.title}
+          src={project.coverImage}
+          darkSrc={project.darkCoverImage}
+          width={160}
+          height={160}
+          className={`h-full w-full object-contain ${
+            project.invertDarkImage ? 'dark:invert' : ''
+          }`}
+        />
       </div>
     </article>
   )

--- a/components/ProjectGroup.tsx
+++ b/components/ProjectGroup.tsx
@@ -45,15 +45,15 @@ export default function ProjectGroup({
       </div>
 
       {projects.length > 0 ? (
-        <ul className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        <ul className="divide-y divide-gray-200 border-y border-gray-200 dark:divide-gray-800 dark:border-gray-800">
           {projects.map((project) => (
-            <li key={project.slug} className="h-full">
+            <li key={project.slug}>
               <ProjectDirectoryCard project={project} />
             </li>
           ))}
         </ul>
       ) : (
-        <p className="rounded-3xl border border-dashed border-gray-300 px-6 py-8 text-sm leading-6 text-gray-600 dark:border-gray-700 dark:text-gray-300">
+        <p className="border-y border-dashed border-gray-300 py-8 text-sm leading-6 text-gray-600 dark:border-gray-700 dark:text-gray-300">
           {emptyMessage || 'Nothing to show here yet.'}
         </p>
       )}

--- a/components/ProjectGroup.tsx
+++ b/components/ProjectGroup.tsx
@@ -1,0 +1,62 @@
+import type { Project } from 'contentlayer/generated'
+import CustomLink from '@/components/Link'
+import ProjectDirectoryCard from '@/components/ProjectDirectoryCard'
+
+type Props = {
+  id?: string
+  title: string
+  description?: string
+  projects: Project[]
+  emptyMessage?: string
+  ctaHref?: string
+  ctaLabel?: string
+}
+
+export default function ProjectGroup({
+  id,
+  title,
+  description,
+  projects,
+  emptyMessage,
+  ctaHref,
+  ctaLabel,
+}: Props) {
+  return (
+    <section id={id} className="space-y-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div className="max-w-3xl space-y-2">
+          <h2 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100">
+            {title}
+          </h2>
+          {description && (
+            <p className="text-base leading-7 text-gray-600 dark:text-gray-300">
+              {description}
+            </p>
+          )}
+        </div>
+        {ctaHref && ctaLabel && (
+          <CustomLink
+            href={ctaHref}
+            className="text-sm font-semibold text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+          >
+            {ctaLabel} &rarr;
+          </CustomLink>
+        )}
+      </div>
+
+      {projects.length > 0 ? (
+        <ul className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {projects.map((project) => (
+            <li key={project.slug} className="h-full">
+              <ProjectDirectoryCard project={project} />
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="rounded-3xl border border-dashed border-gray-300 px-6 py-8 text-sm leading-6 text-gray-600 dark:border-gray-700 dark:text-gray-300">
+          {emptyMessage || 'Nothing to show here yet.'}
+        </p>
+      )}
+    </section>
+  )
+}

--- a/pages/funds/index.tsx
+++ b/pages/funds/index.tsx
@@ -44,27 +44,27 @@ const FundsPage: NextPage<Props> = ({ funds, projects }) => {
             </p>
           </div>
 
-          <div className="flex flex-wrap gap-3">
+          <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm font-semibold">
             {funds.map((fund) => (
               <CustomLink
                 key={fund.slug}
                 href={`#${fund.slug}`}
-                className="inline-flex rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-900 hover:border-primary-500 hover:text-primary-500 dark:border-gray-700 dark:text-gray-100 dark:hover:border-primary-400 dark:hover:text-primary-400"
+                className="text-gray-900 underline decoration-gray-300 underline-offset-4 hover:text-primary-500 dark:text-gray-100 dark:decoration-gray-700 dark:hover:text-primary-400"
               >
                 {fund.title}
               </CustomLink>
             ))}
             <CustomLink
               href="/projects/showcase"
-              className="inline-flex rounded-full bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-500 dark:bg-white dark:text-black dark:hover:bg-primary-400"
+              className="text-gray-900 underline decoration-gray-300 underline-offset-4 hover:text-primary-500 dark:text-gray-100 dark:decoration-gray-700 dark:hover:text-primary-400"
             >
               Browse all projects
             </CustomLink>
           </div>
 
-          <ul className="grid gap-6 xl:grid-cols-3">
+          <ul className="border-b border-gray-200 dark:border-gray-800">
             {funds.map((fund) => (
-              <li key={fund.slug} className="h-full">
+              <li key={fund.slug}>
                 <FundOverviewCard fund={fund} projects={projects} />
               </li>
             ))}
@@ -81,14 +81,14 @@ const FundsPage: NextPage<Props> = ({ funds, projects }) => {
                 <section
                   key={fund.slug}
                   id={fund.slug}
-                  className="rounded-3xl border border-gray-200 bg-white p-8 shadow-sm dark:border-gray-800 dark:bg-stone-900"
+                  className="border-y border-gray-200 py-8 dark:border-gray-800"
                 >
                   <div className="max-w-3xl space-y-4">
-                    <span
-                      className={`inline-flex rounded-full px-3 py-1 text-xs font-semibold ${fundCopy.badgeClassName}`}
+                    <p
+                      className={`text-xs font-semibold uppercase tracking-[0.18em] ${fundCopy.eyebrowClassName}`}
                     >
                       {fundCopy.showcaseHeading}
-                    </span>
+                    </p>
                     <h2 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100">
                       {fund.title}
                     </h2>
@@ -103,16 +103,16 @@ const FundsPage: NextPage<Props> = ({ funds, projects }) => {
                     </p>
                   </div>
 
-                  <div className="mt-8 flex flex-wrap gap-3">
+                  <div className="mt-8 flex flex-wrap gap-x-6 gap-y-2 text-sm font-semibold">
                     <CustomLink
                       href={`/funds/${fund.slug}`}
-                      className="inline-flex rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-900 hover:border-primary-500 hover:text-primary-500 dark:border-gray-700 dark:text-gray-100 dark:hover:border-primary-400 dark:hover:text-primary-400"
+                      className="text-gray-900 underline decoration-gray-300 underline-offset-4 hover:text-primary-500 dark:text-gray-100 dark:decoration-gray-700 dark:hover:text-primary-400"
                     >
                       Read fund page
                     </CustomLink>
                     <CustomLink
                       href={getFundDonateUrl(fund.slug)}
-                      className="inline-flex rounded-full bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-500 dark:bg-white dark:text-black dark:hover:bg-primary-400"
+                      className="text-gray-900 underline decoration-gray-300 underline-offset-4 hover:text-primary-500 dark:text-gray-100 dark:decoration-gray-700 dark:hover:text-primary-400"
                     >
                       Give monthly
                     </CustomLink>

--- a/pages/funds/index.tsx
+++ b/pages/funds/index.tsx
@@ -4,10 +4,8 @@ import { allFunds, allProjects } from 'contentlayer/generated'
 import type { Fund, Project } from 'contentlayer/generated'
 import CustomLink from '@/components/Link'
 import FundOverviewCard from '@/components/FundOverviewCard'
-import ProjectGroup from '@/components/ProjectGroup'
+import ProjectDirectoryCard from '@/components/ProjectDirectoryCard'
 import {
-  getFeaturedProjectsForFund,
-  getFundDonateUrl,
   getFundPageCopy,
   getProjectsForFund,
   sortFunds,
@@ -25,8 +23,8 @@ const FundsPage: NextPage<Props> = ({ funds, projects }) => {
         <title>OpenSats | Funds</title>
       </Head>
 
-      <div className="space-y-16 pb-12 pt-6">
-        <section className="space-y-8">
+      <div className="space-y-14 pb-12 pt-6">
+        <section className="max-w-4xl space-y-5">
           <div className="max-w-4xl space-y-4">
             <h1 className="text-4xl font-extrabold tracking-tight text-gray-900 dark:text-gray-100 sm:text-5xl md:text-6xl">
               Choose a fund
@@ -41,6 +39,10 @@ const FundsPage: NextPage<Props> = ({ funds, projects }) => {
               listed projects and contributors. The Operations Budget covers the
               organization itself and keeps pass-through project donations
               intact.
+            </p>
+            <p className="text-base leading-7 text-gray-600 dark:text-gray-300">
+              Keep it simple: choose the mission area you want to support, then
+              donate into that bucket.
             </p>
           </div>
 
@@ -61,86 +63,57 @@ const FundsPage: NextPage<Props> = ({ funds, projects }) => {
               Browse all projects
             </CustomLink>
           </div>
-
-          <ul className="border-b border-gray-200 dark:border-gray-800">
-            {funds.map((fund) => (
-              <li key={fund.slug}>
-                <FundOverviewCard fund={fund} projects={projects} />
-              </li>
-            ))}
-          </ul>
         </section>
 
-        <div className="space-y-16">
+        <div className="border-b border-gray-200 dark:border-gray-800">
           {funds.map((fund) => {
             const fundCopy = getFundPageCopy(fund.slug)
             const fundProjects = getProjectsForFund(projects, fund.slug)
-
-            if (fund.slug === 'ops') {
-              return (
-                <section
-                  key={fund.slug}
-                  id={fund.slug}
-                  className="border-y border-gray-200 py-8 dark:border-gray-800"
-                >
-                  <div className="max-w-3xl space-y-4">
-                    <p
-                      className={`text-xs font-semibold uppercase tracking-[0.18em] ${fundCopy.eyebrowClassName}`}
-                    >
-                      {fundCopy.showcaseHeading}
-                    </p>
-                    <h2 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100">
-                      {fund.title}
-                    </h2>
-                    <p className="text-base leading-7 text-gray-600 dark:text-gray-300">
-                      {fund.summary}
-                    </p>
-                    <p className="text-base leading-7 text-gray-600 dark:text-gray-300">
-                      {fundCopy.helper}
-                    </p>
-                    <p className="text-base leading-7 text-gray-600 dark:text-gray-300">
-                      {fundCopy.emptyState}
-                    </p>
-                  </div>
-
-                  <div className="mt-8 flex flex-wrap gap-x-6 gap-y-2 text-sm font-semibold">
-                    <CustomLink
-                      href={`/funds/${fund.slug}`}
-                      className="text-gray-900 underline decoration-gray-300 underline-offset-4 hover:text-primary-500 dark:text-gray-100 dark:decoration-gray-700 dark:hover:text-primary-400"
-                    >
-                      Read fund page
-                    </CustomLink>
-                    <CustomLink
-                      href={getFundDonateUrl(fund.slug)}
-                      className="text-gray-900 underline decoration-gray-300 underline-offset-4 hover:text-primary-500 dark:text-gray-100 dark:decoration-gray-700 dark:hover:text-primary-400"
-                    >
-                      Give monthly
-                    </CustomLink>
-                  </div>
-                </section>
-              )
-            }
-
-            const featuredProjects = getFeaturedProjectsForFund(
-              projects,
-              fund.slug,
-              3
-            )
-            const projectCountLabel = `${fundProjects.length} listed project${
-              fundProjects.length === 1 ? '' : 's'
-            } currently sit under this fund in the directory.`
+            const previewProjects = fundProjects.slice(0, 3)
 
             return (
-              <ProjectGroup
+              <FundOverviewCard
                 key={fund.slug}
                 id={fund.slug}
-                title={fundCopy.showcaseHeading}
-                description={`${fundCopy.showcaseDescription} ${projectCountLabel}`}
-                projects={featuredProjects}
-                emptyMessage={fundCopy.emptyState}
-                ctaHref={`/projects/showcase#${fund.slug}-projects`}
-                ctaLabel={`Browse all ${fund.title} projects`}
-              />
+                fund={fund}
+                projects={projects}
+              >
+                {fund.slug === 'ops' ? (
+                  <p className="text-sm leading-7 text-gray-600 dark:text-gray-300">
+                    {fundCopy.emptyState}
+                  </p>
+                ) : (
+                  <div className="space-y-4 pt-1">
+                    <p className="text-sm leading-7 text-gray-600 dark:text-gray-300">
+                      {fundCopy.showcaseDescription} {fundProjects.length}{' '}
+                      listed project{fundProjects.length === 1 ? '' : 's'}
+                      currently sit under this fund.
+                    </p>
+
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-gray-500 dark:text-gray-400">
+                        Selected projects
+                      </p>
+                      <ul className="mt-3 divide-y divide-gray-200 border-y border-gray-200 dark:divide-gray-800 dark:border-gray-800">
+                        {previewProjects.map((project) => (
+                          <li key={project.slug}>
+                            <ProjectDirectoryCard project={project} />
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+
+                    <div className="text-sm font-semibold">
+                      <CustomLink
+                        href={`/projects/showcase#${fund.slug}-projects`}
+                        className="text-gray-900 underline decoration-gray-300 underline-offset-4 hover:text-primary-500 dark:text-gray-100 dark:decoration-gray-700 dark:hover:text-primary-400"
+                      >
+                        Browse all {fund.title} projects
+                      </CustomLink>
+                    </div>
+                  </div>
+                )}
+              </FundOverviewCard>
             )
           })}
         </div>

--- a/pages/funds/index.tsx
+++ b/pages/funds/index.tsx
@@ -1,99 +1,164 @@
 import type { NextPage } from 'next'
-import Link from '@/components/Link'
 import Head from 'next/head'
-import { useEffect, useState } from 'react'
-import ProjectCard from '../../components/ProjectCard'
-import { allProjects, allFunds } from 'contentlayer/generated'
-import { Project, Fund } from 'contentlayer/generated'
+import { allFunds, allProjects } from 'contentlayer/generated'
+import type { Fund, Project } from 'contentlayer/generated'
+import CustomLink from '@/components/Link'
+import FundOverviewCard from '@/components/FundOverviewCard'
+import ProjectGroup from '@/components/ProjectGroup'
+import {
+  getFeaturedProjectsForFund,
+  getFundDonateUrl,
+  getFundPageCopy,
+  getProjectsForFund,
+  sortFunds,
+} from '@/utils/projectShowcase'
 
-const AllProjects: NextPage<{ projects: Project[]; funds: Fund[] }> = ({
-  projects,
-  funds,
-}) => {
-  const [showcaseProjects, setShowcaseProjects] = useState<Project[]>()
-  const [openSatsFunds, setOpenSatsFunds] = useState<Fund[]>()
+type Props = {
+  funds: Fund[]
+  projects: Project[]
+}
 
-  useEffect(() => {
-    setShowcaseProjects(
-      projects
-        .filter(isShowcaseProject)
-        .sort(() => 0.5 - Math.random())
-        .slice(0, 12)
-    )
-    setOpenSatsFunds(funds.sort((a, b) => a.title.localeCompare(b.title)))
-  }, [projects, funds])
-
+const FundsPage: NextPage<Props> = ({ funds, projects }) => {
   return (
     <>
       <Head>
-        <title>OpenSats | Funds & Projects</title>
+        <title>OpenSats | Funds</title>
       </Head>
-      <section className="flex flex-col items-center p-4 md:p-8">
-        <div className="flex w-full items-center justify-between pb-8">
-          <h1 id="funds">Our Funds</h1>
-        </div>
-        <ul className="grid max-w-5xl grid-cols-2 gap-4 md:grid-cols-3">
-          {openSatsFunds &&
-            openSatsFunds.map((f, i) => (
-              <li key={i} className="">
-                <ProjectCard
-                  slug={`/funds/${f.slug}`}
-                  title={f.title}
-                  summary={f.summary}
-                  coverImage={f.coverImage}
-                  nym={f.nym}
-                  tags={f.tags}
-                  customImageStyles={{ objectFit: 'cover' }}
-                />
+
+      <div className="space-y-16 pb-12 pt-6">
+        <section className="space-y-8">
+          <div className="max-w-4xl space-y-4">
+            <h1 className="text-4xl font-extrabold tracking-tight text-gray-900 dark:text-gray-100 sm:text-5xl md:text-6xl">
+              Choose a fund
+            </h1>
+            <p className="text-lg leading-8 text-gray-600 dark:text-gray-300">
+              OpenSats runs three separate funding buckets. This page is for the
+              donor decision first: what kind of work do you want your money to
+              support?
+            </p>
+            <p className="text-base leading-7 text-gray-600 dark:text-gray-300">
+              The General Fund and The Nostr Fund route donations outward to
+              listed projects and contributors. The Operations Budget covers the
+              organization itself and keeps pass-through project donations
+              intact.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            {funds.map((fund) => (
+              <CustomLink
+                key={fund.slug}
+                href={`#${fund.slug}`}
+                className="inline-flex rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-900 hover:border-primary-500 hover:text-primary-500 dark:border-gray-700 dark:text-gray-100 dark:hover:border-primary-400 dark:hover:text-primary-400"
+              >
+                {fund.title}
+              </CustomLink>
+            ))}
+            <CustomLink
+              href="/projects/showcase"
+              className="inline-flex rounded-full bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-500 dark:bg-white dark:text-black dark:hover:bg-primary-400"
+            >
+              Browse all projects
+            </CustomLink>
+          </div>
+
+          <ul className="grid gap-6 xl:grid-cols-3">
+            {funds.map((fund) => (
+              <li key={fund.slug} className="h-full">
+                <FundOverviewCard fund={fund} projects={projects} />
               </li>
             ))}
-        </ul>
-      </section>
-      <section className="flex flex-col p-4 md:p-8">
-        <div className="flex w-full items-center justify-between pb-8">
-          <h1 id="funds">Project Showcase</h1>
+          </ul>
+        </section>
+
+        <div className="space-y-16">
+          {funds.map((fund) => {
+            const fundCopy = getFundPageCopy(fund.slug)
+            const fundProjects = getProjectsForFund(projects, fund.slug)
+
+            if (fund.slug === 'ops') {
+              return (
+                <section
+                  key={fund.slug}
+                  id={fund.slug}
+                  className="rounded-3xl border border-gray-200 bg-white p-8 shadow-sm dark:border-gray-800 dark:bg-stone-900"
+                >
+                  <div className="max-w-3xl space-y-4">
+                    <span
+                      className={`inline-flex rounded-full px-3 py-1 text-xs font-semibold ${fundCopy.badgeClassName}`}
+                    >
+                      {fundCopy.showcaseHeading}
+                    </span>
+                    <h2 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100">
+                      {fund.title}
+                    </h2>
+                    <p className="text-base leading-7 text-gray-600 dark:text-gray-300">
+                      {fund.summary}
+                    </p>
+                    <p className="text-base leading-7 text-gray-600 dark:text-gray-300">
+                      {fundCopy.helper}
+                    </p>
+                    <p className="text-base leading-7 text-gray-600 dark:text-gray-300">
+                      {fundCopy.emptyState}
+                    </p>
+                  </div>
+
+                  <div className="mt-8 flex flex-wrap gap-3">
+                    <CustomLink
+                      href={`/funds/${fund.slug}`}
+                      className="inline-flex rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-900 hover:border-primary-500 hover:text-primary-500 dark:border-gray-700 dark:text-gray-100 dark:hover:border-primary-400 dark:hover:text-primary-400"
+                    >
+                      Read fund page
+                    </CustomLink>
+                    <CustomLink
+                      href={getFundDonateUrl(fund.slug)}
+                      className="inline-flex rounded-full bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-500 dark:bg-white dark:text-black dark:hover:bg-primary-400"
+                    >
+                      Give monthly
+                    </CustomLink>
+                  </div>
+                </section>
+              )
+            }
+
+            const featuredProjects = getFeaturedProjectsForFund(
+              projects,
+              fund.slug,
+              3
+            )
+            const projectCountLabel = `${fundProjects.length} listed project${
+              fundProjects.length === 1 ? '' : 's'
+            } currently sit under this fund in the directory.`
+
+            return (
+              <ProjectGroup
+                key={fund.slug}
+                id={fund.slug}
+                title={fundCopy.showcaseHeading}
+                description={`${fundCopy.showcaseDescription} ${projectCountLabel}`}
+                projects={featuredProjects}
+                emptyMessage={fundCopy.emptyState}
+                ctaHref={`/projects/showcase#${fund.slug}-projects`}
+                ctaLabel={`Browse all ${fund.title} projects`}
+              />
+            )
+          })}
         </div>
-        <ul className="grid max-w-5xl grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-4">
-          {showcaseProjects &&
-            showcaseProjects.map((p, i) => (
-              <li key={i} className="">
-                <ProjectCard
-                  slug={`/projects/${p.slug}`}
-                  title={p.title}
-                  summary={p.summary}
-                  coverImage={p.coverImage}
-                  darkCoverImage={p.darkCoverImage}
-                  invertDarkImage={p.invertDarkImage}
-                  nym={p.nym}
-                  tags={p.tags}
-                />
-              </li>
-            ))}
-        </ul>
-        <div className="flex justify-end pt-4 text-base font-medium leading-6">
-          <Link
-            href="/projects/showcase"
-            className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
-            aria-label="View Project Showcase"
-          >
-            More Projects &rarr;
-          </Link>
-        </div>
-      </section>
+      </div>
     </>
   )
 }
 
-export default AllProjects
+export default FundsPage
 
 export async function getStaticProps() {
-  const projects = allProjects
-  const funds = allFunds
+  const funds = sortFunds(allFunds.filter((fund) => !fund.hidden))
+  const projects = allProjects.filter((project) => !project.hidden)
 
   return {
     props: {
-      projects,
       funds,
+      projects,
     },
   }
 }
@@ -107,5 +172,5 @@ export function isNotOpenSatsProject(project: Project): boolean {
 }
 
 export function isShowcaseProject(project: Project): boolean {
-  return isNotOpenSatsProject(project) && project.showcase
+  return isNotOpenSatsProject(project) && Boolean(project.showcase)
 }

--- a/pages/projects/showcase.tsx
+++ b/pages/projects/showcase.tsx
@@ -4,28 +4,17 @@ import { allProjects } from 'contentlayer/generated'
 import type { Project } from 'contentlayer/generated'
 import CustomLink from '@/components/Link'
 import ProjectGroup from '@/components/ProjectGroup'
-import {
-  getFundPageCopy,
-  getHighlightedProjects,
-  getProjectsForFund,
-} from '@/utils/projectShowcase'
+import { getFundPageCopy, getProjectsForFund } from '@/utils/projectShowcase'
 
 type Props = {
   projects: Project[]
 }
 
 const ProjectShowcase: NextPage<Props> = ({ projects }) => {
-  const highlightedProjects = getHighlightedProjects(projects)
-  const highlightedProjectCount = projects.filter(
-    (project) => project.showcase
-  ).length
   const generalProjects = getProjectsForFund(projects, 'general')
   const nostrProjects = getProjectsForFund(projects, 'nostr')
   const generalCopy = getFundPageCopy('general')
   const nostrCopy = getFundPageCopy('nostr')
-  const representedFunds = new Set(
-    projects.map((project) => project.fund).filter(Boolean)
-  ).size
 
   return (
     <>
@@ -33,8 +22,8 @@ const ProjectShowcase: NextPage<Props> = ({ projects }) => {
         <title>OpenSats | Project Showcase</title>
       </Head>
 
-      <div className="space-y-16 pb-12 pt-6">
-        <section className="space-y-8">
+      <div className="space-y-14 pb-12 pt-6">
+        <section className="max-w-4xl space-y-5">
           <div className="max-w-4xl space-y-4">
             <h1 className="text-4xl font-extrabold tracking-tight text-gray-900 dark:text-gray-100 sm:text-5xl md:text-6xl">
               Project showcase
@@ -44,45 +33,12 @@ const ProjectShowcase: NextPage<Props> = ({ projects }) => {
               fund they sit under.
             </p>
             <p className="text-base leading-7 text-gray-600 dark:text-gray-300">
-              Each entry leads with the work itself and sends you into the full
-              project page for background, funding context, and announcements.
+              Projects marked for showcase rise to the top inside each section.
+              Everything else follows alphabetically.
             </p>
           </div>
 
-          <dl className="grid gap-6 border-y border-gray-200 py-6 dark:border-gray-800 sm:grid-cols-3">
-            <div>
-              <div className="text-sm font-medium text-gray-500 dark:text-gray-400">
-                Listed projects
-              </div>
-              <div className="mt-2 text-3xl font-bold text-gray-900 dark:text-gray-100">
-                {projects.length}
-              </div>
-            </div>
-            <div>
-              <div className="text-sm font-medium text-gray-500 dark:text-gray-400">
-                Highlighted projects
-              </div>
-              <div className="mt-2 text-3xl font-bold text-gray-900 dark:text-gray-100">
-                {highlightedProjectCount}
-              </div>
-            </div>
-            <div>
-              <div className="text-sm font-medium text-gray-500 dark:text-gray-400">
-                Funding tracks represented
-              </div>
-              <div className="mt-2 text-3xl font-bold text-gray-900 dark:text-gray-100">
-                {representedFunds}
-              </div>
-            </div>
-          </dl>
-
           <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm font-semibold">
-            <CustomLink
-              href="#highlights"
-              className="text-gray-900 underline decoration-gray-300 underline-offset-4 hover:text-primary-500 dark:text-gray-100 dark:decoration-gray-700 dark:hover:text-primary-400"
-            >
-              Highlights
-            </CustomLink>
             <CustomLink
               href="#general-projects"
               className="text-gray-900 underline decoration-gray-300 underline-offset-4 hover:text-primary-500 dark:text-gray-100 dark:decoration-gray-700 dark:hover:text-primary-400"
@@ -103,15 +59,6 @@ const ProjectShowcase: NextPage<Props> = ({ projects }) => {
             </CustomLink>
           </div>
         </section>
-
-        <ProjectGroup
-          id="highlights"
-          title="Highlighted projects"
-          description="A curated slice of projects that are already marked as highlights in content."
-          projects={highlightedProjects}
-          ctaHref="#general-projects"
-          ctaLabel="Jump into the full directory"
-        />
 
         <ProjectGroup
           id="general-projects"

--- a/pages/projects/showcase.tsx
+++ b/pages/projects/showcase.tsx
@@ -1,56 +1,141 @@
 import type { NextPage } from 'next'
 import Head from 'next/head'
-import { useEffect, useState } from 'react'
-import ProjectCard from '../../components/ProjectCard'
 import { allProjects } from 'contentlayer/generated'
-import { Project } from 'contentlayer/generated'
-import { isNotOpenSatsProject } from '../funds'
-import Link from '@/components/Link'
+import type { Project } from 'contentlayer/generated'
+import CustomLink from '@/components/Link'
+import ProjectGroup from '@/components/ProjectGroup'
+import {
+  getFundPageCopy,
+  getHighlightedProjects,
+  getProjectsForFund,
+} from '@/utils/projectShowcase'
 
-const ProjectShowcase: NextPage<{ projects: Project[] }> = ({ projects }) => {
-  const [sortedProjects, setSortedProjects] = useState<Project[]>()
+type Props = {
+  projects: Project[]
+}
 
-  useEffect(() => {
-    setSortedProjects(
-      projects.filter(isNotOpenSatsProject).sort(() => 0.5 - Math.random())
-    )
-  }, [projects])
+const ProjectShowcase: NextPage<Props> = ({ projects }) => {
+  const highlightedProjects = getHighlightedProjects(projects)
+  const highlightedProjectCount = projects.filter(
+    (project) => project.showcase
+  ).length
+  const generalProjects = getProjectsForFund(projects, 'general')
+  const nostrProjects = getProjectsForFund(projects, 'nostr')
+  const generalCopy = getFundPageCopy('general')
+  const nostrCopy = getFundPageCopy('nostr')
+  const representedFunds = new Set(
+    projects.map((project) => project.fund).filter(Boolean)
+  ).size
 
   return (
     <>
       <Head>
         <title>OpenSats | Project Showcase</title>
       </Head>
-      <section className="flex flex-col p-4 md:p-8">
-        <div className="flex w-full items-center justify-between pb-8">
-          <h1 id="funds">Project Showcase</h1>
-        </div>
-        <ul className="grid max-w-5xl grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-4">
-          {sortedProjects &&
-            sortedProjects.map((p, i) => (
-              <li key={i} className="">
-                <ProjectCard
-                  slug={`/projects/${p.slug}`}
-                  title={p.title}
-                  summary={p.summary}
-                  coverImage={p.coverImage}
-                  darkCoverImage={p.darkCoverImage}
-                  invertDarkImage={p.invertDarkImage}
-                  nym={p.nym}
-                  tags={p.tags}
-                />
-              </li>
-            ))}
-        </ul>
-      </section>
-      <div className="flex justify-end pt-4 text-base font-medium leading-6">
-        <Link
-          href="/tags/grants"
-          className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
-          aria-label="All Grants"
-        >
-          All Grants &rarr;
-        </Link>
+
+      <div className="space-y-16 pb-12 pt-6">
+        <section className="space-y-8">
+          <div className="max-w-4xl space-y-4">
+            <h1 className="text-4xl font-extrabold tracking-tight text-gray-900 dark:text-gray-100 sm:text-5xl md:text-6xl">
+              Project showcase
+            </h1>
+            <p className="text-lg leading-8 text-gray-600 dark:text-gray-300">
+              Browse the projects currently listed on the site, grouped by the
+              fund they sit under.
+            </p>
+            <p className="text-base leading-7 text-gray-600 dark:text-gray-300">
+              Each card leads with the work itself and sends you into the full
+              project page for background, funding context, and announcements.
+            </p>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="rounded-3xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-stone-900">
+              <div className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                Listed projects
+              </div>
+              <div className="mt-2 text-3xl font-bold text-gray-900 dark:text-gray-100">
+                {projects.length}
+              </div>
+            </div>
+            <div className="rounded-3xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-stone-900">
+              <div className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                Highlighted projects
+              </div>
+              <div className="mt-2 text-3xl font-bold text-gray-900 dark:text-gray-100">
+                {highlightedProjectCount}
+              </div>
+            </div>
+            <div className="rounded-3xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-stone-900">
+              <div className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                Funding tracks represented
+              </div>
+              <div className="mt-2 text-3xl font-bold text-gray-900 dark:text-gray-100">
+                {representedFunds}
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <CustomLink
+              href="#highlights"
+              className="inline-flex rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-900 hover:border-primary-500 hover:text-primary-500 dark:border-gray-700 dark:text-gray-100 dark:hover:border-primary-400 dark:hover:text-primary-400"
+            >
+              Highlights
+            </CustomLink>
+            <CustomLink
+              href="#general-projects"
+              className="inline-flex rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-900 hover:border-primary-500 hover:text-primary-500 dark:border-gray-700 dark:text-gray-100 dark:hover:border-primary-400 dark:hover:text-primary-400"
+            >
+              General Fund
+            </CustomLink>
+            <CustomLink
+              href="#nostr-projects"
+              className="inline-flex rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-900 hover:border-primary-500 hover:text-primary-500 dark:border-gray-700 dark:text-gray-100 dark:hover:border-primary-400 dark:hover:text-primary-400"
+            >
+              Nostr Fund
+            </CustomLink>
+            <CustomLink
+              href="/funds"
+              className="inline-flex rounded-full bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-500 dark:bg-white dark:text-black dark:hover:bg-primary-400"
+            >
+              Compare funds
+            </CustomLink>
+          </div>
+        </section>
+
+        <ProjectGroup
+          id="highlights"
+          title="Highlighted projects"
+          description="A curated slice of projects that are already marked as highlights in content."
+          projects={highlightedProjects}
+          ctaHref="#general-projects"
+          ctaLabel="Jump into the full directory"
+        />
+
+        <ProjectGroup
+          id="general-projects"
+          title={generalCopy.showcaseHeading}
+          description={`${generalCopy.showcaseDescription} ${
+            generalProjects.length
+          } listed project${
+            generalProjects.length === 1 ? '' : 's'
+          } currently sit under this fund.`}
+          projects={generalProjects}
+          emptyMessage={generalCopy.emptyState}
+        />
+
+        <ProjectGroup
+          id="nostr-projects"
+          title={nostrCopy.showcaseHeading}
+          description={`${nostrCopy.showcaseDescription} ${
+            nostrProjects.length
+          } listed project${
+            nostrProjects.length === 1 ? '' : 's'
+          } currently sit under this fund.`}
+          projects={nostrProjects}
+          emptyMessage={nostrCopy.emptyState}
+        />
       </div>
     </>
   )
@@ -59,7 +144,7 @@ const ProjectShowcase: NextPage<{ projects: Project[] }> = ({ projects }) => {
 export default ProjectShowcase
 
 export async function getStaticProps() {
-  const projects = allProjects
+  const projects = allProjects.filter((project) => !project.hidden)
 
   return {
     props: {

--- a/pages/projects/showcase.tsx
+++ b/pages/projects/showcase.tsx
@@ -44,13 +44,13 @@ const ProjectShowcase: NextPage<Props> = ({ projects }) => {
               fund they sit under.
             </p>
             <p className="text-base leading-7 text-gray-600 dark:text-gray-300">
-              Each card leads with the work itself and sends you into the full
+              Each entry leads with the work itself and sends you into the full
               project page for background, funding context, and announcements.
             </p>
           </div>
 
-          <div className="grid gap-4 sm:grid-cols-3">
-            <div className="rounded-3xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-stone-900">
+          <dl className="grid gap-6 border-y border-gray-200 py-6 dark:border-gray-800 sm:grid-cols-3">
+            <div>
               <div className="text-sm font-medium text-gray-500 dark:text-gray-400">
                 Listed projects
               </div>
@@ -58,7 +58,7 @@ const ProjectShowcase: NextPage<Props> = ({ projects }) => {
                 {projects.length}
               </div>
             </div>
-            <div className="rounded-3xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-stone-900">
+            <div>
               <div className="text-sm font-medium text-gray-500 dark:text-gray-400">
                 Highlighted projects
               </div>
@@ -66,7 +66,7 @@ const ProjectShowcase: NextPage<Props> = ({ projects }) => {
                 {highlightedProjectCount}
               </div>
             </div>
-            <div className="rounded-3xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-stone-900">
+            <div>
               <div className="text-sm font-medium text-gray-500 dark:text-gray-400">
                 Funding tracks represented
               </div>
@@ -74,30 +74,30 @@ const ProjectShowcase: NextPage<Props> = ({ projects }) => {
                 {representedFunds}
               </div>
             </div>
-          </div>
+          </dl>
 
-          <div className="flex flex-wrap gap-3">
+          <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm font-semibold">
             <CustomLink
               href="#highlights"
-              className="inline-flex rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-900 hover:border-primary-500 hover:text-primary-500 dark:border-gray-700 dark:text-gray-100 dark:hover:border-primary-400 dark:hover:text-primary-400"
+              className="text-gray-900 underline decoration-gray-300 underline-offset-4 hover:text-primary-500 dark:text-gray-100 dark:decoration-gray-700 dark:hover:text-primary-400"
             >
               Highlights
             </CustomLink>
             <CustomLink
               href="#general-projects"
-              className="inline-flex rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-900 hover:border-primary-500 hover:text-primary-500 dark:border-gray-700 dark:text-gray-100 dark:hover:border-primary-400 dark:hover:text-primary-400"
+              className="text-gray-900 underline decoration-gray-300 underline-offset-4 hover:text-primary-500 dark:text-gray-100 dark:decoration-gray-700 dark:hover:text-primary-400"
             >
               General Fund
             </CustomLink>
             <CustomLink
               href="#nostr-projects"
-              className="inline-flex rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-900 hover:border-primary-500 hover:text-primary-500 dark:border-gray-700 dark:text-gray-100 dark:hover:border-primary-400 dark:hover:text-primary-400"
+              className="text-gray-900 underline decoration-gray-300 underline-offset-4 hover:text-primary-500 dark:text-gray-100 dark:decoration-gray-700 dark:hover:text-primary-400"
             >
               Nostr Fund
             </CustomLink>
             <CustomLink
               href="/funds"
-              className="inline-flex rounded-full bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-500 dark:bg-white dark:text-black dark:hover:bg-primary-400"
+              className="text-gray-900 underline decoration-gray-300 underline-offset-4 hover:text-primary-500 dark:text-gray-100 dark:decoration-gray-700 dark:hover:text-primary-400"
             >
               Compare funds
             </CustomLink>

--- a/utils/projectShowcase.ts
+++ b/utils/projectShowcase.ts
@@ -94,7 +94,16 @@ export function sortFunds(funds: Fund[]): Fund[] {
 }
 
 export function sortProjects(projects: Project[]): Project[] {
-  return [...projects].sort((a, b) => a.title.localeCompare(b.title))
+  return [...projects].sort((a, b) => {
+    const showcaseDelta =
+      Number(Boolean(b.showcase)) - Number(Boolean(a.showcase))
+
+    if (showcaseDelta !== 0) {
+      return showcaseDelta
+    }
+
+    return a.title.localeCompare(b.title)
+  })
 }
 
 export function getProjectsForFund(
@@ -102,32 +111,6 @@ export function getProjectsForFund(
   fundSlug: string
 ): Project[] {
   return sortProjects(projects.filter((project) => project.fund === fundSlug))
-}
-
-export function getFeaturedProjectsForFund(
-  projects: Project[],
-  fundSlug: string,
-  limit = 3
-): Project[] {
-  const matchingProjects = getProjectsForFund(projects, fundSlug)
-  const featuredProjects = matchingProjects.filter(
-    (project) => project.showcase
-  )
-  const remainingProjects = matchingProjects.filter(
-    (project) => !project.showcase
-  )
-
-  return [...featuredProjects, ...remainingProjects].slice(0, limit)
-}
-
-export function getHighlightedProjects(
-  projects: Project[],
-  limit = 6
-): Project[] {
-  return sortProjects(projects.filter((project) => project.showcase)).slice(
-    0,
-    limit
-  )
 }
 
 export function countProjectsForFund(

--- a/utils/projectShowcase.ts
+++ b/utils/projectShowcase.ts
@@ -1,0 +1,142 @@
+import type { Fund, Project } from 'contentlayer/generated'
+import { MONTHLY_DONATION_URL } from './constants'
+
+export const FUND_ORDER = ['general', 'nostr', 'ops'] as const
+
+export type FundSlug = (typeof FUND_ORDER)[number]
+
+type FundPageCopy = {
+  eyebrow: string
+  helper: string
+  showcaseHeading: string
+  showcaseDescription: string
+  emptyState: string
+  badgeClassName: string
+}
+
+const FUND_DESIGNATION_IDS: Partial<Record<FundSlug, string>> = {
+  nostr: 'ENWRA6YZ',
+  ops: 'ELL6P2J6',
+}
+
+const DEFAULT_BADGE_CLASS_NAME =
+  'bg-stone-100 text-stone-700 dark:bg-stone-800 dark:text-stone-200'
+
+const FUND_PAGE_COPY: Record<FundSlug, FundPageCopy> = {
+  general: {
+    eyebrow: 'Broad bitcoin and FOSS support',
+    helper:
+      'Use this fund when you want OpenSats to route capital across bitcoin, lightning, privacy, education, and adjacent open-source work.',
+    showcaseHeading: 'General Fund projects',
+    showcaseDescription:
+      'A cross-section of the bitcoin and freedom-tech work currently listed under the General Fund.',
+    emptyState: 'No listed projects are attached to this fund yet.',
+    badgeClassName:
+      'bg-orange-100 text-orange-800 dark:bg-orange-500/15 dark:text-orange-200',
+  },
+  nostr: {
+    eyebrow: 'Nostr protocol and ecosystem',
+    helper:
+      'Use this fund when you want to back the nostr protocol, clients, relays, and developer tooling.',
+    showcaseHeading: 'Nostr Fund projects',
+    showcaseDescription:
+      'Projects currently listed under the Nostr Fund, from clients and relays to publishing and identity tooling.',
+    emptyState: 'No listed projects are attached to this fund yet.',
+    badgeClassName:
+      'bg-purple-100 text-purple-800 dark:bg-purple-500/15 dark:text-purple-200',
+  },
+  ops: {
+    eyebrow: 'Keeps OpenSats running',
+    helper:
+      'Use this fund when you want to cover OpenSats operating costs and preserve 100% pass-through donations to supported projects.',
+    showcaseHeading: 'Operations Budget',
+    showcaseDescription:
+      'This bucket covers OpenSats itself, so there are no downstream project cards to browse here.',
+    emptyState:
+      'The Operations Budget covers OpenSats itself, so this section stays focused on the fund rather than downstream projects.',
+    badgeClassName:
+      'bg-sky-100 text-sky-800 dark:bg-sky-500/15 dark:text-sky-200',
+  },
+}
+
+export function getFundPageCopy(slug: string): FundPageCopy {
+  if (slug in FUND_PAGE_COPY) {
+    return FUND_PAGE_COPY[slug as FundSlug]
+  }
+
+  return {
+    eyebrow: 'Open-source funding',
+    helper: 'Support open-source builders through OpenSats.',
+    showcaseHeading: 'Projects',
+    showcaseDescription: 'Browse projects connected to this fund.',
+    emptyState: 'No listed projects are attached to this fund yet.',
+    badgeClassName: DEFAULT_BADGE_CLASS_NAME,
+  }
+}
+
+export function getFundDonateUrl(slug: string): string {
+  const designationId = FUND_DESIGNATION_IDS[slug as FundSlug]
+  return designationId
+    ? `${MONTHLY_DONATION_URL}?designationId=${designationId}`
+    : MONTHLY_DONATION_URL
+}
+
+export function sortFunds(funds: Fund[]): Fund[] {
+  return [...funds].sort((a, b) => {
+    const aIndex = FUND_ORDER.indexOf(a.slug as FundSlug)
+    const bIndex = FUND_ORDER.indexOf(b.slug as FundSlug)
+
+    if (aIndex === -1 && bIndex === -1) {
+      return a.title.localeCompare(b.title)
+    }
+
+    if (aIndex === -1) return 1
+    if (bIndex === -1) return -1
+
+    return aIndex - bIndex
+  })
+}
+
+export function sortProjects(projects: Project[]): Project[] {
+  return [...projects].sort((a, b) => a.title.localeCompare(b.title))
+}
+
+export function getProjectsForFund(
+  projects: Project[],
+  fundSlug: string
+): Project[] {
+  return sortProjects(projects.filter((project) => project.fund === fundSlug))
+}
+
+export function getFeaturedProjectsForFund(
+  projects: Project[],
+  fundSlug: string,
+  limit = 3
+): Project[] {
+  const matchingProjects = getProjectsForFund(projects, fundSlug)
+  const featuredProjects = matchingProjects.filter(
+    (project) => project.showcase
+  )
+  const remainingProjects = matchingProjects.filter(
+    (project) => !project.showcase
+  )
+
+  return [...featuredProjects, ...remainingProjects].slice(0, limit)
+}
+
+export function getHighlightedProjects(
+  projects: Project[],
+  limit = 6
+): Project[] {
+  return sortProjects(projects.filter((project) => project.showcase)).slice(
+    0,
+    limit
+  )
+}
+
+export function countProjectsForFund(
+  projects: Project[],
+  fundSlug: string
+): number {
+  return projects.filter((project) => project.fund === fundSlug).length
+}

--- a/utils/projectShowcase.ts
+++ b/utils/projectShowcase.ts
@@ -11,7 +11,7 @@ type FundPageCopy = {
   showcaseHeading: string
   showcaseDescription: string
   emptyState: string
-  badgeClassName: string
+  eyebrowClassName: string
 }
 
 const FUND_DESIGNATION_IDS: Partial<Record<FundSlug, string>> = {
@@ -19,8 +19,7 @@ const FUND_DESIGNATION_IDS: Partial<Record<FundSlug, string>> = {
   ops: 'ELL6P2J6',
 }
 
-const DEFAULT_BADGE_CLASS_NAME =
-  'bg-stone-100 text-stone-700 dark:bg-stone-800 dark:text-stone-200'
+const DEFAULT_EYEBROW_CLASS_NAME = 'text-stone-600 dark:text-stone-300'
 
 const FUND_PAGE_COPY: Record<FundSlug, FundPageCopy> = {
   general: {
@@ -31,8 +30,7 @@ const FUND_PAGE_COPY: Record<FundSlug, FundPageCopy> = {
     showcaseDescription:
       'A cross-section of the bitcoin and freedom-tech work currently listed under the General Fund.',
     emptyState: 'No listed projects are attached to this fund yet.',
-    badgeClassName:
-      'bg-orange-100 text-orange-800 dark:bg-orange-500/15 dark:text-orange-200',
+    eyebrowClassName: 'text-orange-700 dark:text-orange-300',
   },
   nostr: {
     eyebrow: 'Nostr protocol and ecosystem',
@@ -42,8 +40,7 @@ const FUND_PAGE_COPY: Record<FundSlug, FundPageCopy> = {
     showcaseDescription:
       'Projects currently listed under the Nostr Fund, from clients and relays to publishing and identity tooling.',
     emptyState: 'No listed projects are attached to this fund yet.',
-    badgeClassName:
-      'bg-purple-100 text-purple-800 dark:bg-purple-500/15 dark:text-purple-200',
+    eyebrowClassName: 'text-purple-700 dark:text-purple-300',
   },
   ops: {
     eyebrow: 'Keeps OpenSats running',
@@ -54,8 +51,7 @@ const FUND_PAGE_COPY: Record<FundSlug, FundPageCopy> = {
       'This bucket covers OpenSats itself, so there are no downstream project cards to browse here.',
     emptyState:
       'The Operations Budget covers OpenSats itself, so this section stays focused on the fund rather than downstream projects.',
-    badgeClassName:
-      'bg-sky-100 text-sky-800 dark:bg-sky-500/15 dark:text-sky-200',
+    eyebrowClassName: 'text-sky-700 dark:text-sky-300',
   },
 }
 
@@ -70,7 +66,7 @@ export function getFundPageCopy(slug: string): FundPageCopy {
     showcaseHeading: 'Projects',
     showcaseDescription: 'Browse projects connected to this fund.',
     emptyState: 'No listed projects are attached to this fund yet.',
-    badgeClassName: DEFAULT_BADGE_CLASS_NAME,
+    eyebrowClassName: DEFAULT_EYEBROW_CLASS_NAME,
   }
 }
 


### PR DESCRIPTION
This redesign turns `/funds` into a clearer fund chooser and reshapes `/projects/showcase` into a stable directory grouped by fund, using shared components instead of the old randomized card grids.

- adds shared `FundOverviewCard`, `ProjectDirectoryCard`, and `ProjectGroup` components plus shared fund/showcase helpers
- rewrites `/funds` around fund comparison, fund-specific project previews, and a dedicated `ops` section
- rewrites `/projects/showcase` into stable highlighted, `General Fund`, and `Nostr Fund` sections

---
Build preview:
- [`/funds`](https://os-website-git-feat-redesign-funds-showcase-opensats.vercel.app/funds)
- [`/projects/showcase`](https://os-website-git-feat-redesign-funds-showcase-opensats.vercel.app/projects/showcase)
