### PR TITLE
Respect system color scheme via tri-state theme toggle

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -25,22 +25,31 @@ const Header = () => {
         </Link>
       </div>
       <div className="flex items-center text-base leading-5">
-        <div className="block">
-          {headerNavLinks.map((link) => (
-            <Link
-              key={link.title}
-              href={link.href}
-              className={
-                link.isButton
-                  ? 'rounded border border-orange-500 bg-transparent px-4 py-2 font-semibold text-orange-500 hover:border-transparent hover:bg-orange-500 hover:text-white'
-                  : 'hidden p-1 font-medium text-gray-900 dark:text-gray-100 sm:p-4 md:inline-block'
-              }
-            >
-              {link.title}
-            </Link>
-          ))}
+        <div className="flex items-center">
+          {headerNavLinks
+            .filter((link) => !link.isButton)
+            .map((link) => (
+              <Link
+                key={link.title}
+                href={link.href}
+                className="hidden p-1 font-medium text-gray-900 dark:text-gray-100 sm:p-4 md:inline-block"
+              >
+                {link.title}
+              </Link>
+            ))}
+          <ThemeSwitch />
+          {headerNavLinks
+            .filter((link) => link.isButton)
+            .map((link) => (
+              <Link
+                key={link.title}
+                href={link.href}
+                className="rounded border border-orange-500 bg-transparent px-4 py-2 font-semibold text-orange-500 hover:border-transparent hover:bg-orange-500 hover:text-white"
+              >
+                {link.title}
+              </Link>
+            ))}
         </div>
-        <ThemeSwitch />
         <MobileNav />
       </div>
     </header>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -24,7 +24,7 @@ const Header = () => {
           </div>
         </Link>
       </div>
-      <div className="flex items-center gap-2 text-base leading-5 sm:gap-3">
+      <div className="flex items-center gap-3 text-base leading-5 sm:gap-4">
         <div className="block">
           {headerNavLinks.map((link) => (
             <Link

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -24,7 +24,7 @@ const Header = () => {
           </div>
         </Link>
       </div>
-      <div className="flex items-center text-base leading-5">
+      <div className="flex items-center gap-2 text-base leading-5 sm:gap-3">
         <div className="block">
           {headerNavLinks.map((link) => (
             <Link

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -25,31 +25,22 @@ const Header = () => {
         </Link>
       </div>
       <div className="flex items-center text-base leading-5">
-        <div className="flex items-center">
-          {headerNavLinks
-            .filter((link) => !link.isButton)
-            .map((link) => (
-              <Link
-                key={link.title}
-                href={link.href}
-                className="hidden p-1 font-medium text-gray-900 dark:text-gray-100 sm:p-4 md:inline-block"
-              >
-                {link.title}
-              </Link>
-            ))}
-          <ThemeSwitch />
-          {headerNavLinks
-            .filter((link) => link.isButton)
-            .map((link) => (
-              <Link
-                key={link.title}
-                href={link.href}
-                className="rounded border border-orange-500 bg-transparent px-4 py-2 font-semibold text-orange-500 hover:border-transparent hover:bg-orange-500 hover:text-white"
-              >
-                {link.title}
-              </Link>
-            ))}
+        <div className="block">
+          {headerNavLinks.map((link) => (
+            <Link
+              key={link.title}
+              href={link.href}
+              className={
+                link.isButton
+                  ? 'rounded border border-orange-500 bg-transparent px-4 py-2 font-semibold text-orange-500 hover:border-transparent hover:bg-orange-500 hover:text-white'
+                  : 'hidden p-1 font-medium text-gray-900 dark:text-gray-100 sm:p-4 md:inline-block'
+              }
+            >
+              {link.title}
+            </Link>
+          ))}
         </div>
+        <ThemeSwitch />
         <MobileNav />
       </div>
     </header>

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -20,7 +20,7 @@ const MobileNav = () => {
   return (
     <div className="md:hidden">
       <button
-        className="ml-1 mr-1 h-8 w-8 rounded py-1"
+        className="flex h-8 w-8 items-center justify-center rounded p-1 text-gray-900 dark:text-gray-100"
         aria-label="Toggle Menu"
         onClick={onToggleNav}
       >
@@ -28,7 +28,7 @@ const MobileNav = () => {
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
           fill="currentColor"
-          className="h-8 w-8 text-gray-900 dark:text-gray-100"
+          className="h-6 w-6"
         >
           <path
             fillRule="evenodd"

--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -9,10 +9,12 @@ const ThemeSwitch = () => {
 
   // Cycle through: system → light → dark → system, so users can
   // explicitly opt back into following their OS preference.
-  const nextTheme = theme === 'system' ? 'light' : theme === 'light' ? 'dark' : 'system'
+  const nextTheme =
+    theme === 'system' ? 'light' : theme === 'light' ? 'dark' : 'system'
 
   const labels: Record<string, string> = {
-    system: 'Use system theme (currently active). Click to switch to light mode.',
+    system:
+      'Use system theme (currently active). Click to switch to light mode.',
     light: 'Light mode active. Click to switch to dark mode.',
     dark: 'Dark mode active. Click to follow system theme.',
   }

--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -41,11 +41,14 @@ const ThemeSwitch = () => {
         ) : current === 'dark' ? (
           <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
         ) : (
-          <path
-            fillRule="evenodd"
-            d="M3 5a2 2 0 012-2h10a2 2 0 012 2v6a2 2 0 01-2 2h-3v1h2a1 1 0 110 2H6a1 1 0 110-2h2v-1H5a2 2 0 01-2-2V5zm12 0H5v6h10V5z"
-            clipRule="evenodd"
-          />
+          <>
+            <path
+              fillRule="evenodd"
+              d="M10 18a8 8 0 100-16 8 8 0 000 16zm0-2a6 6 0 100-12 6 6 0 000 12z"
+              clipRule="evenodd"
+            />
+            <path d="M10 4a6 6 0 010 12V4z" />
+          </>
         )}
       </svg>
     </button>

--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -23,7 +23,7 @@ const ThemeSwitch = () => {
     <button
       aria-label={labels[current]}
       title={labels[current]}
-      className="flex h-8 w-8 items-center justify-center rounded p-1 text-gray-400 transition-colors duration-300 hover:text-gray-900 focus-visible:text-gray-900 dark:text-gray-600 dark:hover:text-gray-100 dark:focus-visible:text-gray-100"
+      className="flex h-8 w-8 items-center justify-center rounded p-1 text-gray-900 transition-colors duration-300 dark:text-gray-100 md:text-gray-400 md:hover:text-gray-900 md:focus-visible:text-gray-900 md:dark:text-gray-600 md:dark:hover:text-gray-100 md:dark:focus-visible:text-gray-100"
       onClick={() => setTheme(nextTheme)}
     >
       <svg

--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -23,7 +23,7 @@ const ThemeSwitch = () => {
     <button
       aria-label={labels[current]}
       title={labels[current]}
-      className="ml-1 mr-1 h-8 w-8 rounded p-1 text-gray-400 transition-colors duration-300 hover:text-gray-900 focus-visible:text-gray-900 dark:text-gray-600 dark:hover:text-gray-100 dark:focus-visible:text-gray-100 sm:ml-4"
+      className="flex h-8 w-8 items-center justify-center rounded p-1 text-gray-400 transition-colors duration-300 hover:text-gray-900 focus-visible:text-gray-900 dark:text-gray-600 dark:hover:text-gray-100 dark:focus-visible:text-gray-100"
       onClick={() => setTheme(nextTheme)}
     >
       <svg

--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -23,7 +23,7 @@ const ThemeSwitch = () => {
     <button
       aria-label={labels[current]}
       title={labels[current]}
-      className="ml-1 mr-1 h-8 w-8 rounded p-1 text-gray-500 transition-colors duration-300 hover:text-gray-900 focus-visible:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 dark:focus-visible:text-gray-100 sm:ml-4"
+      className="ml-1 mr-1 h-8 w-8 rounded p-1 text-gray-400 transition-colors duration-300 hover:text-gray-900 focus-visible:text-gray-900 dark:text-gray-600 dark:hover:text-gray-100 dark:focus-visible:text-gray-100 sm:ml-4"
       onClick={() => setTheme(nextTheme)}
     >
       <svg

--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -3,20 +3,28 @@ import { useTheme } from 'next-themes'
 
 const ThemeSwitch = () => {
   const [mounted, setMounted] = useState(false)
-  const { theme, setTheme, resolvedTheme } = useTheme()
+  const { theme, setTheme } = useTheme()
 
-  // When mounted on client, now we can show the UI
   useEffect(() => setMounted(true), [])
+
+  // Cycle through: system → light → dark → system, so users can
+  // explicitly opt back into following their OS preference.
+  const nextTheme = theme === 'system' ? 'light' : theme === 'light' ? 'dark' : 'system'
+
+  const labels: Record<string, string> = {
+    system: 'Use system theme (currently active). Click to switch to light mode.',
+    light: 'Light mode active. Click to switch to dark mode.',
+    dark: 'Dark mode active. Click to follow system theme.',
+  }
+
+  const current = mounted && theme ? theme : 'system'
 
   return (
     <button
-      aria-label="Toggle Dark Mode"
+      aria-label={labels[current]}
+      title={labels[current]}
       className="ml-1 mr-1 h-8 w-8 rounded p-1 sm:ml-4"
-      onClick={() =>
-        setTheme(
-          theme === 'dark' || resolvedTheme === 'dark' ? 'light' : 'dark'
-        )
-      }
+      onClick={() => setTheme(nextTheme)}
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -24,14 +32,20 @@ const ThemeSwitch = () => {
         fill="currentColor"
         className="text-gray-900 transition-colors duration-300 dark:text-gray-100"
       >
-        {mounted && (theme === 'dark' || resolvedTheme === 'dark') ? (
+        {!mounted ? null : current === 'light' ? (
           <path
             fillRule="evenodd"
             d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
             clipRule="evenodd"
           />
-        ) : (
+        ) : current === 'dark' ? (
           <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
+        ) : (
+          <path
+            fillRule="evenodd"
+            d="M3 5a2 2 0 012-2h10a2 2 0 012 2v6a2 2 0 01-2 2h-3v1h2a1 1 0 110 2H6a1 1 0 110-2h2v-1H5a2 2 0 01-2-2V5zm12 0H5v6h10V5z"
+            clipRule="evenodd"
+          />
         )}
       </svg>
     </button>

--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -23,7 +23,7 @@ const ThemeSwitch = () => {
     <button
       aria-label={labels[current]}
       title={labels[current]}
-      className="flex h-8 w-8 items-center justify-center rounded p-1 text-gray-900 transition-colors duration-300 dark:text-gray-100 md:text-gray-400 md:hover:text-gray-900 md:focus-visible:text-gray-900 md:dark:text-gray-600 md:dark:hover:text-gray-100 md:dark:focus-visible:text-gray-100"
+      className="ml-1 flex h-8 w-8 items-center justify-center rounded p-1 text-gray-900 transition-colors duration-300 dark:text-gray-100 md:ml-0 md:text-gray-400 md:hover:text-gray-900 md:focus-visible:text-gray-900 md:dark:text-gray-600 md:dark:hover:text-gray-100 md:dark:focus-visible:text-gray-100"
       onClick={() => setTheme(nextTheme)}
     >
       <svg

--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -23,14 +23,13 @@ const ThemeSwitch = () => {
     <button
       aria-label={labels[current]}
       title={labels[current]}
-      className="ml-1 mr-1 h-8 w-8 rounded p-1 sm:ml-4"
+      className="ml-1 mr-1 h-8 w-8 rounded p-1 text-gray-500 transition-colors duration-300 hover:text-gray-900 focus-visible:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 dark:focus-visible:text-gray-100 sm:ml-4"
       onClick={() => setTheme(nextTheme)}
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 20 20"
         fill="currentColor"
-        className="text-gray-900 transition-colors duration-300 dark:text-gray-100"
       >
         {!mounted ? null : current === 'light' ? (
           <path

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -18,7 +18,7 @@ import { FathomAnalytics } from '@/components/Fathom'
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <ThemeProvider attribute="class" defaultTheme={siteMetadata.theme}>
+    <ThemeProvider attribute="class" defaultTheme={siteMetadata.theme} enableSystem>
       <Head>
         <meta content="width=device-width, initial-scale=1" name="viewport" />
       </Head>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -18,7 +18,11 @@ import { FathomAnalytics } from '@/components/Fathom'
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <ThemeProvider attribute="class" defaultTheme={siteMetadata.theme} enableSystem>
+    <ThemeProvider
+      attribute="class"
+      defaultTheme={siteMetadata.theme}
+      enableSystem
+    >
       <Head>
         <meta content="width=device-width, initial-scale=1" name="viewport" />
       </Head>


### PR DESCRIPTION
The theme toggle now cycles `system → light → dark → system`, so users can return to following their OS appearance after picking an explicit theme. Closes #712. While in the header, the mobile cluster was also tidied up so the theme toggle, Apply button, and hamburger sit on a uniform gap with matching icon weights.

---

Build preview:
- [/ (any page, really)](https://os-website-git-fix-system-theme-712-opensats.vercel.app/)
