### PR TITLE
Animate lifetime totals

### DIFF
--- a/components/LifetimeStats.tsx
+++ b/components/LifetimeStats.tsx
@@ -1,30 +1,8 @@
-import React, { useState, useEffect } from 'react'
-import PublicGoogleSheetsParser from 'public-google-sheets-parser'
-
-export function formatNumber(num: number): string {
-  const abbreviations = ['k', 'M', 'B', 'T']
-  let i = 0
-  while (num > 1e3 && i < abbreviations.length) {
-    num /= 1e3
-    if (num < 1e3) {
-      return `${num.toFixed(1)} ${abbreviations[i]}`
-    }
-    i += 1
-  }
-  return num.toString()
-}
+import React from 'react'
+import { formatNumber, useAnimatedLifetimeStats } from '@/utils/lifetimeStats'
 
 const LifetimeStats = () => {
-  const [items, setItems] = useState([])
-
-  useEffect(() => {
-    const parser = new PublicGoogleSheetsParser(
-      '1mLEbHcrJibLN2PKxYq1LHJssq0CGuJRRoaZwot-ncZQ'
-    )
-    parser.parse().then((data) => {
-      setItems(data)
-    })
-  }, [])
+  const items = useAnimatedLifetimeStats()
 
   return (
     <div className="py-4">

--- a/components/StatsSentence.tsx
+++ b/components/StatsSentence.tsx
@@ -1,10 +1,8 @@
-import { useState, useEffect } from 'react'
 import Link from '@/components/Link'
-import PublicGoogleSheetsParser from 'public-google-sheets-parser'
-import { formatNumber } from '@/components/LifetimeStats'
 import {
-  LIFETIME_STATS_SHEET_ID,
+  formatNumber,
   type LifetimeStat,
+  useAnimatedLifetimeStats,
 } from '@/utils/lifetimeStats'
 
 type StatsSentenceProps = {
@@ -12,33 +10,16 @@ type StatsSentenceProps = {
   initialStats?: LifetimeStat[] | null
 }
 
-const skeleton = (
-  <span className="inline-block h-[1em] w-12 animate-pulse rounded bg-stone-200 align-middle dark:bg-stone-700" />
-)
-
 export default function StatsSentence({
   className = '',
   initialStats,
 }: StatsSentenceProps) {
-  const [stats, setStats] = useState<LifetimeStat[]>(initialStats ?? [])
-
-  useEffect(() => {
-    const parser = new PublicGoogleSheetsParser(LIFETIME_STATS_SHEET_ID)
-    parser.parse().then((data) => {
-      if (Array.isArray(data) && data.length > 0) {
-        setStats(data as LifetimeStat[])
-      }
-    })
-  }, [])
+  const stats = useAnimatedLifetimeStats(initialStats)
 
   // stats[0] = grants given, stats[1] = USD allocated, stats[2] = sats sent
-  const grantsGiven = stats[0]?.value ? formatNumber(stats[0].value) : null
-  const usdAllocated = stats[1]?.value
-    ? Math.round(stats[1].value).toLocaleString()
-    : null
-  const satsSent = stats[2]?.value
-    ? formatNumber(stats[2].value).replace('B', 'billion')
-    : null
+  const grantsGiven = formatNumber(stats[0]?.value ?? 0)
+  const usdAllocated = Math.round(stats[1]?.value ?? 0).toLocaleString()
+  const satsSent = formatNumber(stats[2]?.value ?? 0).replace('B', 'billion')
 
   return (
     <p className={className}>
@@ -47,21 +28,21 @@ export default function StatsSentence({
         href="/transparency"
         className="-mx-1 rounded bg-primary-100/50 px-1 no-underline hover:bg-primary-100 dark:bg-primary-900/20 dark:hover:bg-primary-900/40"
       >
-        {usdAllocated ? <>${usdAllocated} USD</> : <>{skeleton} USD</>}
+        ${usdAllocated} USD
       </Link>{' '}
       to free and open-source projects and sent{' '}
       <Link
         href="/transparency"
         className="-mx-1 whitespace-nowrap rounded bg-primary-100/50 px-1 no-underline hover:bg-primary-100 dark:bg-primary-900/20 dark:hover:bg-primary-900/40"
       >
-        {satsSent ? <>~{satsSent} sats</> : <>{skeleton} sats</>}
+        ~{satsSent} sats
       </Link>{' '}
       to{' '}
       <Link
         href="/transparency"
         className="-mx-1 rounded bg-primary-100/50 px-1 no-underline hover:bg-primary-100 dark:bg-primary-900/20 dark:hover:bg-primary-900/40"
       >
-        {grantsGiven ? <>{grantsGiven} grantees</> : <>{skeleton} grantees</>}
+        {grantsGiven} grantees
       </Link>{' '}
       in{' '}
       <Link

--- a/components/StatsSentence.tsx
+++ b/components/StatsSentence.tsx
@@ -2,6 +2,7 @@ import Link from '@/components/Link'
 import {
   formatNumber,
   type LifetimeStat,
+  useAnimatedCount,
   useAnimatedLifetimeStats,
 } from '@/utils/lifetimeStats'
 
@@ -20,6 +21,7 @@ export default function StatsSentence({
   const grantsGiven = formatNumber(stats[0]?.value ?? 0)
   const usdAllocated = Math.round(stats[1]?.value ?? 0).toLocaleString()
   const satsSent = formatNumber(stats[2]?.value ?? 0).replace('B', 'billion')
+  const countryCount = Math.round(useAnimatedCount(40))
 
   return (
     <p className={className}>
@@ -49,7 +51,7 @@ export default function StatsSentence({
         href="/map"
         className="-mx-1 whitespace-nowrap rounded bg-primary-100/50 px-1 no-underline hover:bg-primary-100 dark:bg-primary-900/20 dark:hover:bg-primary-900/40"
       >
-        40+ countries
+        {countryCount}+ countries
       </Link>
       .
     </p>

--- a/utils/lifetimeStats.ts
+++ b/utils/lifetimeStats.ts
@@ -121,6 +121,46 @@ export async function getLifetimeStats(): Promise<LifetimeStat[] | null> {
   return lifetimeStatsPromise
 }
 
+export function useAnimatedCount(
+  targetValue: number,
+  durationMs = 1200
+): number {
+  const [value, setValue] = useState(() => getAnimationStartValue(targetValue))
+  const frameRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    const startValue = getAnimationStartValue(targetValue)
+    setValue(startValue)
+
+    if (prefersReducedMotion()) {
+      setValue(targetValue)
+      return
+    }
+
+    const startTime = performance.now()
+
+    const step = (now: number) => {
+      const progress = Math.min((now - startTime) / durationMs, 1)
+      const eased = easeOutCubic(progress)
+      setValue(startValue + (targetValue - startValue) * eased)
+
+      if (progress < 1) {
+        frameRef.current = window.requestAnimationFrame(step)
+      }
+    }
+
+    frameRef.current = window.requestAnimationFrame(step)
+
+    return () => {
+      if (frameRef.current !== null) {
+        window.cancelAnimationFrame(frameRef.current)
+      }
+    }
+  }, [targetValue, durationMs])
+
+  return value
+}
+
 export function useAnimatedLifetimeStats(
   initialStats?: LifetimeStat[] | null,
   durationMs = 1200

--- a/utils/lifetimeStats.ts
+++ b/utils/lifetimeStats.ts
@@ -50,11 +50,11 @@ function createParser() {
 function getAnimationStartValue(targetValue: number): number {
   if (targetValue <= 0) return 0
 
-  const halvedValue = targetValue / 2
-  const digits = Math.max(Math.floor(halvedValue).toString().length, 1)
+  const discountedValue = targetValue * 0.79
+  const digits = Math.max(Math.floor(discountedValue).toString().length, 1)
   const magnitude = 10 ** Math.max(digits - 2, 0)
 
-  return Math.floor(halvedValue / magnitude) * magnitude
+  return Math.floor(discountedValue / magnitude) * magnitude
 }
 
 function createStartStats(targetStats: LifetimeStat[]): LifetimeStat[] {

--- a/utils/lifetimeStats.ts
+++ b/utils/lifetimeStats.ts
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
 import PublicGoogleSheetsParser from 'public-google-sheets-parser'
 
 export type LifetimeStat = { label: string; value: number }
@@ -5,19 +6,182 @@ export type LifetimeStat = { label: string; value: number }
 export const LIFETIME_STATS_SHEET_ID =
   '1mLEbHcrJibLN2PKxYq1LHJssq0CGuJRRoaZwot-ncZQ'
 
+const DEFAULT_LIFETIME_STATS: LifetimeStat[] = [
+  { label: 'Grants given', value: 404 },
+  { label: 'USD allocated', value: 34668655 },
+  { label: 'Sats sent', value: 39524655813 },
+]
+
+let lifetimeStatsPromise: Promise<LifetimeStat[] | null> | null = null
+
+export function formatNumber(num: number): string {
+  const abbreviations = ['k', 'M', 'B', 'T']
+  let i = 0
+  while (num > 1e3 && i < abbreviations.length) {
+    num /= 1e3
+    if (num < 1e3) {
+      return `${num.toFixed(1)} ${abbreviations[i]}`
+    }
+    i += 1
+  }
+  return Math.round(num).toString()
+}
+
+function normalizeLifetimeStats(
+  data: LifetimeStat[] | null | undefined,
+  fallback: LifetimeStat[] = DEFAULT_LIFETIME_STATS
+): LifetimeStat[] {
+  return fallback.map((fallbackItem, index) => {
+    const item = data?.[index]
+    return {
+      label:
+        typeof item?.label === 'string' && item.label.length > 0
+          ? item.label
+          : fallbackItem.label,
+      value: typeof item?.value === 'number' ? item.value : fallbackItem.value,
+    }
+  })
+}
+
+function createParser() {
+  return new PublicGoogleSheetsParser(LIFETIME_STATS_SHEET_ID)
+}
+
+function getAnimationStartValue(targetValue: number): number {
+  if (targetValue <= 0) return 0
+
+  const digits = Math.max(Math.floor(targetValue).toString().length, 1)
+  const magnitude = 10 ** Math.max(digits - 2, 0)
+  const roundedDown = Math.floor(targetValue / magnitude) * magnitude
+
+  return roundedDown === targetValue
+    ? Math.max(targetValue - magnitude, 0)
+    : roundedDown
+}
+
+function createStartStats(targetStats: LifetimeStat[]): LifetimeStat[] {
+  return targetStats.map((item) => ({
+    label: item.label,
+    value: getAnimationStartValue(item.value),
+  }))
+}
+
+function easeOutCubic(progress: number): number {
+  return 1 - Math.pow(1 - progress, 3)
+}
+
+function prefersReducedMotion(): boolean {
+  if (
+    typeof window === 'undefined' ||
+    typeof window.matchMedia !== 'function'
+  ) {
+    return false
+  }
+
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+function interpolateStats(
+  startStats: LifetimeStat[],
+  endStats: LifetimeStat[],
+  progress: number
+): LifetimeStat[] {
+  const eased = easeOutCubic(progress)
+
+  return endStats.map((targetItem, index) => {
+    const startItem = startStats[index] ?? targetItem
+    return {
+      label: targetItem.label,
+      value: Math.round(
+        startItem.value + (targetItem.value - startItem.value) * eased
+      ),
+    }
+  })
+}
+
+async function fetchLifetimeStats(): Promise<LifetimeStat[] | null> {
+  try {
+    const data = (await createParser().parse()) as LifetimeStat[]
+    return Array.isArray(data) && data.length > 0
+      ? normalizeLifetimeStats(data)
+      : null
+  } catch {
+    return null
+  }
+}
+
 /**
  * Fetches the OpenSats lifetime stats sheet (grants given, USD allocated,
  * sats sent) from Google Sheets. Returns null when the sheet is unreachable
  * so that build pipelines never fail on a transient network blip — the
- * client-side refresh inside `<StatsSentence />` will fill in the numbers
+ * client-side refresh inside the stats components will fill in the numbers
  * after hydration.
  */
 export async function getLifetimeStats(): Promise<LifetimeStat[] | null> {
-  try {
-    const parser = new PublicGoogleSheetsParser(LIFETIME_STATS_SHEET_ID)
-    const data = (await parser.parse()) as LifetimeStat[]
-    return Array.isArray(data) && data.length > 0 ? data : null
-  } catch {
-    return null
+  if (typeof window === 'undefined') {
+    return fetchLifetimeStats()
   }
+
+  if (!lifetimeStatsPromise) {
+    lifetimeStatsPromise = fetchLifetimeStats()
+  }
+
+  return lifetimeStatsPromise
+}
+
+export function useAnimatedLifetimeStats(
+  initialStats?: LifetimeStat[] | null,
+  durationMs = 1200
+): LifetimeStat[] {
+  const baseStats = useMemo(
+    () => normalizeLifetimeStats(initialStats),
+    [initialStats]
+  )
+  const [stats, setStats] = useState<LifetimeStat[]>(() =>
+    createStartStats(baseStats)
+  )
+  const frameRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    const startStats = createStartStats(baseStats)
+    setStats(startStats)
+
+    let cancelled = false
+
+    const animateTo = (targetStats: LifetimeStat[]) => {
+      if (prefersReducedMotion()) {
+        setStats(targetStats)
+        return
+      }
+
+      const startTime = performance.now()
+
+      const step = (now: number) => {
+        if (cancelled) return
+
+        const progress = Math.min((now - startTime) / durationMs, 1)
+        setStats(interpolateStats(startStats, targetStats, progress))
+
+        if (progress < 1) {
+          frameRef.current = window.requestAnimationFrame(step)
+        }
+      }
+
+      frameRef.current = window.requestAnimationFrame(step)
+    }
+
+    getLifetimeStats().then((fetchedStats) => {
+      if (cancelled) return
+      animateTo(normalizeLifetimeStats(fetchedStats, baseStats))
+    })
+
+    return () => {
+      cancelled = true
+      if (frameRef.current !== null) {
+        window.cancelAnimationFrame(frameRef.current)
+      }
+    }
+  }, [baseStats, durationMs])
+
+  return stats
 }

--- a/utils/lifetimeStats.ts
+++ b/utils/lifetimeStats.ts
@@ -50,11 +50,7 @@ function createParser() {
 function getAnimationStartValue(targetValue: number): number {
   if (targetValue <= 0) return 0
 
-  const discountedValue = targetValue * 0.79
-  const digits = Math.max(Math.floor(discountedValue).toString().length, 1)
-  const magnitude = 10 ** Math.max(digits - 2, 0)
-
-  return Math.floor(discountedValue / magnitude) * magnitude
+  return targetValue * 0.79
 }
 
 function createStartStats(targetStats: LifetimeStat[]): LifetimeStat[] {
@@ -90,9 +86,7 @@ function interpolateStats(
     const startItem = startStats[index] ?? targetItem
     return {
       label: targetItem.label,
-      value: Math.round(
-        startItem.value + (targetItem.value - startItem.value) * eased
-      ),
+      value: startItem.value + (targetItem.value - startItem.value) * eased,
     }
   })
 }

--- a/utils/lifetimeStats.ts
+++ b/utils/lifetimeStats.ts
@@ -50,13 +50,11 @@ function createParser() {
 function getAnimationStartValue(targetValue: number): number {
   if (targetValue <= 0) return 0
 
-  const digits = Math.max(Math.floor(targetValue).toString().length, 1)
+  const halvedValue = targetValue / 2
+  const digits = Math.max(Math.floor(halvedValue).toString().length, 1)
   const magnitude = 10 ** Math.max(digits - 2, 0)
-  const roundedDown = Math.floor(targetValue / magnitude) * magnitude
 
-  return roundedDown === targetValue
-    ? Math.max(targetValue - magnitude, 0)
-    : roundedDown
+  return Math.floor(halvedValue / magnitude) * magnitude
 }
 
 function createStartStats(targetStats: LifetimeStat[]): LifetimeStat[] {


### PR DESCRIPTION
Adds a minimal count-up animation for the lifetime totals so the stats start from a lower snapshot and settle on the live sheet values after hydration.

- shares the sheet fetch and animation logic in `utils/lifetimeStats.ts`
- animates `/transparency`, the shared `StatsSentence`, and the `40+ countries` count
- respects reduced-motion preferences and keeps client-side fallback behavior when the sheet is temporarily unavailable

Closes https://github.com/OpenSats/website/issues/723

---

Build preview:
- [/transparency](https://os-website-git-feat-animate-transparency-stats-opensats.vercel.app/transparency)
- [/map](https://os-website-git-feat-animate-transparency-stats-opensats.vercel.app/map)
