### PR TITLE
Add fuzzing topic page

### DIFF
--- a/data/projects/bitcoinfuzz.mdx
+++ b/data/projects/bitcoinfuzz.mdx
@@ -11,7 +11,7 @@ fund: general
 announcementLink: '/blog/bruno-garcia-receives-lts-grant'
 ---
 
-`bitcoinfuzz` is a differential fuzzing harness for Bitcoin implementations and libraries. It builds multiple modules side by side, feeds them the same randomized inputs, and compares how they parse, validate, and serialize data. That catches crashes, consensus edge cases, and behavior mismatches before they ship downstream.
+`bitcoinfuzz` is a differential [fuzzing](/topics/fuzzing) harness for Bitcoin implementations and libraries. It builds multiple modules side by side, feeds them the same randomized inputs, and compares how they parse, validate, and serialize data. That catches crashes, consensus edge cases, and behavior mismatches before they ship downstream.
 
 The public repository already covers a broad set of Bitcoin, Lightning, and library modules, along with a separate public [corpora](https://github.com/bitcoinfuzz/corpora) repository for shared fuzz inputs. Public work on the repo shows the direction clearly. Earlier fuzzing exposed a critical NBitcoin consensus bug through script evaluation, and newer public pull requests add differential `libbitcoinkernel` modules, the first Utreexo target with `rustreexo`, `libwally-core`, `bitcoin-s`, and a `verify_script` target across Bitcoin Core, `btcd`, and NBitcoin.
 

--- a/data/topics/fuzzing.mdx
+++ b/data/topics/fuzzing.mdx
@@ -1,0 +1,28 @@
+---
+title: 'Fuzzing'
+summary: 'Automated testing that feeds malformed or randomized inputs into software to expose crashes, logic bugs, and inconsistent behavior.'
+category: 'Open Source'
+aliases:
+  [
+    'fuzz testing',
+    'fuzzer',
+    'fuzzers',
+    'differential fuzzing',
+    'coverage-guided fuzzing',
+  ]
+---
+
+**Fuzzing** is an automated testing technique that feeds software large numbers of unexpected, malformed, or randomized inputs and watches what breaks. A good fuzz target treats every crash, hang, assertion failure, memory error, or inconsistent result as a bug worth investigating.
+
+Modern fuzzers usually mutate a seed corpus, keep inputs that reach new code paths, and then keep iterating. That makes fuzzing especially good at finding edge cases that are tedious to cover by hand. It is widely used on parsers, network protocols, script engines, wallet logic, and other code that has to handle untrusted input safely.
+
+Some fuzzers focus on one implementation at a time. **Differential fuzzing** compares two or more implementations with the same input and flags mismatches in parsing, validation, or serialization. That matters in Bitcoin and Lightning, where consensus and interoperability depend on separate codebases agreeing on the same rules.
+
+OpenSats funds projects that use fuzzing to harden critical freedom tech. [bitcoinfuzz](/projects/bitcoinfuzz) focuses on cross-implementation testing in the Bitcoin stack, and other grantees use fuzzing to improve protocol libraries, node software, and security tooling.
+
+## References
+
+- [Wikipedia: Fuzzing](https://en.wikipedia.org/wiki/Fuzzing)
+- [Google OSS-Fuzz](https://google.github.io/oss-fuzz/)
+- [Bitcoin Core fuzzing docs](https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md)
+- [bitcoinfuzz/bitcoinfuzz](https://github.com/bitcoinfuzz/bitcoinfuzz)


### PR DESCRIPTION
Adds a `fuzzing` topic page so `bitcoinfuzz` and future fuzzing-related content can link to a shared glossary entry.

- adds `/topics/fuzzing` with a short definition, aliases, and references
- links `bitcoinfuzz` to the new topic page

Closes OpenSats/content#105

---

Build preview:
- [/topics/fuzzing](https://os-website-git-content-add-fuzzing-topic-opensats.vercel.app/topics/fuzzing)
- [/projects/bitcoinfuzz](https://os-website-git-content-add-fuzzing-topic-opensats.vercel.app/projects/bitcoinfuzz)
