### PR TITLE
Add FOSS topic page

### DIFF
--- a/data/topics/foss.mdx
+++ b/data/topics/foss.mdx
@@ -22,12 +22,19 @@ People sometimes use "open-source" as shorthand for the same idea, though differ
 
 Satoshi Nakamoto made the Bitcoin-specific case clearly in 2009. Open code lets users verify security claims for themselves instead of outsourcing that trust:
 
-> Being open source means anyone can independently review the code. If it was closed source, nobody could verify the security. I think it's essential for a program of this nature to be open source.
->
-> <cite>
->   Satoshi Nakamoto, [Re: Questions about
->   Bitcoin](https://satoshi.nakamotoinstitute.org/quotes/trusted-third-parties/)
-> </cite>
+<blockquote>
+  <p>
+    Being open source means anyone can independently review the code. If it was
+    closed source, nobody could verify the security. I think it's essential for
+    a program of this nature to be open source.
+  </p>
+  <cite>
+    - Satoshi Nakamoto,{' '}
+    <a href="https://satoshi.nakamotoinstitute.org/quotes/trusted-third-parties/">
+      Re: Questions about Bitcoin
+    </a>
+  </cite>
+</blockquote>
 
 ## References
 

--- a/data/topics/foss.mdx
+++ b/data/topics/foss.mdx
@@ -1,0 +1,27 @@
+---
+title: 'FOSS'
+summary: 'Free and open-source software: software released under a license that lets anyone inspect, use, modify, and share the code.'
+category: 'Open Source'
+aliases:
+  [
+    'FLOSS',
+    'free software',
+    'open-source',
+    'open source',
+    'free and open-source',
+    'free and open-source software',
+    'free/libre and open-source software',
+  ]
+---
+
+FOSS stands for free and open-source software. FLOSS means the same thing, with the extra "libre" included to stress freedom rather than price. In both cases, the source code is available and the license gives users the right to inspect, use, modify, and share it.
+
+At OpenSats, this is the baseline for the work we fund. Software should be released under a free and open-source license, and the work should be produced in the open so other people can study it, build on it, and verify progress. That applies to software, tools, research, and educational material across Bitcoin, Nostr, and related freedom tech.
+
+People sometimes use "open-source" as shorthand for the same idea, though different communities emphasize different parts of the tradition. The Free Software movement centers user freedom. The Open Source movement centers collaborative development and practical adoption. OpenSats uses the broader umbrella term because both matter here: the work should be public, reusable, and permissionless to build on.
+
+## References
+
+- [Open Source Initiative: The Open Source Definition](https://opensource.org/osd)
+- [GNU: What is Free Software?](https://www.gnu.org/philosophy/free-sw.en.html)
+- [GNU: FLOSS and FOSS](https://www.gnu.org/philosophy/floss-and-foss.en.html)

--- a/data/topics/foss.mdx
+++ b/data/topics/foss.mdx
@@ -22,11 +22,11 @@ People sometimes use "open-source" as shorthand for the same idea, though differ
 
 Satoshi Nakamoto made the Bitcoin-specific case clearly in 2009. Open code lets users verify security claims for themselves instead of outsourcing that trust:
 
-> "Being open source means anyone can independently review the code. If it was closed source, nobody could verify the security. I think it's essential for a program of this nature to be open source."
+> Being open source means anyone can independently review the code. If it was closed source, nobody could verify the security. I think it's essential for a program of this nature to be open source.
 >
 > <cite>
->   Satoshi Nakamoto, ["Re: Questions about
->   Bitcoin"](https://satoshi.nakamotoinstitute.org/quotes/trusted-third-parties/)
+>   Satoshi Nakamoto, [Re: Questions about
+>   Bitcoin](https://satoshi.nakamotoinstitute.org/quotes/trusted-third-parties/)
 > </cite>
 
 ## References

--- a/data/topics/foss.mdx
+++ b/data/topics/foss.mdx
@@ -20,8 +20,18 @@ At OpenSats, this is the baseline for the work we fund. Software should be relea
 
 People sometimes use "open-source" as shorthand for the same idea, though different communities emphasize different parts of the tradition. The Free Software movement centers user freedom. The Open Source movement centers collaborative development and practical adoption. OpenSats uses the broader umbrella term because both matter here: the work should be public, reusable, and permissionless to build on.
 
+Satoshi Nakamoto made the Bitcoin-specific case clearly in 2009. Open code lets users verify security claims for themselves instead of outsourcing that trust:
+
+> "Being open source means anyone can independently review the code. If it was closed source, nobody could verify the security. I think it's essential for a program of this nature to be open source."
+>
+> <cite>
+>   Satoshi Nakamoto, ["Re: Questions about
+>   Bitcoin"](https://satoshi.nakamotoinstitute.org/quotes/trusted-third-parties/)
+> </cite>
+
 ## References
 
 - [Open Source Initiative: The Open Source Definition](https://opensource.org/osd)
 - [GNU: What is Free Software?](https://www.gnu.org/philosophy/free-sw.en.html)
 - [GNU: FLOSS and FOSS](https://www.gnu.org/philosophy/floss-and-foss.en.html)
+- [The Quotable Satoshi: Trusted Third Parties](https://satoshi.nakamotoinstitute.org/quotes/trusted-third-parties/)

--- a/pages/topics/categories.tsx
+++ b/pages/topics/categories.tsx
@@ -14,6 +14,7 @@ const CATEGORY_ORDER = [
   'Mining',
   'Nostr',
   'Scaling',
+  'Open Source',
 ]
 
 type Group = {


### PR DESCRIPTION
Adds a new `FOSS` topic page so `FLOSS`, `open-source`, and related terms have a shared definition in the OpenSats glossary.

- adds aliases for `FLOSS`, `open-source`, and related terms
- groups the page under `Open Source` in the topics category index

Closes https://github.com/OpenSats/content/issues/93

---

Build preview:
- [/topics/foss](https://os-website-git-content-add-foss-topic-opensats.vercel.app/topics/foss)
- [/topics/categories](https://os-website-git-content-add-foss-topic-opensats.vercel.app/topics/categories)
