### PR TITLE
fix(topics): link "Propose an edit" to master branch

### DIFF
--- a/pages/topics/[slug].tsx
+++ b/pages/topics/[slug].tsx
@@ -54,7 +54,7 @@ export default function TopicPage({
   projectLink,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   const repo = siteMetadata.siteRepo.replace(/\/$/, '')
-  const editUrl = `${repo}/edit/main/data/${topic.filePath}`
+  const editUrl = `${repo}/blob/master/data/${topic.filePath}`
   return (
     <>
       <MDXLayoutRenderer

--- a/pages/topics/[slug].tsx
+++ b/pages/topics/[slug].tsx
@@ -54,7 +54,7 @@ export default function TopicPage({
   projectLink,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   const repo = siteMetadata.siteRepo.replace(/\/$/, '')
-  const editUrl = `${repo}/blob/master/data/${topic.filePath}`
+  const editUrl = `${repo}/edit/master/data/${topic.filePath}`
   return (
     <>
       <MDXLayoutRenderer


### PR DESCRIPTION
The "Propose an edit" link on topic pages pointed to `/edit/main/...`, which 404'd because the default branch is `master`, not `main`. This switches the URL to `/edit/master/...` so the link opens GitHub's editor directly (fork + edit + PR for non-collaborators), matching what the button label implies.

- Fix `editUrl` in `pages/topics/[slug].tsx` to use `edit/master`
- Keep the `/edit/...` route segment so the button lands on the editor instead of the blob view

---

Build preview:
- [/topics/ark](https://os-website-git-fix-topic-edit-url-opensats.vercel.app/topics/ark)
