### PR TITLE
feat(showcase): redesign /funds and /projects/showcase

### DIFF
--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -1,17 +1,41 @@
 import Image from '@/components/Image'
 import Link from 'next/link'
-import { useState, useEffect } from 'react'
+import SocialIcon from '@/components/social-icons'
+
+const FUND_LABELS: Record<FundId, string> = {
+  general: 'General Fund',
+  nostr: 'Nostr Fund',
+  ops: 'Operations Budget',
+}
+
+export type FundId = 'general' | 'nostr' | 'ops'
+
+export type LastUpdate = { date: string; href: string }
 
 export type ProjectCardProps = {
-  slug
-  title
-  summary
-  coverImage
-  darkCoverImage?
-  invertDarkImage?
-  nym
-  tags
+  slug: string
+  title: string
+  summary: string
+  coverImage: string
+  darkCoverImage?: string
+  invertDarkImage?: boolean
+  nym: string
+  fund?: FundId
+  lastUpdate?: LastUpdate
+  git?: string
+  nostr?: string
+  heartbeat?: string
+  zapstore?: string
+  // Accepted for backwards compatibility; the redesigned card no longer
+  // surfaces tag chips or per-card image overrides.
+  tags?: string[]
   customImageStyles?: React.CSSProperties
+}
+
+function shortDate(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleString('en-US', { month: 'short', year: 'numeric' })
 }
 
 const ProjectCard: React.FC<ProjectCardProps> = ({
@@ -22,65 +46,79 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
   darkCoverImage,
   invertDarkImage,
   nym,
-  tags,
-  customImageStyles,
+  fund,
+  lastUpdate,
+  git,
+  nostr,
+  heartbeat,
+  zapstore,
 }) => {
-  const [isHorizontal, setIsHorizontal] = useState<boolean | null>(null)
-
-  useEffect(() => {
-    const img = document.createElement('img')
-    img.src = coverImage
-
-    // check if image is horizontal - added additional 10% to height to ensure only true
-    // horizontals get flagged.
-    img.onload = () => {
-      const { naturalWidth, naturalHeight } = img
-      const isHorizontal = naturalWidth >= naturalHeight * 1.1
-      setIsHorizontal(isHorizontal)
-    }
-  }, [coverImage])
-
-  let cardStyle
-  if (tags.includes('Nostr')) {
-    cardStyle =
-      'h-full space-y-4 rounded-xl border-b-4 border-purple-600 bg-stone-100 dark:border-purple-600 dark:bg-stone-900'
-  } else if (tags.includes('Lightning')) {
-    cardStyle =
-      'h-full space-y-4 rounded-xl border-b-4 border-yellow-300 bg-stone-100 dark:border-yellow-300 dark:bg-stone-900'
-  } else if (tags.includes('Bitcoin')) {
-    cardStyle =
-      'h-full space-y-4 rounded-xl border-b-4 border-orange-400 bg-stone-100 dark:border-orange-400 dark:bg-stone-900'
-  } else {
-    cardStyle =
-      'h-full space-y-4 rounded-xl border-b-4 border-stone-100 bg-stone-100 dark:border-stone-800 dark:bg-stone-900'
-  }
+  const hasFooter = Boolean(lastUpdate || git || heartbeat || nostr || zapstore)
 
   return (
-    <figure className={cardStyle}>
-      <Link href={`${slug}`} passHref>
-        <div className="flex h-36 w-full sm:h-52">
+    <figure className="flex h-full flex-col overflow-hidden rounded-xl bg-stone-100 dark:bg-stone-900">
+      <Link href={slug} className="block">
+        <div className="relative aspect-[4/3] w-full bg-white dark:bg-black">
           <Image
             alt={title}
             src={coverImage}
             darkSrc={darkCoverImage}
-            width={1200}
-            height={1200}
-            style={{
-              objectFit: isHorizontal ? 'fill' : 'cover',
-              ...customImageStyles,
-            }}
-            priority={true}
-            className={`cursor-pointer rounded-t-xl bg-white dark:bg-black ${
+            fill
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+            className={`cursor-pointer object-cover ${
               invertDarkImage ? 'dark:invert' : ''
             }`}
           />
         </div>
-        <figcaption className="p-2">
-          <h2 className="font-bold">{title}</h2>
-          <div className="mb-4 text-sm">by {nym}</div>
-          <div className="mb-2 line-clamp-3">{summary}</div>
-        </figcaption>
       </Link>
+      <figcaption className="flex flex-1 flex-col gap-2 p-4">
+        <h2 className="font-bold leading-tight">
+          <Link href={slug} className="hover:text-orange-500">
+            {title}
+          </Link>
+        </h2>
+        <div className="text-sm text-stone-500 dark:text-stone-400">
+          by {nym}
+          {fund && (
+            <>
+              {' · '}
+              <Link
+                href={`/funds/${fund}`}
+                className="underline-offset-2 hover:text-orange-500 hover:underline"
+              >
+                via the {FUND_LABELS[fund]}
+              </Link>
+            </>
+          )}
+        </div>
+        <p className="line-clamp-3 text-sm">{summary}</p>
+        {hasFooter && (
+          <div className="mt-auto flex items-center justify-between gap-2 pt-2 text-xs text-stone-500 dark:text-stone-400">
+            {lastUpdate ? (
+              <Link
+                href={lastUpdate.href}
+                className="underline-offset-2 hover:text-orange-500 hover:underline"
+              >
+                Last update · {shortDate(lastUpdate.date)}
+              </Link>
+            ) : (
+              <span />
+            )}
+            <span className="flex items-center gap-2 [&>a]:opacity-70 [&>a]:transition-opacity [&>a]:hover:opacity-100">
+              <SocialIcon kind="github" href={git} size={4} />
+              <SocialIcon kind="heartbeat" href={heartbeat} size={4} />
+              {nostr && (
+                <SocialIcon
+                  kind="nostr"
+                  href={`https://njump.to/${nostr}`}
+                  size={4}
+                />
+              )}
+              <SocialIcon kind="zapstore" href={zapstore} size={4} />
+            </span>
+          </div>
+        )}
+      </figcaption>
     </figure>
   )
 }

--- a/components/StatsSentence.tsx
+++ b/components/StatsSentence.tsx
@@ -2,31 +2,43 @@ import { useState, useEffect } from 'react'
 import Link from '@/components/Link'
 import PublicGoogleSheetsParser from 'public-google-sheets-parser'
 import { formatNumber } from '@/components/LifetimeStats'
+import {
+  LIFETIME_STATS_SHEET_ID,
+  type LifetimeStat,
+} from '@/utils/lifetimeStats'
 
 type StatsSentenceProps = {
   className?: string
+  initialStats?: LifetimeStat[] | null
 }
 
