### PR TITLE
Disallow outdated grant numbers in report form

### DIFF
--- a/pages/api/grant.ts
+++ b/pages/api/grant.ts
@@ -53,7 +53,12 @@ export default async function handler(
 
     // Iterate through all issues using pagination and stop when we find a match
     let matchingIssue:
-      | { title: string; body?: string | null; number: number }
+      | {
+          title: string
+          body?: string | null
+          number: number
+          state: 'open' | 'closed'
+        }
       | undefined
 
     for await (const { data: issues } of octokit.paginate.iterator(
@@ -77,6 +82,7 @@ export default async function handler(
           title: found.title,
           body: found.body,
           number: found.number,
+          state: found.state as 'open' | 'closed',
         }
         break
       }
@@ -86,6 +92,13 @@ export default async function handler(
       return res.status(404).json({
         valid: false,
         error: ERROR_MESSAGES.GRANT_NOT_FOUND,
+      })
+    }
+
+    if (matchingIssue.state === 'closed') {
+      return res.status(409).json({
+        valid: false,
+        error: ERROR_MESSAGES.PAST_GRANT,
       })
     }
 

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -8,6 +8,8 @@ export const STORAGE_KEYS = {
 
 export const ERROR_MESSAGES = {
   GRANT_NOT_FOUND: 'Grant not found, contact support for assistance',
+  PAST_GRANT:
+    'This is a past grant that already ended. Please use your new grant number.',
 }
 
 export const MONTHLY_DONATION_URL =


### PR DESCRIPTION
Prevents grantees from authenticating with an old grant number when the matching reports issue is already closed.

- Returns a specific validation error for past grants
- Leaves active grant validation unchanged

Closes OpenSats/website#734

---

Build preview:
- [/reports/submit](https://os-website-git-fix-disallow-outdated-grant-numbers-opensats.vercel.app/reports/submit)
