### PR TITLE
Add Bitcoin Research Kit project page

### DIFF
--- a/data/projects/bitcoinresearchkit.mdx
+++ b/data/projects/bitcoinresearchkit.mdx
@@ -23,7 +23,7 @@ OpenSats highlighted BRK in the [twelfth wave of Bitcoin grants][announce]. That
 
 ## What's next?
 
-The grant announcement laid out the near-term roadmap: explorer views for blocks, addresses, and transactions; support for mempool.space and Electrum protocols; prebuilt binaries and integrated `bitcoind` support for self-hosters; a terminal view for more complex queries; a toggle for disabling price data; and Prometheus monitoring. The public BRK stack already includes Bitview, a documented API, and language clients. The next stretch is making that same data pipeline easier to run and more useful for researchers, miners, node operators, and analysts.
+The grant announcement laid out the near-term roadmap: explorer views for blocks, addresses, and transactions, support for mempool.space and Electrum protocols, prebuilt binaries and integrated `bitcoind` support for self-hosters, a terminal view for more complex queries, a toggle for disabling price data, and Prometheus monitoring. The public BRK stack already includes Bitview, a documented API, and language clients. The next stretch is making that same data pipeline easier to run and more useful for researchers, miners, node operators, and analysts.
 
 [announce]: /blog/twelfth-wave-of-bitcoin-grants#bitcoin-research-kit
 [bitview]: https://bitview.space/

