### PR TITLE
Remove `grants` tag from Call for Applications post

### DIFF
--- a/data/blog/call-for-applications-spring-2026.mdx
+++ b/data/blog/call-for-applications-spring-2026.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Call for Applications"
 date: '2026-04-29'
-tags: ['OpenSats', 'bitcoin', 'grants', 'applications']
+tags: ['OpenSats', 'bitcoin', 'applications']
 authors: ['default', 'arvin', 'tuma', 'btcschellingpt']
 images: ['/static/images/blog/107-call-for-applications-spring-2026.jpg']
 draft: false


### PR DESCRIPTION
This removes the `grants` tag from the spring 2026 `Call for Applications` post so it no longer appears in grant lists linked elsewhere.

Closes OpenSats/website#751

---
Build preview:
- [Call for Applications](https://os-website-git-content-remove-grants-tag-call-f-709031-opensats.vercel.app/blog/call-for-applications-spring-2026)
