### PR TITLE
Add FAQ entry for the OpenSats name

### DIFF
--- a/data/pages/faq.mdx
+++ b/data/pages/faq.mdx
@@ -43,10 +43,10 @@ infrastructure.
 
 ## Why the name OpenSats?
 
-Open refers to [free and open-source software](/topics/foss). Sats refers to
-[satoshis](/topics/sats), the base unit of bitcoin. We send sats to open-source
-developers so they can focus on code instead of worrying about money. Hence:
-OpenSats.
+_Open_ refers to [free and open-source software](/topics/foss). _Sats_ refers
+to [satoshis](/topics/sats), the base unit of bitcoin. We send sats to
+open-source developers so they can focus on code instead of worrying about
+money. Hence: OpenSats.
 
 ## How are funds distributed?
 

--- a/data/pages/faq.mdx
+++ b/data/pages/faq.mdx
@@ -8,6 +8,7 @@ layout: PageLayout
 Frequently asked questions:
 
 - [What are you doing at OpenSats?](#what-are-you-doing-at-opensats)
+- [Why the name OpenSats?](#why-the-name-opensats)
 - [How are funds distributed?](#how-are-funds-distributed)
 - [How much of my donation goes towards open-source contributors?](#how-much-of-my-donation-goes-towards-open-source-contributors)
 - [How can I donate to OpenSats?](#how-can-i-donate-to-opensats)
@@ -39,6 +40,17 @@ We distribute grants to a wide variety of contributor types (developers,
 designers, researchers, educators, reviewers...), but only to those working on
 Bitcoin and open-source projects that will improve public access to Bitcoin
 infrastructure.
+
+## Why the name OpenSats?
+
+The name says what we support and how we support it.
+
+**Open** refers to [free and open-source](/topics/foss) work. We fund software,
+tools, research, and education that are built in the open and can be inspected,
+reused, and improved by anyone.
+
+**Sats** refers to [satoshis](/topics/sats), the smallest unit of bitcoin. We
+send sats to contributors working on Bitcoin and related freedom tech.
 
 ## How are funds distributed?
 

--- a/data/pages/faq.mdx
+++ b/data/pages/faq.mdx
@@ -43,13 +43,10 @@ infrastructure.
 
 ## Why the name OpenSats?
 
-Because we fund open-source work with sats.
-
-**Open** refers to [free and open-source](/topics/foss) software, research, and
-education.
-
-**Sats** refers to [satoshis](/topics/sats), the bitcoin unit we use for
-grants.
+Open refers to [free and open-source software](/topics/foss). Sats refers to
+[satoshis](/topics/sats), the base unit of bitcoin. We send sats to open-source
+developers so they can focus on code instead of worrying about money. Hence:
+OpenSats.
 
 ## How are funds distributed?
 

--- a/data/pages/faq.mdx
+++ b/data/pages/faq.mdx
@@ -43,12 +43,12 @@ infrastructure.
 
 ## Why the name OpenSats?
 
-Because we fund open work with sats.
+Because we fund open-source work with sats.
 
-**Open** points to [free and open-source](/topics/foss) software, research, and
-education done in the open.
+**Open** refers to [free and open-source](/topics/foss) software, research, and
+education.
 
-**Sats** points to [satoshis](/topics/sats), the bitcoin unit we use for
+**Sats** refers to [satoshis](/topics/sats), the bitcoin unit we use for
 grants.
 
 ## How are funds distributed?

--- a/data/pages/faq.mdx
+++ b/data/pages/faq.mdx
@@ -43,14 +43,13 @@ infrastructure.
 
 ## Why the name OpenSats?
 
-The name says what we support and how we support it.
+Because we fund open work with sats.
 
-**Open** refers to [free and open-source](/topics/foss) work. We fund software,
-tools, research, and education that are built in the open and can be inspected,
-reused, and improved by anyone.
+**Open** points to [free and open-source](/topics/foss) software, research, and
+education done in the open.
 
-**Sats** refers to [satoshis](/topics/sats), the smallest unit of bitcoin. We
-send sats to contributors working on Bitcoin and related freedom tech.
+**Sats** points to [satoshis](/topics/sats), the bitcoin unit we use for
+grants.
 
 ## How are funds distributed?
 


### PR DESCRIPTION
Adds a `Why the name OpenSats?` entry to `/faq` so the name is explained in one place and links back to the `foss` and `sats` topic pages.

- adds the new FAQ entry to `data/pages/faq.mdx`
- links `Open` to `/topics/foss` and `Sats` to `/topics/sats`

Closes https://github.com/OpenSats/content/issues/92

---

Build preview:
- [/faq#why-the-name-opensats](https://os-website-git-content-add-opensats-name-faq-opensats.vercel.app/faq#why-the-name-opensats)