-export default function StatsSentence({ className = '' }: StatsSentenceProps) {
-  const [stats, setStats] = useState<{ label: string; value: number }[]>([])
+const skeleton = (
+  <span className="inline-block h-[1em] w-12 animate-pulse rounded bg-stone-200 align-middle dark:bg-stone-700" />
+)
+
+export default function StatsSentence({
+  className = '',
+  initialStats,
+}: StatsSentenceProps) {
+  const [stats, setStats] = useState<LifetimeStat[]>(initialStats ?? [])
 
   useEffect(() => {
-    const parser = new PublicGoogleSheetsParser(
-      '1mLEbHcrJibLN2PKxYq1LHJssq0CGuJRRoaZwot-ncZQ'
-    )
+    const parser = new PublicGoogleSheetsParser(LIFETIME_STATS_SHEET_ID)
     parser.parse().then((data) => {
-      setStats(data)
+      if (Array.isArray(data) && data.length > 0) {
+        setStats(data as LifetimeStat[])
+      }
     })
   }, [])
 
   // stats[0] = grants given, stats[1] = USD allocated, stats[2] = sats sent
-  const grantsGiven = stats[0]?.value ? formatNumber(stats[0].value) : '...'
+  const grantsGiven = stats[0]?.value ? formatNumber(stats[0].value) : null
   const usdAllocated = stats[1]?.value
     ? Math.round(stats[1].value).toLocaleString()
-    : '...'
+    : null
   const satsSent = stats[2]?.value
     ? formatNumber(stats[2].value).replace('B', 'billion')
-    : '...'
+    : null
 
   return (
     <p className={className}>
@@ -35,21 +47,21 @@ export default function StatsSentence({ className = '' }: StatsSentenceProps) {
         href="/transparency"
         className="-mx-1 rounded bg-primary-100/50 px-1 no-underline hover:bg-primary-100 dark:bg-primary-900/20 dark:hover:bg-primary-900/40"
       >
-        ${usdAllocated} USD
+        {usdAllocated ? <>${usdAllocated} USD</> : <>{skeleton} USD</>}
       </Link>{' '}
       to free and open-source projects and sent{' '}
       <Link
         href="/transparency"
         className="-mx-1 whitespace-nowrap rounded bg-primary-100/50 px-1 no-underline hover:bg-primary-100 dark:bg-primary-900/20 dark:hover:bg-primary-900/40"
       >
-        ~{satsSent} sats
+        {satsSent ? <>~{satsSent} sats</> : <>{skeleton} sats</>}
       </Link>{' '}
       to{' '}
       <Link
         href="/transparency"
         className="-mx-1 rounded bg-primary-100/50 px-1 no-underline hover:bg-primary-100 dark:bg-primary-900/20 dark:hover:bg-primary-900/40"
       >
-        {grantsGiven} grantees
+        {grantsGiven ? <>{grantsGiven} grantees</> : <>{skeleton} grantees</>}
       </Link>{' '}
       in{' '}
       <Link

--- a/pages/funds/index.tsx
+++ b/pages/funds/index.tsx
@@ -2,6 +2,7 @@ import type { GetStaticProps, NextPage } from 'next'
 import Head from 'next/head'
 import { useState } from 'react'
 import Link from '@/components/Link'
+import Image from '@/components/Image'
 import StatsSentence from '@/components/StatsSentence'
 import DonateRecurringButtonV2 from '@/components/DonateRecurringButtonV2'
 import PaymentModal from '@/components/PaymentModal'
@@ -9,6 +10,7 @@ import { allFunds } from 'contentlayer/generated'
 import type { Fund } from 'contentlayer/generated'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faBitcoin } from '@fortawesome/free-brands-svg-icons'
+import { MONTHLY_DONATION_URL } from '@/utils/constants'
 
 type FundsIndexProps = {
   funds: Fund[]
@@ -22,12 +24,13 @@ type FundConfig = {
   tagline: string
 }
 
-const FUND_ORDER: FundConfig[] = [
-  {
-    slug: 'general',
-    preTagline: 'Help us support',
-    tagline: 'Bitcoin & FOSS',
-  },
+const PRIMARY_FUND_CONFIG: FundConfig = {
+  slug: 'general',
+  preTagline: 'Help us support',
+  tagline: 'Bitcoin & FOSS',
+}
+
+const SECONDARY_FUND_CONFIGS: FundConfig[] = [
   {
     slug: 'nostr',
     designation: 'nostr',
@@ -43,12 +46,22 @@ const FUND_ORDER: FundConfig[] = [
   },
 ]
 
+const DESIGNATION_IDS = { nostr: 'ENWRA6YZ', ops: 'ELL6P2J6' } as const
+
+function getMonthlyDonationUrl(cfg: FundConfig): string {
+  return cfg.designation
+    ? `${MONTHLY_DONATION_URL}?designationId=${
+        DESIGNATION_IDS[cfg.designation]
+      }`
+    : MONTHLY_DONATION_URL
+}
+
 const FundsIndex: NextPage<FundsIndexProps> = ({ funds }) => {
   const [modalFund, setModalFund] = useState<Fund | undefined>(undefined)
-
   const closeModal = () => setModalFund(undefined)
 
-  const sections = FUND_ORDER.map((cfg) => ({
+  const primaryFund = funds.find((f) => f.slug === PRIMARY_FUND_CONFIG.slug)
+  const secondaryFunds = SECONDARY_FUND_CONFIGS.map((cfg) => ({
     cfg,
     fund: funds.find((f) => f.slug === cfg.slug),
   })).filter((s): s is { cfg: FundConfig; fund: Fund } => Boolean(s.fund))
@@ -70,64 +83,116 @@ const FundsIndex: NextPage<FundsIndexProps> = ({ funds }) => {
         <StatsSentence className="pt-4 text-lg leading-7 text-gray-500 dark:text-gray-400" />
       </section>
 
-      <ul className="divide-y divide-gray-200 dark:divide-gray-700">
-        {sections.map(({ cfg, fund }) => (
-          <li
-            key={fund.slug}
-            className="items-start py-10 first:pt-6 xl:grid xl:grid-cols-3 xl:gap-x-8"
-          >
-            <div></div>
-            <div className="flex flex-col gap-4 xl:col-span-2">
-              <div>
-                <h2 className="text-3xl font-bold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl">
-                  {fund.title}
-                </h2>
-                <p className="pt-2 text-lg leading-7 text-gray-500 dark:text-gray-400">
-                  {fund.summary}
-                </p>
-              </div>
-              <DonateRecurringButtonV2
-                designation={cfg.designation}
-                variant={cfg.variant}
-                preTagline={cfg.preTagline}
-                tagline={cfg.tagline}
-              />
-              <div className="flex flex-wrap items-center gap-4 text-base font-medium leading-6">
-                <button
-                  onClick={() => setModalFund(fund)}
-                  className="inline-flex items-center gap-1.5 text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
-                  aria-label={`Donate sats directly to the ${fund.title}`}
-                >
-                  <FontAwesomeIcon
-                    icon={faBitcoin}
-                    className="h-4 w-4"
-                    aria-hidden="true"
-                  />
-                  Donate sats directly &rarr;
-                </button>
-                <Link
-                  href={`/funds/${fund.slug}`}
-                  className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
-                  aria-label={`Read more about the ${fund.title}`}
-                >
-                  Read the fund page &rarr;
-                </Link>
-                {fund.heartbeat && (
-                  <Link
-                    href={fund.heartbeat}
-                    className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
-                    aria-label={`View ${fund.title} heartbeat`}
-                  >
-                    View heartbeat &rarr;
-                  </Link>
-                )}
-              </div>
+      {primaryFund && (
+        <section className="items-start py-10 xl:grid xl:grid-cols-3 xl:gap-x-8">
+          <div className="hidden pt-2 xl:flex xl:justify-center">
+            <Image
+              src={primaryFund.coverImage}
+              alt={primaryFund.title}
+              width={210}
+              height={210}
+              className="h-40 w-40"
+            />
+          </div>
+          <div className="flex flex-col gap-4 xl:col-span-2">
+            <div>
+              <h2 className="text-3xl font-bold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl">
+                {primaryFund.title}
+              </h2>
+              <p className="pt-2 text-lg leading-7 text-gray-500 dark:text-gray-400">
+                {primaryFund.summary}
+              </p>
             </div>
-          </li>
-        ))}
-      </ul>
+            <DonateRecurringButtonV2
+              designation={PRIMARY_FUND_CONFIG.designation}
+              variant={PRIMARY_FUND_CONFIG.variant}
+              preTagline={PRIMARY_FUND_CONFIG.preTagline}
+              tagline={PRIMARY_FUND_CONFIG.tagline}
+            />
+            <div className="flex flex-wrap items-center gap-4 text-base font-medium leading-6">
+              <button
+                onClick={() => setModalFund(primaryFund)}
+                className="inline-flex items-center gap-1.5 text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+                aria-label={`Donate sats directly to the ${primaryFund.title}`}
+              >
+                <FontAwesomeIcon
+                  icon={faBitcoin}
+                  className="h-4 w-4"
+                  aria-hidden="true"
+                />
+                Donate sats directly &rarr;
+              </button>
+              <Link
+                href={`/funds/${primaryFund.slug}`}
+                className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+                aria-label={`Read more about the ${primaryFund.title}`}
+              >
+                Read the fund page &rarr;
+              </Link>
+              {primaryFund.heartbeat && (
+                <Link
+                  href={primaryFund.heartbeat}
+                  className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+                  aria-label={`View ${primaryFund.title} heartbeat`}
+                >
+                  View heartbeat &rarr;
+                </Link>
+              )}
+            </div>
+          </div>
+        </section>
+      )}
 
-      <div className="flex justify-end pt-4 text-base font-medium leading-6">
+      {secondaryFunds.length > 0 && (
+        <section className="border-t border-gray-200 pt-10 dark:border-gray-700">
+          <h2 className="text-2xl font-bold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-3xl">
+            Designate your gift
+          </h2>
+          <p className="pt-1 text-base text-gray-500 dark:text-gray-400">
+            Earmark a recurring donation for a specific fund instead.
+          </p>
+          <div className="grid grid-cols-1 gap-6 pt-6 sm:grid-cols-2">
+            {secondaryFunds.map(({ cfg, fund }) => (
+              <article
+                key={fund.slug}
+                className="flex gap-4 rounded-xl bg-stone-100 p-4 dark:bg-stone-900"
+              >
+                <Image
+                  src={fund.coverImage}
+                  alt={fund.title}
+                  width={64}
+                  height={64}
+                  className="h-16 w-16 shrink-0 rounded-lg"
+                />
+                <div className="flex flex-1 flex-col gap-2">
+                  <h3 className="text-lg font-bold">{fund.title}</h3>
+                  <p className="line-clamp-2 text-sm text-gray-500 dark:text-gray-400">
+                    {fund.summary}
+                  </p>
+                  <div className="mt-auto flex flex-wrap gap-x-4 gap-y-1 pt-1 text-sm font-medium leading-6">
+                    <Link
+                      href={getMonthlyDonationUrl(cfg)}
+                      className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+                      aria-label={`Donate monthly to ${fund.title}`}
+                    >
+                      Donate monthly &rarr;
+                    </Link>
+                    <Link
+                      href={`/funds/${fund.slug}`}
+                      className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+                      aria-label={`Read more about ${fund.title}`}
+                    >
+                      Read the fund page &rarr;
+                    </Link>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <div className="flex justify-end pt-8 text-base font-medium leading-6">
         <Link
           href="/projects/showcase"
           className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"

--- a/pages/funds/index.tsx
+++ b/pages/funds/index.tsx
@@ -72,8 +72,12 @@ const FundsIndex: NextPage<FundsIndexProps> = ({ funds }) => {
 
       <ul className="divide-y divide-gray-200 dark:divide-gray-700">
         {sections.map(({ cfg, fund }) => (
-          <li key={fund.slug} className="py-10 first:pt-6">
-            <div className="flex flex-col gap-4">
+          <li
+            key={fund.slug}
+            className="items-start py-10 first:pt-6 xl:grid xl:grid-cols-3 xl:gap-x-8"
+          >
+            <div></div>
+            <div className="flex flex-col gap-4 xl:col-span-2">
               <div>
                 <h2 className="text-3xl font-bold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl">
                   {fund.title}

--- a/pages/funds/index.tsx
+++ b/pages/funds/index.tsx
@@ -1,111 +1,156 @@
-import type { NextPage } from 'next'
-import Link from '@/components/Link'
+import type { GetStaticProps, NextPage } from 'next'
 import Head from 'next/head'
-import { useEffect, useState } from 'react'
-import ProjectCard from '../../components/ProjectCard'
-import { allProjects, allFunds } from 'contentlayer/generated'
-import { Project, Fund } from 'contentlayer/generated'
+import { useState } from 'react'
+import Link from '@/components/Link'
+import StatsSentence from '@/components/StatsSentence'
+import DonateRecurringButtonV2 from '@/components/DonateRecurringButtonV2'
+import PaymentModal from '@/components/PaymentModal'
+import { allFunds } from 'contentlayer/generated'
+import type { Fund } from 'contentlayer/generated'
 
-const AllProjects: NextPage<{ projects: Project[]; funds: Fund[] }> = ({
-  projects,
-  funds,
-}) => {
-  const [showcaseProjects, setShowcaseProjects] = useState<Project[]>()
-  const [openSatsFunds, setOpenSatsFunds] = useState<Fund[]>()
+type FundsIndexProps = {
+  funds: Fund[]
+}
 
-  useEffect(() => {
-    setShowcaseProjects(
-      projects
-        .filter(isShowcaseProject)
-        .sort(() => 0.5 - Math.random())
-        .slice(0, 12)
-    )
-    setOpenSatsFunds(funds.sort((a, b) => a.title.localeCompare(b.title)))
-  }, [projects, funds])
+type FundConfig = {
+  slug: 'general' | 'nostr' | 'ops'
+  designation?: 'nostr' | 'ops'
+  variant?: 'orange' | 'purple'
+  preTagline: string
+  tagline: string
+}
+
+const FUND_ORDER: FundConfig[] = [
+  {
+    slug: 'general',
+    preTagline: 'Help us support',
+    tagline: 'Bitcoin & FOSS',
+  },
+  {
+    slug: 'nostr',
+    designation: 'nostr',
+    variant: 'purple',
+    preTagline: 'Help us support',
+    tagline: 'Nostr development',
+  },
+  {
+    slug: 'ops',
+    designation: 'ops',
+    preTagline: 'Help us keep',
+    tagline: 'OpenSats running',
+  },
+]
+
+const FundsIndex: NextPage<FundsIndexProps> = ({ funds }) => {
+  const [modalFund, setModalFund] = useState<Fund | undefined>(undefined)
+
+  const closeModal = () => setModalFund(undefined)
+
+  const sections = FUND_ORDER.map((cfg) => ({
+    cfg,
+    fund: funds.find((f) => f.slug === cfg.slug),
+  })).filter((s): s is { cfg: FundConfig; fund: Fund } => Boolean(s.fund))
 
   return (
     <>
       <Head>
-        <title>OpenSats | Funds & Projects</title>
+        <title>OpenSats | Funds</title>
       </Head>
-      <section className="flex flex-col items-center p-4 md:p-8">
-        <div className="flex w-full items-center justify-between pb-8">
-          <h1 id="funds">Our Funds</h1>
-        </div>
-        <ul className="grid max-w-5xl grid-cols-2 gap-4 md:grid-cols-3">
-          {openSatsFunds &&
-            openSatsFunds.map((f, i) => (
-              <li key={i} className="">
-                <ProjectCard
-                  slug={`/funds/${f.slug}`}
-                  title={f.title}
-                  summary={f.summary}
-                  coverImage={f.coverImage}
-                  nym={f.nym}
-                  tags={f.tags}
-                  customImageStyles={{ objectFit: 'cover' }}
-                />
-              </li>
-            ))}
-        </ul>
+      <section className="pt-4 md:pb-8">
+        <h1 className="py-2 text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 max-[375px]:text-2xl sm:text-3xl sm:leading-10 md:py-4 md:text-5xl md:leading-14 lg:text-6xl">
+          Where your money goes
+        </h1>
+        <p className="text-xl leading-7 text-gray-500 dark:text-gray-400">
+          OpenSats is a 501(c)(3) public charity. 100% of every dollar donated
+          to the General Fund and the Nostr Fund goes to grantees. Our own
+          bills are paid out of a separate Operations Budget.
+        </p>
+        <StatsSentence className="pt-4 text-lg leading-7 text-gray-500 dark:text-gray-400" />
       </section>
-      <section className="flex flex-col p-4 md:p-8">
-        <div className="flex w-full items-center justify-between pb-8">
-          <h1 id="funds">Project Showcase</h1>
-        </div>
-        <ul className="grid max-w-5xl grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-4">
-          {showcaseProjects &&
-            showcaseProjects.map((p, i) => (
-              <li key={i} className="">
-                <ProjectCard
-                  slug={`/projects/${p.slug}`}
-                  title={p.title}
-                  summary={p.summary}
-                  coverImage={p.coverImage}
-                  darkCoverImage={p.darkCoverImage}
-                  invertDarkImage={p.invertDarkImage}
-                  nym={p.nym}
-                  tags={p.tags}
-                />
-              </li>
-            ))}
-        </ul>
-        <div className="flex justify-end pt-4 text-base font-medium leading-6">
-          <Link
-            href="/projects/showcase"
-            className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
-            aria-label="View Project Showcase"
-          >
-            More Projects &rarr;
-          </Link>
-        </div>
-      </section>
+
+      <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+        {sections.map(({ cfg, fund }) => (
+          <li key={fund.slug} className="py-10 first:pt-6">
+            <div className="flex flex-col gap-4">
+              <div>
+                <h2 className="text-3xl font-bold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl">
+                  {fund.title}
+                </h2>
+                <p className="pt-2 text-lg leading-7 text-gray-500 dark:text-gray-400">
+                  {fund.summary}
+                </p>
+              </div>
+              <DonateRecurringButtonV2
+                designation={cfg.designation}
+                variant={cfg.variant}
+                preTagline={cfg.preTagline}
+                tagline={cfg.tagline}
+              />
+              <div className="flex flex-wrap items-center gap-4">
+                <button
+                  onClick={() => setModalFund(fund)}
+                  className="rounded border border-stone-800 bg-transparent px-4 py-2 font-semibold text-stone-800 hover:border-transparent hover:bg-orange-500 hover:text-stone-800 dark:border-white dark:text-white dark:hover:bg-orange-500 dark:hover:text-black"
+                >
+                  Donate sats directly
+                </button>
+                <Link
+                  href={`/funds/${fund.slug}`}
+                  className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+                  aria-label={`Read more about the ${fund.title}`}
+                >
+                  Read the fund page &rarr;
+                </Link>
+                {fund.heartbeat && (
+                  <Link
+                    href={fund.heartbeat}
+                    className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+                    aria-label={`View ${fund.title} heartbeat`}
+                  >
+                    View heartbeat &rarr;
+                  </Link>
+                )}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <div className="flex justify-end pt-4 text-base font-medium leading-6">
+        <Link
+          href="/projects/showcase"
+          className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+          aria-label="Browse all funded projects"
+        >
+          Browse all funded projects &rarr;
+        </Link>
+      </div>
+
+      <PaymentModal
+        isOpen={Boolean(modalFund)}
+        onRequestClose={closeModal}
+        fund={modalFund}
+      />
     </>
   )
 }
 
-export default AllProjects
+export default FundsIndex
 
-export async function getStaticProps() {
-  const projects = allProjects
-  const funds = allFunds
-
-  return {
-    props: {
-      projects,
-      funds,
-    },
-  }
+export const getStaticProps: GetStaticProps<FundsIndexProps> = async () => {
+  return { props: { funds: allFunds } }
 }
 
-export function isOpenSatsProject(project: Project): boolean {
+export function isOpenSatsProject(project: { nym: string }): boolean {
   return project.nym === 'OpenSats'
 }
 
-export function isNotOpenSatsProject(project: Project): boolean {
+export function isNotOpenSatsProject(project: { nym: string }): boolean {
   return !isOpenSatsProject(project)
 }
 
-export function isShowcaseProject(project: Project): boolean {
-  return isNotOpenSatsProject(project) && project.showcase
+export function isShowcaseProject(project: {
+  nym: string
+  showcase?: boolean
+}): boolean {
+  return isNotOpenSatsProject(project) && Boolean(project.showcase)
 }

--- a/pages/funds/index.tsx
+++ b/pages/funds/index.tsx
@@ -109,6 +109,7 @@ const FundsIndex: NextPage<FundsIndexProps> = ({ funds, lifetimeStats }) => {
               </p>
             </div>
             <DonateRecurringButtonV2
+              prelude=""
               designation={PRIMARY_FUND_CONFIG.designation}
               variant={PRIMARY_FUND_CONFIG.variant}
               preTagline={PRIMARY_FUND_CONFIG.preTagline}

--- a/pages/funds/index.tsx
+++ b/pages/funds/index.tsx
@@ -58,7 +58,7 @@ const FundsIndex: NextPage<FundsIndexProps> = ({ funds }) => {
       </Head>
       <section className="pt-4 md:pb-8">
         <h1 className="py-2 text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 max-[375px]:text-2xl sm:text-3xl sm:leading-10 md:py-4 md:text-5xl md:leading-14 lg:text-6xl">
-          Where your money goes
+          Make the most of your donation
         </h1>
         <p className="text-xl leading-7 text-gray-500 dark:text-gray-400">
           OpenSats is a 501(c)(3) public charity. 100% of every dollar donated

--- a/pages/funds/index.tsx
+++ b/pages/funds/index.tsx
@@ -7,6 +7,8 @@ import DonateRecurringButtonV2 from '@/components/DonateRecurringButtonV2'
 import PaymentModal from '@/components/PaymentModal'
 import { allFunds } from 'contentlayer/generated'
 import type { Fund } from 'contentlayer/generated'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faBitcoin } from '@fortawesome/free-brands-svg-icons'
 
 type FundsIndexProps = {
   funds: Fund[]
@@ -61,8 +63,8 @@ const FundsIndex: NextPage<FundsIndexProps> = ({ funds }) => {
           Make the most of your donation
         </h1>
         <p className="text-xl leading-7 text-gray-500 dark:text-gray-400">
-          OpenSats is a 501(c)(3) public charity. 100% of every sat donated
-          to the General Fund and the Nostr Fund goes to grantees. Our own bills
+          OpenSats is a 501(c)(3) public charity. 100% of every sat donated to
+          the General Fund and the Nostr Fund goes to grantees. Our own bills
           are paid out of a separate Operations Budget.
         </p>
         <StatsSentence className="pt-4 text-lg leading-7 text-gray-500 dark:text-gray-400" />
@@ -86,12 +88,18 @@ const FundsIndex: NextPage<FundsIndexProps> = ({ funds }) => {
                 preTagline={cfg.preTagline}
                 tagline={cfg.tagline}
               />
-              <div className="flex flex-wrap items-center gap-4">
+              <div className="flex flex-wrap items-center gap-4 text-base font-medium leading-6">
                 <button
                   onClick={() => setModalFund(fund)}
-                  className="rounded border border-stone-800 bg-transparent px-4 py-2 font-semibold text-stone-800 hover:border-transparent hover:bg-orange-500 hover:text-stone-800 dark:border-white dark:text-white dark:hover:bg-orange-500 dark:hover:text-black"
+                  className="inline-flex items-center gap-1.5 text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+                  aria-label={`Donate sats directly to the ${fund.title}`}
                 >
-                  Donate sats directly
+                  <FontAwesomeIcon
+                    icon={faBitcoin}
+                    className="h-4 w-4"
+                    aria-hidden="true"
+                  />
+                  Donate sats directly &rarr;
                 </button>
                 <Link
                   href={`/funds/${fund.slug}`}

--- a/pages/funds/index.tsx
+++ b/pages/funds/index.tsx
@@ -11,9 +11,11 @@ import type { Fund } from 'contentlayer/generated'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faBitcoin } from '@fortawesome/free-brands-svg-icons'
 import { MONTHLY_DONATION_URL } from '@/utils/constants'
+import { getLifetimeStats, type LifetimeStat } from '@/utils/lifetimeStats'
 
 type FundsIndexProps = {
   funds: Fund[]
+  lifetimeStats: LifetimeStat[] | null
 }
 
 type FundConfig = {
@@ -56,7 +58,7 @@ function getMonthlyDonationUrl(cfg: FundConfig): string {
     : MONTHLY_DONATION_URL
 }
 
-const FundsIndex: NextPage<FundsIndexProps> = ({ funds }) => {
+const FundsIndex: NextPage<FundsIndexProps> = ({ funds, lifetimeStats }) => {
   const [modalFund, setModalFund] = useState<Fund | undefined>(undefined)
   const closeModal = () => setModalFund(undefined)
 
@@ -80,7 +82,10 @@ const FundsIndex: NextPage<FundsIndexProps> = ({ funds }) => {
           the General Fund and the Nostr Fund goes to grantees. Our own bills
           are paid out of a separate Operations Budget.
         </p>
-        <StatsSentence className="pt-4 text-lg leading-7 text-gray-500 dark:text-gray-400" />
+        <StatsSentence
+          initialStats={lifetimeStats}
+          className="pt-4 text-lg leading-7 text-gray-500 dark:text-gray-400"
+        />
       </section>
 
       {primaryFund && (
@@ -214,7 +219,11 @@ const FundsIndex: NextPage<FundsIndexProps> = ({ funds }) => {
 export default FundsIndex
 
 export const getStaticProps: GetStaticProps<FundsIndexProps> = async () => {
-  return { props: { funds: allFunds } }
+  const lifetimeStats = await getLifetimeStats()
+  return {
+    props: { funds: allFunds, lifetimeStats },
+    revalidate: 60 * 60 * 12,
+  }
 }
 
 export function isOpenSatsProject(project: { nym: string }): boolean {

--- a/pages/funds/index.tsx
+++ b/pages/funds/index.tsx
@@ -62,8 +62,8 @@ const FundsIndex: NextPage<FundsIndexProps> = ({ funds }) => {
         </h1>
         <p className="text-xl leading-7 text-gray-500 dark:text-gray-400">
           OpenSats is a 501(c)(3) public charity. 100% of every dollar donated
-          to the General Fund and the Nostr Fund goes to grantees. Our own
-          bills are paid out of a separate Operations Budget.
+          to the General Fund and the Nostr Fund goes to grantees. Our own bills
+          are paid out of a separate Operations Budget.
         </p>
         <StatsSentence className="pt-4 text-lg leading-7 text-gray-500 dark:text-gray-400" />
       </section>

--- a/pages/funds/index.tsx
+++ b/pages/funds/index.tsx
@@ -115,7 +115,7 @@ const FundsIndex: NextPage<FundsIndexProps> = ({ funds, lifetimeStats }) => {
               preTagline={PRIMARY_FUND_CONFIG.preTagline}
               tagline={PRIMARY_FUND_CONFIG.tagline}
             />
-            <div className="flex flex-wrap items-center gap-4 text-base font-medium leading-6">
+            <div className="flex flex-wrap items-center justify-end gap-x-6 gap-y-2 text-base font-medium leading-6">
               <button
                 onClick={() => setModalFund(primaryFund)}
                 className="inline-flex items-center gap-1.5 text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"

--- a/pages/funds/index.tsx
+++ b/pages/funds/index.tsx
@@ -119,7 +119,7 @@ const FundsIndex: NextPage<FundsIndexProps> = ({ funds, lifetimeStats }) => {
               <button
                 onClick={() => setModalFund(primaryFund)}
                 className="inline-flex items-center gap-1.5 text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
-                aria-label={`Donate sats directly to the ${primaryFund.title}`}
+                aria-label={`Donate sats directly to ${primaryFund.title}`}
               >
                 <FontAwesomeIcon
                   icon={faBitcoin}
@@ -131,7 +131,7 @@ const FundsIndex: NextPage<FundsIndexProps> = ({ funds, lifetimeStats }) => {
               <Link
                 href={`/funds/${primaryFund.slug}`}
                 className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
-                aria-label={`Read more about the ${primaryFund.title}`}
+                aria-label={`Read more about ${primaryFund.title}`}
               >
                 Read the fund page &rarr;
               </Link>

--- a/pages/funds/index.tsx
+++ b/pages/funds/index.tsx
@@ -61,7 +61,7 @@ const FundsIndex: NextPage<FundsIndexProps> = ({ funds }) => {
           Make the most of your donation
         </h1>
         <p className="text-xl leading-7 text-gray-500 dark:text-gray-400">
-          OpenSats is a 501(c)(3) public charity. 100% of every dollar donated
+          OpenSats is a 501(c)(3) public charity. 100% of every sat donated
           to the General Fund and the Nostr Fund goes to grantees. Our own bills
           are paid out of a separate Operations Budget.
         </p>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -17,6 +17,7 @@ import { isShowcaseProject } from './funds'
 import Typing from '@/components/Typing'
 import CustomLink from '@/components/Link'
 import StatsSentence from '@/components/StatsSentence'
+import { getLifetimeStats } from '@/utils/lifetimeStats'
 
 const MAX_DISPLAY = 2
 
@@ -31,7 +32,12 @@ export const getStaticProps = async () => {
   const generalFund = allFunds.find((f) => f.slug === 'general')
   const opsFund = allFunds.find((f) => f.slug === 'ops')
 
-  return { props: { posts, projects, generalFund, opsFund } }
+  const lifetimeStats = await getLifetimeStats()
+
+  return {
+    props: { posts, projects, generalFund, opsFund, lifetimeStats },
+    revalidate: 60 * 60 * 12,
+  }
 }
 
 export default function Home({
@@ -39,6 +45,7 @@ export default function Home({
   projects,
   generalFund,
   opsFund,
+  lifetimeStats,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   const [modalOpen, setModalOpen] = useState(false)
 
@@ -170,7 +177,10 @@ export default function Home({
           <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 max-[375px]:text-2xl sm:text-3xl sm:leading-10 md:text-5xl md:leading-14 lg:text-6xl">
             Current Allocation
           </h1>
-          <StatsSentence className="text-2xl leading-9 text-gray-500 dark:text-gray-400" />
+          <StatsSentence
+            initialStats={lifetimeStats}
+            className="text-2xl leading-9 text-gray-500 dark:text-gray-400"
+          />
           <div className="flex justify-end text-base font-medium leading-6">
             <Link
               href="/transparency"

--- a/pages/projects/showcase.tsx
+++ b/pages/projects/showcase.tsx
@@ -1,55 +1,122 @@
-import type { NextPage } from 'next'
+import type { GetStaticProps, NextPage } from 'next'
 import Head from 'next/head'
-import { useEffect, useState } from 'react'
-import ProjectCard from '../../components/ProjectCard'
-import { allProjects } from 'contentlayer/generated'
-import { Project } from 'contentlayer/generated'
-import { isNotOpenSatsProject } from '../funds'
 import Link from '@/components/Link'
+import StatsSentence from '@/components/StatsSentence'
+import ProjectCard from '@/components/ProjectCard'
+import type { FundId } from '@/components/ProjectCard'
+import { allBlogs, allProjects } from 'contentlayer/generated'
+import type { Blog } from 'contentlayer/generated'
+import { sortedBlogPost } from 'pliny/utils/contentlayer'
+import { buildClusters } from '@/utils/projectClusters'
+import { getLatestPostForProject } from '@/utils/relatedPosts'
 
-const ProjectShowcase: NextPage<{ projects: Project[] }> = ({ projects }) => {
-  const [sortedProjects, setSortedProjects] = useState<Project[]>()
+type CardData = {
+  slug: string
+  title: string
+  summary: string
+  coverImage: string
+  darkCoverImage?: string
+  invertDarkImage?: boolean
+  nym: string
+  fund?: FundId
+  git?: string
+  nostr?: string
+  heartbeat?: string
+  zapstore?: string
+  lastUpdate?: { date: string; href: string }
+}
 
-  useEffect(() => {
-    setSortedProjects(
-      projects.filter(isNotOpenSatsProject).sort(() => 0.5 - Math.random())
-    )
-  }, [projects])
+type RenderCluster = {
+  id: string
+  title: string
+  blurb: string
+  projects: CardData[]
+}
 
+type ShowcaseProps = {
+  clusters: RenderCluster[]
+}
+
+const KNOWN_FUNDS: FundId[] = ['general', 'nostr', 'ops']
+
+function toCardData(
+  project: (typeof allProjects)[number],
+  sortedBlogs: Blog[]
+): CardData {
+  const latest = getLatestPostForProject(project, sortedBlogs)
+  const fund = (KNOWN_FUNDS as string[]).includes(project.fund || '')
+    ? (project.fund as FundId)
+    : undefined
+
+  return {
+    slug: `/projects/${project.slug}`,
+    title: project.title,
+    summary: project.summary,
+    coverImage: project.coverImage,
+    darkCoverImage: project.darkCoverImage,
+    invertDarkImage: project.invertDarkImage,
+    nym: project.nym,
+    fund,
+    git: project.git,
+    nostr: project.nostr,
+    heartbeat: project.heartbeat,
+    zapstore: project.zapstore,
+    lastUpdate: latest
+      ? { date: latest.date, href: `/blog/${latest.slug}` }
+      : undefined,
+  }
+}
+
+const ProjectShowcase: NextPage<ShowcaseProps> = ({ clusters }) => {
   return (
     <>
       <Head>
         <title>OpenSats | Project Showcase</title>
       </Head>
-      <section className="flex flex-col p-4 md:p-8">
-        <div className="flex w-full items-center justify-between pb-8">
-          <h1 id="funds">Project Showcase</h1>
-        </div>
-        <ul className="grid max-w-5xl grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-4">
-          {sortedProjects &&
-            sortedProjects.map((p, i) => (
-              <li key={i} className="">
-                <ProjectCard
-                  slug={`/projects/${p.slug}`}
-                  title={p.title}
-                  summary={p.summary}
-                  coverImage={p.coverImage}
-                  darkCoverImage={p.darkCoverImage}
-                  invertDarkImage={p.invertDarkImage}
-                  nym={p.nym}
-                  tags={p.tags}
-                />
-              </li>
-            ))}
-        </ul>
+
+      <section className="pt-4 md:pb-8">
+        <h1 className="py-2 text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 max-[375px]:text-2xl sm:text-3xl sm:leading-10 md:py-4 md:text-5xl md:leading-14 lg:text-6xl">
+          Project Showcase
+        </h1>
+        <StatsSentence className="text-lg leading-7 text-gray-500 dark:text-gray-400" />
       </section>
-      <div className="flex justify-end pt-4 text-base font-medium leading-6">
+
+      <div className="divide-y divide-gray-200 dark:divide-gray-700">
+        {clusters.map((cluster) => (
+          <section key={cluster.id} className="py-10 first:pt-6">
+            <div className="pb-6">
+              <h2 className="text-2xl font-bold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-3xl">
+                {cluster.title}
+              </h2>
+              <p className="pt-1 text-base text-gray-500 dark:text-gray-400">
+                {cluster.blurb}
+              </p>
+            </div>
+            <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {cluster.projects.map((p) => (
+                <li key={p.slug}>
+                  <ProjectCard {...p} />
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap justify-end gap-6 pt-4 text-base font-medium leading-6">
+        <Link
+          href="/apply"
+          className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+          aria-label="Apply for funding"
+        >
+          Apply for funding &rarr;
+        </Link>
         <Link
           href="/tags/grants"
           className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
-          aria-label="All Grants"
+          aria-label="All grant announcements"
         >
-          All Grants &rarr;
+          All grant announcements &rarr;
         </Link>
       </div>
     </>
@@ -58,12 +125,15 @@ const ProjectShowcase: NextPage<{ projects: Project[] }> = ({ projects }) => {
 
 export default ProjectShowcase
 
-export async function getStaticProps() {
-  const projects = allProjects
+export const getStaticProps: GetStaticProps<ShowcaseProps> = async () => {
+  const sortedBlogs = sortedBlogPost(allBlogs) as Blog[]
+  const clusters: RenderCluster[] = buildClusters(allProjects).map((c) => ({
+    id: c.id,
+    title: c.title,
+    blurb: c.blurb,
+    projects: c.projects.map((p) => toCardData(p, sortedBlogs)),
+  }))
 
-  return {
-    props: {
-      projects,
-    },
-  }
+  // Strip `undefined` values so getStaticProps can serialize the payload.
+  return { props: JSON.parse(JSON.stringify({ clusters })) }
 }

--- a/pages/projects/showcase.tsx
+++ b/pages/projects/showcase.tsx
@@ -9,6 +9,7 @@ import type { Blog } from 'contentlayer/generated'
 import { sortedBlogPost } from 'pliny/utils/contentlayer'
 import { buildClusters } from '@/utils/projectClusters'
 import { getLatestPostForProject } from '@/utils/relatedPosts'
+import { getLifetimeStats, type LifetimeStat } from '@/utils/lifetimeStats'
 
 type CardData = {
   slug: string
@@ -35,6 +36,7 @@ type RenderCluster = {
 
 type ShowcaseProps = {
   clusters: RenderCluster[]
+  lifetimeStats: LifetimeStat[] | null
 }
 
 const KNOWN_FUNDS: FundId[] = ['general', 'nostr', 'ops']
@@ -67,7 +69,10 @@ function toCardData(
   }
 }
 
-const ProjectShowcase: NextPage<ShowcaseProps> = ({ clusters }) => {
+const ProjectShowcase: NextPage<ShowcaseProps> = ({
+  clusters,
+  lifetimeStats,
+}) => {
   return (
     <>
       <Head>
@@ -78,7 +83,10 @@ const ProjectShowcase: NextPage<ShowcaseProps> = ({ clusters }) => {
         <h1 className="py-2 text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 max-[375px]:text-2xl sm:text-3xl sm:leading-10 md:py-4 md:text-5xl md:leading-14 lg:text-6xl">
           Project Showcase
         </h1>
-        <StatsSentence className="text-lg leading-7 text-gray-500 dark:text-gray-400" />
+        <StatsSentence
+          initialStats={lifetimeStats}
+          className="text-lg leading-7 text-gray-500 dark:text-gray-400"
+        />
       </section>
 
       <div className="divide-y divide-gray-200 dark:divide-gray-700">
@@ -134,6 +142,11 @@ export const getStaticProps: GetStaticProps<ShowcaseProps> = async () => {
     projects: c.projects.map((p) => toCardData(p, sortedBlogs)),
   }))
 
+  const lifetimeStats = await getLifetimeStats()
+
   // Strip `undefined` values so getStaticProps can serialize the payload.
-  return { props: JSON.parse(JSON.stringify({ clusters })) }
+  return {
+    props: JSON.parse(JSON.stringify({ clusters, lifetimeStats })),
+    revalidate: 60 * 60 * 12,
+  }
 }

--- a/utils/lifetimeStats.ts
+++ b/utils/lifetimeStats.ts
@@ -1,0 +1,23 @@
+import PublicGoogleSheetsParser from 'public-google-sheets-parser'
+
+export type LifetimeStat = { label: string; value: number }
+
+export const LIFETIME_STATS_SHEET_ID =
+  '1mLEbHcrJibLN2PKxYq1LHJssq0CGuJRRoaZwot-ncZQ'
+
+/**
+ * Fetches the OpenSats lifetime stats sheet (grants given, USD allocated,
+ * sats sent) from Google Sheets. Returns null when the sheet is unreachable
+ * so that build pipelines never fail on a transient network blip — the
+ * client-side refresh inside `<StatsSentence />` will fill in the numbers
+ * after hydration.
+ */
+export async function getLifetimeStats(): Promise<LifetimeStat[] | null> {
+  try {
+    const parser = new PublicGoogleSheetsParser(LIFETIME_STATS_SHEET_ID)
+    const data = (await parser.parse()) as LifetimeStat[]
+    return Array.isArray(data) && data.length > 0 ? data : null
+  } catch {
+    return null
+  }
+}

--- a/utils/projectClusters.ts
+++ b/utils/projectClusters.ts
@@ -45,7 +45,15 @@ export const CLUSTERS: Cluster[] = [
     id: 'nostr-infra',
     title: 'Nostr Infrastructure',
     blurb: 'Relays, libraries, signers, and developer tooling.',
-    slugs: ['ndk', 'applesauce', 'citrine', 'frostr', 'amber', 'ngit', 'zapstore'],
+    slugs: [
+      'ndk',
+      'applesauce',
+      'citrine',
+      'frostr',
+      'amber',
+      'ngit',
+      'zapstore',
+    ],
   },
   {
     id: 'privacy-infra',

--- a/utils/projectClusters.ts
+++ b/utils/projectClusters.ts
@@ -1,0 +1,94 @@
+import type { Project } from 'contentlayer/generated'
+
+export type Cluster = {
+  id: string
+  title: string
+  blurb: string
+  slugs: string[]
+}
+
+export type ResolvedCluster = Omit<Cluster, 'slugs'> & {
+  projects: Project[]
+}
+
+/**
+ * Editorial groupings for the project showcase. Order matters — clusters are
+ * rendered in the order they appear here, and projects within a cluster are
+ * rendered in the order their slugs are listed.
+ */
+export const CLUSTERS: Cluster[] = [
+  {
+    id: 'core',
+    title: 'Bitcoin Core & Consensus',
+    blurb: 'The full node, validation, and the protocol underneath.',
+    slugs: ['bitcoin-core', 'floresta', 'stratumv2', 'splicing', 'vls', 'bdk'],
+  },
+  {
+    id: 'wallets',
+    title: 'Wallets',
+    blurb: 'Self-custody software people actually use.',
+    slugs: ['cove', 'blixt', 'blitz-wallet', 'minibits'],
+  },
+  {
+    id: 'lightning-payments',
+    title: 'Lightning & Payments',
+    blurb: 'Payments, point-of-sale, and ecash on top of Lightning.',
+    slugs: ['btcpayserver', 'lnbits', 'cdk', 'cashu', 'opencash'],
+  },
+  {
+    id: 'nostr-clients',
+    title: 'Nostr Clients',
+    blurb: 'How people read and post on nostr today.',
+    slugs: ['damus', 'amethyst', '0xchat', 'coracle', 'flotilla', 'soapbox'],
+  },
+  {
+    id: 'nostr-infra',
+    title: 'Nostr Infrastructure',
+    blurb: 'Relays, libraries, signers, and developer tooling.',
+    slugs: ['ndk', 'applesauce', 'citrine', 'frostr', 'amber', 'ngit', 'zapstore'],
+  },
+  {
+    id: 'privacy-infra',
+    title: 'Privacy & Infrastructure',
+    blurb: 'The plumbing that keeps the rest of the stack honest.',
+    slugs: ['tor', 'grapheneos', 'pdk'],
+  },
+  {
+    id: 'education',
+    title: 'Education & Research',
+    blurb: 'People bringing in the next wave of contributors.',
+    slugs: ['summerofbitcoin', 'satoshinakamotoinstitute', 'bitcoindesign'],
+  },
+]
+
+/**
+ * Resolve cluster slug lists against the full project set, dropping unknown
+ * slugs and clusters that end up empty. In development, warns about
+ * non-OpenSats projects that aren't included in any cluster so the curation
+ * stays in sync with the data folder.
+ */
+export function buildClusters(allProjects: Project[]): ResolvedCluster[] {
+  const bySlug = new Map(allProjects.map((p) => [p.slug, p]))
+
+  const resolved = CLUSTERS.map(({ slugs, ...rest }) => ({
+    ...rest,
+    projects: slugs
+      .map((slug) => bySlug.get(slug))
+      .filter((p): p is Project => Boolean(p)),
+  })).filter((c) => c.projects.length > 0)
+
+  if (process.env.NODE_ENV !== 'production') {
+    const clustered = new Set(CLUSTERS.flatMap((c) => c.slugs))
+    const orphans = allProjects
+      .filter((p) => p.nym !== 'OpenSats' && !clustered.has(p.slug))
+      .map((p) => p.slug)
+    if (orphans.length > 0) {
+      console.warn(
+        `[projectClusters] ${orphans.length} project(s) not in any cluster:`,
+        orphans
+      )
+    }
+  }
+
+  return resolved
+}

--- a/utils/relatedPosts.ts
+++ b/utils/relatedPosts.ts
@@ -60,6 +60,22 @@ export function getRelatedBlogPostsForProject(
   return getRelatedBlogPostsByTerms([title, slug], blogs)
 }
 
+export type LatestPost = { slug: string; date: string; title: string }
+
+/**
+ * Returns the most recent related blog post for a project as a small DTO,
+ * or null if there are none. Expects `sortedBlogs` to already be sorted
+ * newest-first (e.g. via pliny's `sortedBlogPost`).
+ */
+export function getLatestPostForProject(
+  project: Project,
+  sortedBlogs: Blog[]
+): LatestPost | null {
+  const [latest] = getRelatedBlogPostsForProject(project, sortedBlogs)
+  if (!latest) return null
+  return { slug: latest.slug, date: latest.date, title: latest.title }
+}
+
 /**
  * Finds blog posts that mention a given topic by its title or any alias.
  */


### PR DESCRIPTION
## Summary

Redesign the two project-discovery pages from scratch (per the agreed top-5 plan, minus filter/search and minus pills):

- **`/funds`** is now donation-focused. Lifetime allocation stats lead, then the three funds (General, Nostr, Operations) render as full-width sections with the existing recurring-donation banner, a "Donate sats directly" button that opens the existing `PaymentModal`, and tertiary links to the fund detail page and its heartbeat. The random 12-card project strip is gone; project discovery moves behind a single "Browse all funded projects" link.
- **`/projects/showcase`** is now an editorially curated directory. A small stats hero precedes seven curated cluster sections (Bitcoin Core, Wallets, Lightning & Payments, Nostr Clients, Nostr Infrastructure, Privacy & Infrastructure, Education & Research). Cluster-to-slug mapping lives in code (`utils/projectClusters.ts`); no frontmatter changes.
- **`ProjectCard`** is shared, evolved, and DRY across the showcase and the homepage. It drops the runtime image-dimension probe and the tag-based bottom border, uses a stable `aspect-[4/3]` cover frame, and now surfaces fund attribution ("via the Nostr Fund"), a "Last update" link to the most recent related announcement, and a thin row of monochrome social icons (GitHub, Heartbeat, Nostr, Zapstore). All metadata is precomputed in `getStaticProps` via `getLatestPostForProject` so there's no client-side scanning, no `useEffect` ordering, and no `Math.random()` sort anywhere.

## Commits

1. `feat(showcase): add curated project clusters`
2. `feat(showcase): add latest-post helper for projects`
3. `refactor(showcase): redesign ProjectCard with live metadata`
4. `feat(funds): redesign /funds as donation-focused page`
5. `feat(showcase): rebuild /projects/showcase with curated clusters`

## Out of scope (intentional)

- No filters, no search, no URL-synced state.
- No pills, no colored badges, no tag chips.
- No new frontmatter fields (clusters live in code).
- Project detail layout and fund detail layout untouched.
- Homepage \`ProjectList\` continues to work with the evolved card.

## Test plan

- [ ] `/funds` renders the lifetime stats line and the three fund sections in order (General, Nostr, Operations); each donate banner uses the right variant (orange / purple / orange).
- [ ] "Donate sats directly" opens `PaymentModal` with the right fund preselected; the modal closes cleanly.
- [ ] "Read the fund page" and "View heartbeat" links resolve to the right URLs.
- [ ] "Browse all funded projects" goes to `/projects/showcase`.
- [ ] `/projects/showcase` renders all seven clusters in order; each card shows the fund attribution, the "Last update · MMM YYYY" link (where a related announcement exists), and the social icons (where the project frontmatter has the relevant fields).
- [ ] No hydration warnings in the browser console; image frames don't flash.
- [ ] Homepage `/` still renders the existing 4-card project preview without regressions.
- [ ] Dev console shows the orphan-projects warning if any non-OpenSats project is missing from `CLUSTERS`.