### PR TITLE
Fix invisible theme switcher icon on iOS mobile

### DIFF
--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -32,6 +32,8 @@ const ThemeSwitch = () => {
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 20 20"
         fill="currentColor"
+        className="h-5 w-5 flex-shrink-0"
+        aria-hidden="true"
       >
         {!mounted ? null : current === 'light' ? (
           <path


### PR DESCRIPTION
Keeps the theme switcher icon visible on iOS mobile by giving the inline SVG explicit dimensions.

- Adds fixed sizing to the inline SVG inside `ThemeSwitch`
- Leaves the existing tri-state theme behavior unchanged

Closes OpenSats/website#736

---

Build preview:
- [/](https://os-website-git-fix-ios-theme-switcher-icons-opensats.vercel.app/)