--- a/data/projects/bitcoinresearchkit.mdx
+++ b/data/projects/bitcoinresearchkit.mdx
@@ -1,0 +1,30 @@
+---
+title: 'Bitcoin Research Kit'
+dateAdded: '2026-05-07'
+summary: 'A self-hostable Bitcoin analytics stack that indexes chain data, computes metrics, serves an API, and powers the public Bitview instance.'
+nym: 'nym21'
+website: 'https://bitview.space/'
+coverImage: '/static/images/projects/bitcoinresearchkit.svg'
+git: 'https://github.com/bitcoinresearchkit/brk'
+tags: ['Bitcoin', 'Research', 'Infrastructure']
+fund: general
+announcementLink: '/blog/twelfth-wave-of-bitcoin-grants#bitcoin-research-kit'
+---
+
+Bitcoin Research Kit (BRK) is an open-source analytics stack for Bitcoin. It parses chain data from a [Bitcoin Core](/projects/bitcoin-core) node, indexes blocks and transactions, computes metrics, serves an API, and renders charts from the same local dataset. The upstream [README][readme] describes it as a self-hostable package that combines pieces users usually reach for through separate services such as [Glassnode](https://glassnode.com/), [mempool.space](https://mempool.space/), and [electrs](https://github.com/romanz/electrs). [Bitview][bitview] is the project's official free hosted instance.
+
+The current stack covers more than charts. BRK exposes 8,000+ metrics across 15 time resolutions, tracks blockchain data for blocks, transactions, addresses, and UTXOs, and includes mempool data such as fee estimates, projected blocks, and unconfirmed transactions. It also ships client libraries for JavaScript, Python, and Rust. All of that runs with a Bitcoin Core node as the only required external dependency, which keeps the data pipeline local and verifiable.
+
+## Why fund it?
+
+Researchers, miners, and node operators need reliable chain data. When analytics, explorer data, and market indicators sit behind someone else's API, the verification story gets weaker. BRK lowers that dependency by letting anyone compute the same metrics from their own node and expose them through their own API or UI.
+
+OpenSats highlighted BRK in the [twelfth wave of Bitcoin grants][announce]. That grant backed work on a fuller explorer, easier self-hosting, and better operator tooling. The project is MIT licensed, fully open-source, and the upstream README currently lists OpenSats as a supporter through June 2026.
+
+## What's next?
+
+The grant announcement laid out the near-term roadmap: explorer views for blocks, addresses, and transactions; support for mempool.space and Electrum protocols; prebuilt binaries and integrated `bitcoind` support for self-hosters; a terminal view for more complex queries; a toggle for disabling price data; and Prometheus monitoring. The public BRK stack already includes Bitview, a documented API, and language clients. The next stretch is making that same data pipeline easier to run and more useful for researchers, miners, node operators, and analysts.
+
+[announce]: /blog/twelfth-wave-of-bitcoin-grants#bitcoin-research-kit
+[bitview]: https://bitview.space/
+[readme]: https://github.com/bitcoinresearchkit/brk/blob/main/docs/README.md

--- a/public/static/images/projects/bitcoinresearchkit.svg
+++ b/public/static/images/projects/bitcoinresearchkit.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 173.2 200" role="img" aria-label="Bitcoin Research Kit">
+  <title>Bitcoin Research Kit</title>
+  <style>
+    svg {
+      --fill: 0.5;
+      --face-top:    oklch(67.64% 0.191 44.41);
+      --face-left:   oklch(64.34% 0.191 44.41);
+      --face-right:  oklch(61.04% 0.191 44.41);
+      --face-bottom: oklch(57.74% 0.191 44.41);
+    }
+    svg[data-theme="light"] {
+      --face-top:    oklch(90% 0 0);
+      --face-left:   oklch(86.7% 0 0);
+      --face-right:  oklch(83.4% 0 0);
+      --face-bottom: oklch(80.1% 0 0);
+    }
+    svg[data-theme="dark"] {
+      --face-top:    oklch(26.6% 0 0);
+      --face-left:   oklch(23.3% 0 0);
+      --face-right:  oklch(20% 0 0);
+      --face-bottom: oklch(10.1% 0 0);
+    }
+    .glass { fill-opacity: 0.4; }
+    .glass-top,       .liquid-top   { fill: var(--face-top); }
+    .glass-right,     .liquid-right { fill: var(--face-right); }
+    .glass-left,      .liquid-left  { fill: var(--face-left); }
+    .glass-bottom                   { fill: var(--face-bottom); }
+    .glass-rear-left                { fill: var(--face-top); }
+    .glass-rear-right               { fill: var(--face-left); }
+    .liquid {
+      transform-box: view-box;
+      transform: translateY(calc((1 - var(--fill)) * 50%));
+      opacity: ceil(var(--fill));
+    }
+  </style>
+  <defs>
+    <clipPath id="hex" clipPathUnits="userSpaceOnUse">
+      <polygon points="86.6,0 173.2,50 173.2,150 86.6,200 0,150 0,50"/>
+    </clipPath>
+  </defs>
+
+  <polygon class="glass glass-bottom"     points="86.6,100 173.2,150 86.6,200 0,150"/>
+  <polygon class="glass glass-rear-left"  points="86.6,100 0,150 0,50 86.6,0"/>
+  <polygon class="glass glass-rear-right" points="86.6,100 173.2,150 173.2,50 86.6,0"/>
+
+  <g clip-path="url(#hex)">
+    <g class="liquid">
+      <polygon class="liquid-top"   points="86.6,0 173.2,50 86.6,100 0,50"/>
+      <polygon class="liquid-right" points="173.2,50 173.2,150 86.6,200 86.6,100"/>
+      <polygon class="liquid-left"  points="0,50 0,150 86.6,200 86.6,100"/>
+    </g>
+  </g>
+
+  <polygon class="glass glass-top"   points="0,50 86.6,0 173.2,50 86.6,100"/>
+  <polygon class="glass glass-right" points="173.2,50 173.2,150 86.6,200 86.6,100"/>
+  <polygon class="glass glass-left"  points="0,50 0,150 86.6,200 86.6,100"/>
+</svg>


### PR DESCRIPTION
Adds a `/projects/bitcoinresearchkit` page covering the self-hosted analytics stack, the public `Bitview` instance, and the OpenSats grant context.

- adds `data/projects/bitcoinresearchkit.mdx` with project scope, funding context, and current direction
- adds `public/static/images/projects/bitcoinresearchkit.svg` with the project logo

Closes OpenSats/content#91

---

Build preview:
- [/projects/bitcoinresearchkit](https://os-website-git-content-add-bitcoin-research-kit-e1cb1f-opensats.vercel.app/projects/bitcoinresearchkit)
