### PR TITLE
Fix loading state issue on submit buttons

### DIFF
--- a/components/LTSApplicationForm.tsx
+++ b/components/LTSApplicationForm.tsx
@@ -273,11 +273,12 @@ export default function ApplicationForm() {
       </div>
 
       <FormButton
-        variant={isFLOSS ? 'enabled' : 'disabled'}
+        variant={isFLOSS && !loading ? 'enabled' : 'disabled'}
         type="submit"
-        disabled={loading}
+        disabled={loading || !isFLOSS}
+        aria-busy={loading}
       >
-        Submit LTS Application
+        {loading ? 'Submitting…' : 'Submit LTS Application'}
       </FormButton>
 
       {!!failureReason && (

--- a/components/grant-application/StepNavigation.tsx
+++ b/components/grant-application/StepNavigation.tsx
@@ -41,6 +41,7 @@ export default function StepNavigation({
           type="button"
           onClick={onSubmit}
           disabled={loading}
+          aria-busy={loading}
           className={`rounded-md bg-orange-500 px-6 py-2 text-sm font-semibold text-white hover:bg-orange-600 ${
             loading ? 'cursor-not-allowed opacity-50' : ''
           }`}


### PR DESCRIPTION
Adds a proper loading state to the apply forms so the submit button gives clear feedback during submission and prevents duplicate requests. The LTS form gets the full treatment (disabled while submitting, dimmed visual variant, `Submitting…` label, and `aria-busy`), and the General Grant form gets `aria-busy` on its already-disabling submit button so both behave consistently for assistive tech.

- Disable submit and switch label to `Submitting…` on `/apply/lts`
- Add `aria-busy={loading}` to the submit button on `/apply/grant`
- Keep the FLOSS prerequisite check on the LTS submit button

Closes #75

---

Build preview:
- [/apply/lts](https://os-website-git-fix-issue-75-apply-loading-state-opensats.vercel.app/apply/lts)
- [/apply/grant](https://os-website-git-fix-issue-75-apply-loading-state-opensats.vercel.app/apply/grant)
