### PR TITLE
Add Utreexo topic page

### DIFF
--- a/data/topics/utreexo.mdx
+++ b/data/topics/utreexo.mdx
@@ -11,7 +11,7 @@ When a transaction spends a coin, the spender or a bridge node supplies an inclu
 
 This shifts some cost from local storage to extra proof data and bandwidth. The payoff is that fully validating compact-state nodes become practical on smaller machines, and sync strategies such as SwiftSync can parallelize more of the initial block download work.
 
-OpenSats has funded work on the protocol itself and on implementations built around it, including [utreexod](https://github.com/utreexo/utreexod) and [Floresta](/projects/floresta). Draft BIPs now cover the accumulator format, validation rules, and P2P messages needed for interoperable implementations.
+OpenSats has funded work on the protocol itself and on implementations built around it, including [utreexod](/projects/utreexod) and [Floresta](/projects/floresta). Draft BIPs now cover the accumulator format, validation rules, and P2P messages needed for interoperable implementations.
 
 ## References
 

--- a/data/topics/utreexo.mdx
+++ b/data/topics/utreexo.mdx
@@ -1,0 +1,21 @@
+---
+title: 'Utreexo'
+summary: 'A protocol for representing the Bitcoin UTXO set with a small accumulator and inclusion proofs.'
+category: 'Scaling'
+aliases: ['utreexo accumulator', 'compact-state node', 'compact state node']
+---
+
+Utreexo is a proposed protocol for representing Bitcoin's UTXO set with a small cryptographic accumulator instead of storing every unspent output directly. In practice, the accumulator is usually described as a forest of Merkle trees that commits to the current UTXO set.
+
+When a transaction spends a coin, the spender or a bridge node supplies an inclusion proof showing that the spent output is part of that committed set. A validating node can check the proof, update its accumulator, and keep enforcing Bitcoin's consensus rules without keeping the full UTXO set on disk.
+
+This shifts some cost from local storage to extra proof data and bandwidth. The payoff is that fully validating compact-state nodes become practical on smaller machines, and sync strategies such as SwiftSync can parallelize more of the initial block download work.
+
+OpenSats has funded work on the protocol itself and on implementations built around it, including [utreexod](https://github.com/utreexo/utreexod) and [Floresta](/projects/floresta). Draft BIPs now cover the accumulator format, validation rules, and P2P messages needed for interoperable implementations.
+
+## References
+
+- [Utreexo paper](https://eprint.iacr.org/2019/611)
+- [Bitcoin Optech: Utreexo](https://bitcoinops.org/en/topics/utreexo/)
+- [BIPs for Utreexo](https://github.com/bitcoin/bips/pull/1923)
+- [utreexo/utreexo](https://github.com/utreexo/utreexo)

--- a/data/topics/utreexo.mdx
+++ b/data/topics/utreexo.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Utreexo'
 summary: 'A protocol for representing the Bitcoin UTXO set with a small accumulator and inclusion proofs.'
-category: 'Scaling'
+category: 'Bitcoin'
 aliases: ['utreexo accumulator', 'compact-state node', 'compact state node']
 ---
 

--- a/data/topics/utreexo.mdx
+++ b/data/topics/utreexo.mdx
@@ -5,7 +5,7 @@ category: 'Scaling'
 aliases: ['utreexo accumulator', 'compact-state node', 'compact state node']
 ---
 
-Utreexo is a proposed protocol for representing Bitcoin's UTXO set with a small cryptographic accumulator instead of storing every unspent output directly. In practice, the accumulator is usually described as a forest of Merkle trees that commits to the current UTXO set.
+Utreexo is a proposed protocol for representing Bitcoin's [UTXO](/topics/utxo) set with a small cryptographic accumulator instead of storing every unspent output directly. In practice, the accumulator is usually described as a forest of Merkle trees that commits to the current UTXO set.
 
 When a transaction spends a coin, the spender or a bridge node supplies an inclusion proof showing that the spent output is part of that committed set. A validating node can check the proof, update its accumulator, and keep enforcing Bitcoin's consensus rules without keeping the full UTXO set on disk.
 


### PR DESCRIPTION
Adds a new `Utreexo` topic page so the protocol has a clear glossary entry alongside related OpenSats project and blog coverage.

- explains the accumulator model and the proof and bandwidth trade-off
- groups the page under `Scaling` in the topics category index

Closes https://github.com/OpenSats/content/issues/94

---

Build preview:
- [/topics/utreexo](https://os-website-git-content-add-utreexo-topic-opensats.vercel.app/topics/utreexo)
- [/topics/categories](https://os-website-git-content-add-utreexo-topic-opensats.vercel.app/topics/categories)
