### PR TITLE
feat(showcase): add directory layout alternative

### DIFF
--- a/components/ShowcaseProjectEntry.tsx
+++ b/components/ShowcaseProjectEntry.tsx
@@ -1,0 +1,91 @@
+import Image from '@/components/Image'
+import Link from '@/components/Link'
+
+const FUND_LABELS: Record<FundId, string> = {
+  general: 'General Fund',
+  nostr: 'Nostr Fund',
+  ops: 'Operations Budget',
+}
+
+export type FundId = 'general' | 'nostr' | 'ops'
+
+export type ShowcaseProjectEntryProps = {
+  slug: string
+  title: string
+  summary: string
+  coverImage: string
+  darkCoverImage?: string
+  invertDarkImage?: boolean
+  nym: string
+  fund?: FundId
+}
+
+const ShowcaseProjectEntry: React.FC<ShowcaseProjectEntryProps> = ({
+  slug,
+  title,
+  summary,
+  coverImage,
+  darkCoverImage,
+  invertDarkImage,
+  nym,
+  fund,
+}) => {
+  return (
+    <li className="py-5 first:pt-0 last:pb-0">
+      <article className="grid gap-4 sm:grid-cols-[5.5rem_minmax(0,1fr)] sm:gap-5">
+        <Link href={slug} className="block">
+          <div className="aspect-square relative overflow-hidden rounded border border-gray-200 bg-white dark:border-gray-800 dark:bg-black">
+            <Image
+              alt={title}
+              src={coverImage}
+              darkSrc={darkCoverImage}
+              fill
+              sizes="88px"
+              className={`object-contain p-3 ${
+                invertDarkImage ? 'dark:invert' : ''
+              }`}
+            />
+          </div>
+        </Link>
+
+        <div className="min-w-0">
+          <h3 className="text-lg font-semibold leading-7 text-gray-900 dark:text-gray-100">
+            <Link
+              href={slug}
+              className="hover:text-primary-500 dark:hover:text-primary-400"
+            >
+              {title}
+            </Link>
+          </h3>
+          <p className="pt-1 text-sm text-gray-500 dark:text-gray-400">
+            by {nym}
+            {fund && (
+              <>
+                {' · '}
+                <Link
+                  href={`/funds/${fund}`}
+                  className="underline-offset-2 hover:text-primary-500 hover:underline dark:hover:text-primary-400"
+                >
+                  via the {FUND_LABELS[fund]}
+                </Link>
+              </>
+            )}
+          </p>
+          <p className="pt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">
+            {summary}
+          </p>
+          <p className="pt-3 text-sm font-medium leading-6">
+            <Link
+              href={slug}
+              className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+            >
+              View project page &rarr;
+            </Link>
+          </p>
+        </div>
+      </article>
+    </li>
+  )
+}
+
+export default ShowcaseProjectEntry

--- a/components/ShowcaseProjectEntry.tsx
+++ b/components/ShowcaseProjectEntry.tsx
@@ -32,7 +32,7 @@ const ShowcaseProjectEntry: React.FC<ShowcaseProjectEntryProps> = ({
 }) => {
   return (
     <li className="py-5 first:pt-0 last:pb-0">
-      <article className="relative grid grid-cols-[4rem_minmax(0,1fr)] items-start gap-3 pr-5 sm:grid-cols-[6rem_minmax(0,1fr)] sm:gap-5 sm:pr-0">
+      <article className="relative grid grid-cols-[4rem_minmax(0,1fr)] items-start gap-3 pr-6 sm:grid-cols-[6rem_minmax(0,1fr)] sm:gap-5 sm:pr-0">
         <Link href={slug} className="block">
           <div className="flex h-16 w-16 items-center justify-center overflow-hidden rounded border border-gray-200 bg-white dark:border-gray-800 dark:bg-black sm:h-24 sm:w-24">
             <Image
@@ -86,7 +86,7 @@ const ShowcaseProjectEntry: React.FC<ShowcaseProjectEntryProps> = ({
         <Link
           href={slug}
           aria-label={`Learn more about ${title}`}
-          className="absolute inset-y-0 right-0 flex items-center text-gray-300 transition-colors hover:text-gray-400 dark:text-gray-600 dark:hover:text-gray-500 sm:hidden"
+          className="absolute inset-y-0 -right-1 flex items-center text-gray-300 transition-colors hover:text-gray-400 dark:text-gray-600 dark:hover:text-gray-500 sm:hidden"
         >
           <svg
             aria-hidden="true"

--- a/components/ShowcaseProjectEntry.tsx
+++ b/components/ShowcaseProjectEntry.tsx
@@ -73,7 +73,7 @@ const ShowcaseProjectEntry: React.FC<ShowcaseProjectEntryProps> = ({
           <p className="pt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">
             {summary}
           </p>
-          <p className="pt-3 text-sm font-medium leading-6">
+          <p className="pt-3 text-right text-sm font-medium leading-6">
             <Link
               href={slug}
               className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"

--- a/components/ShowcaseProjectEntry.tsx
+++ b/components/ShowcaseProjectEntry.tsx
@@ -32,9 +32,9 @@ const ShowcaseProjectEntry: React.FC<ShowcaseProjectEntryProps> = ({
 }) => {
   return (
     <li className="py-5 first:pt-0 last:pb-0">
-      <article className="grid gap-4 sm:grid-cols-[6rem_minmax(0,1fr)] sm:gap-5">
+      <article className="grid grid-cols-[4rem_minmax(0,1fr)] items-start gap-3 sm:grid-cols-[6rem_minmax(0,1fr)] sm:gap-5">
         <Link href={slug} className="block">
-          <div className="flex h-24 w-24 items-center justify-center overflow-hidden rounded border border-gray-200 bg-white dark:border-gray-800 dark:bg-black">
+          <div className="flex h-16 w-16 items-center justify-center overflow-hidden rounded border border-gray-200 bg-white dark:border-gray-800 dark:bg-black sm:h-24 sm:w-24">
             <Image
               alt={title}
               src={coverImage}
@@ -42,7 +42,7 @@ const ShowcaseProjectEntry: React.FC<ShowcaseProjectEntryProps> = ({
               width={96}
               height={96}
               style={{ width: '100%', height: '100%', objectFit: 'contain' }}
-              className={`p-3 ${invertDarkImage ? 'dark:invert' : ''}`}
+              className={`p-2 sm:p-3 ${invertDarkImage ? 'dark:invert' : ''}`}
             />
           </div>
         </Link>

--- a/components/ShowcaseProjectEntry.tsx
+++ b/components/ShowcaseProjectEntry.tsx
@@ -78,7 +78,8 @@ const ShowcaseProjectEntry: React.FC<ShowcaseProjectEntryProps> = ({
               href={slug}
               className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
             >
-              View project page &rarr;
+              <span className="sr-only sm:not-sr-only">Learn more</span>
+              <span aria-hidden="true"> &rarr;</span>
             </Link>
           </p>
         </div>

--- a/components/ShowcaseProjectEntry.tsx
+++ b/components/ShowcaseProjectEntry.tsx
@@ -32,7 +32,7 @@ const ShowcaseProjectEntry: React.FC<ShowcaseProjectEntryProps> = ({
 }) => {
   return (
     <li className="py-5 first:pt-0 last:pb-0">
-      <article className="grid grid-cols-[4rem_minmax(0,1fr)] items-start gap-3 sm:grid-cols-[6rem_minmax(0,1fr)] sm:gap-5">
+      <article className="relative grid grid-cols-[4rem_minmax(0,1fr)] items-start gap-3 pr-5 sm:grid-cols-[6rem_minmax(0,1fr)] sm:gap-5 sm:pr-0">
         <Link href={slug} className="block">
           <div className="flex h-16 w-16 items-center justify-center overflow-hidden rounded border border-gray-200 bg-white dark:border-gray-800 dark:bg-black sm:h-24 sm:w-24">
             <Image
@@ -73,16 +73,35 @@ const ShowcaseProjectEntry: React.FC<ShowcaseProjectEntryProps> = ({
           <p className="pt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">
             {summary}
           </p>
-          <p className="pt-3 text-right text-sm font-medium leading-6">
+          <p className="hidden pt-3 text-right text-sm font-medium leading-6 sm:block">
             <Link
               href={slug}
               className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
             >
-              <span className="sr-only sm:not-sr-only">Learn more</span>
-              <span aria-hidden="true"> &rarr;</span>
+              Learn more &rarr;
             </Link>
           </p>
         </div>
+
+        <Link
+          href={slug}
+          aria-label={`Learn more about ${title}`}
+          className="absolute inset-y-0 right-0 flex items-center text-gray-300 transition-colors hover:text-gray-400 dark:text-gray-600 dark:hover:text-gray-500 sm:hidden"
+        >
+          <svg
+            aria-hidden="true"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            className="h-6 w-6"
+          >
+            <path
+              fillRule="evenodd"
+              d="M7.22 4.22a.75.75 0 0 1 1.06 0l5.25 5.25a.75.75 0 0 1 0 1.06l-5.25 5.25a.75.75 0 1 1-1.06-1.06L11.94 10 7.22 5.28a.75.75 0 0 1 0-1.06Z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </Link>
       </article>
     </li>
   )

--- a/components/ShowcaseProjectEntry.tsx
+++ b/components/ShowcaseProjectEntry.tsx
@@ -32,18 +32,17 @@ const ShowcaseProjectEntry: React.FC<ShowcaseProjectEntryProps> = ({
 }) => {
   return (
     <li className="py-5 first:pt-0 last:pb-0">
-      <article className="grid gap-4 sm:grid-cols-[5.5rem_minmax(0,1fr)] sm:gap-5">
+      <article className="grid gap-4 sm:grid-cols-[6rem_minmax(0,1fr)] sm:gap-5">
         <Link href={slug} className="block">
-          <div className="aspect-square relative overflow-hidden rounded border border-gray-200 bg-white dark:border-gray-800 dark:bg-black">
+          <div className="flex h-24 w-24 items-center justify-center overflow-hidden rounded border border-gray-200 bg-white dark:border-gray-800 dark:bg-black">
             <Image
               alt={title}
               src={coverImage}
               darkSrc={darkCoverImage}
-              fill
-              sizes="88px"
-              className={`object-contain p-3 ${
-                invertDarkImage ? 'dark:invert' : ''
-              }`}
+              width={96}
+              height={96}
+              style={{ width: '100%', height: '100%', objectFit: 'contain' }}
+              className={`p-3 ${invertDarkImage ? 'dark:invert' : ''}`}
             />
           </div>
         </Link>

--- a/pages/projects/showcase.tsx
+++ b/pages/projects/showcase.tsx
@@ -1,56 +1,120 @@
-import type { NextPage } from 'next'
-import { useEffect, useState } from 'react'
-import ProjectCard from '../../components/ProjectCard'
-import { allProjects } from 'contentlayer/generated'
-import { Project } from 'contentlayer/generated'
-import { isNotOpenSatsProject } from '../funds'
+import type { GetStaticProps, NextPage } from 'next'
 import Link from '@/components/Link'
 import { PageSEO } from '@/components/SEO'
+import ShowcaseProjectEntry from '@/components/ShowcaseProjectEntry'
+import type { FundId } from '@/components/ShowcaseProjectEntry'
+import { allProjects } from 'contentlayer/generated'
+import { buildClusters } from '@/utils/projectClusters'
 
-const ProjectShowcase: NextPage<{ projects: Project[] }> = ({ projects }) => {
-  const [sortedProjects, setSortedProjects] = useState<Project[]>()
+type EntryData = {
+  slug: string
+  title: string
+  summary: string
+  coverImage: string
+  darkCoverImage?: string
+  invertDarkImage?: boolean
+  nym: string
+  fund?: FundId
+}
 
-  useEffect(() => {
-    setSortedProjects(
-      projects.filter(isNotOpenSatsProject).sort(() => 0.5 - Math.random())
-    )
-  }, [projects])
+type RenderCluster = {
+  id: string
+  title: string
+  blurb: string
+  projects: EntryData[]
+}
 
+type ShowcaseProps = {
+  clusters: RenderCluster[]
+}
+
+const KNOWN_FUNDS: FundId[] = ['general', 'nostr', 'ops']
+
+function toEntryData(project: (typeof allProjects)[number]): EntryData {
+  const fund = (KNOWN_FUNDS as string[]).includes(project.fund || '')
+    ? (project.fund as FundId)
+    : undefined
+
+  return {
+    slug: `/projects/${project.slug}`,
+    title: project.title,
+    summary: project.summary,
+    coverImage: project.coverImage,
+    darkCoverImage: project.darkCoverImage,
+    invertDarkImage: project.invertDarkImage,
+    nym: project.nym,
+    fund,
+  }
+}
+
+const ProjectShowcase: NextPage<ShowcaseProps> = ({ clusters }) => {
   return (
     <>
       <PageSEO
         title="Project Showcase - OpenSats"
         description="A showcase of free and open-source Bitcoin and Nostr projects supported by OpenSats."
       />
-      <section className="flex flex-col p-4 md:p-8">
-        <div className="flex w-full items-center justify-between pb-8">
-          <h1 id="funds">Project Showcase</h1>
-        </div>
-        <ul className="grid max-w-5xl grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-4">
-          {sortedProjects &&
-            sortedProjects.map((p, i) => (
-              <li key={i} className="">
-                <ProjectCard
-                  slug={`/projects/${p.slug}`}
-                  title={p.title}
-                  summary={p.summary}
-                  coverImage={p.coverImage}
-                  darkCoverImage={p.darkCoverImage}
-                  invertDarkImage={p.invertDarkImage}
-                  nym={p.nym}
-                  tags={p.tags}
-                />
-              </li>
-            ))}
-        </ul>
+
+      <section className="pt-4 md:pb-8">
+        <h1 className="py-2 text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 max-[375px]:text-2xl sm:text-3xl sm:leading-10 md:py-4 md:text-5xl md:leading-14 lg:text-6xl">
+          Project Showcase
+        </h1>
+        <p className="max-w-3xl pt-3 text-lg leading-7 text-gray-500 dark:text-gray-400">
+          OpenSats has funded work across Bitcoin and Nostr, from full node
+          infrastructure to wallets, payments, and education. This page groups a
+          selection of those projects by the part of the stack they help
+          strengthen.
+        </p>
+        <p className="max-w-3xl pt-3 text-lg leading-7 text-gray-500 dark:text-gray-400">
+          For the full list, see our{' '}
+          <Link
+            href="/tags/grants"
+            className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+          >
+            grant announcements
+          </Link>
+          .
+        </p>
       </section>
-      <div className="flex justify-end pt-4 text-base font-medium leading-6">
+
+      <div className="divide-y divide-gray-200 dark:divide-gray-700">
+        {clusters.map((cluster) => (
+          <section
+            key={cluster.id}
+            className="grid gap-8 py-10 first:pt-6 lg:grid-cols-[minmax(0,16rem)_minmax(0,1fr)] lg:gap-12"
+          >
+            <div>
+              <h2 className="text-2xl font-bold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-3xl">
+                {cluster.title}
+              </h2>
+              <p className="pt-2 text-base leading-7 text-gray-500 dark:text-gray-400">
+                {cluster.blurb}
+              </p>
+            </div>
+
+            <ul className="divide-y divide-gray-200 dark:divide-gray-800">
+              {cluster.projects.map((project) => (
+                <ShowcaseProjectEntry key={project.slug} {...project} />
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap justify-end gap-6 pt-4 text-base font-medium leading-6">
+        <Link
+          href="/apply"
+          className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+          aria-label="Apply for funding"
+        >
+          Apply for funding &rarr;
+        </Link>
         <Link
           href="/tags/grants"
           className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
-          aria-label="All Grants"
+          aria-label="All grant announcements"
         >
-          All Grants &rarr;
+          All grant announcements &rarr;
         </Link>
       </div>
     </>
@@ -59,12 +123,18 @@ const ProjectShowcase: NextPage<{ projects: Project[] }> = ({ projects }) => {
 
 export default ProjectShowcase
 
-export async function getStaticProps() {
-  const projects = allProjects
+export const getStaticProps: GetStaticProps<ShowcaseProps> = async () => {
+  const clusters: RenderCluster[] = buildClusters(allProjects).map(
+    (cluster) => ({
+      id: cluster.id,
+      title: cluster.title,
+      blurb: cluster.blurb,
+      projects: cluster.projects.map((project) => toEntryData(project)),
+    })
+  )
 
   return {
-    props: {
-      projects,
-    },
+    props: JSON.parse(JSON.stringify({ clusters })),
+    revalidate: 60 * 60 * 12,
   }
 }

--- a/utils/projectClusters.ts
+++ b/utils/projectClusters.ts
@@ -1,0 +1,124 @@
+import type { Project } from 'contentlayer/generated'
+
+export type Cluster = {
+  id: string
+  title: string
+  blurb: string
+  slugs: string[]
+}
+
+export type ResolvedCluster = Omit<Cluster, 'slugs'> & {
+  projects: Project[]
+}
+
+export const CLUSTERS: Cluster[] = [
+  {
+    id: 'privacy-infra',
+    title: 'Privacy & Infrastructure',
+    blurb: 'The plumbing that keeps the rest of the stack honest.',
+    slugs: ['tor', 'grapheneos', 'pdk', 'wireguard'],
+  },
+  {
+    id: 'core',
+    title: 'Protocol Maintenance & Development',
+    blurb: 'The full node, validation, and the protocol underneath.',
+    slugs: [
+      'bitcoin-core',
+      'libbitcoin',
+      'floresta',
+      'utreexod',
+      'stratumv2',
+      'splicing',
+      'vls',
+      'asmap',
+    ],
+  },
+  {
+    id: 'education',
+    title: 'Education & Research',
+    blurb: 'People bringing in the next wave of contributors.',
+    slugs: [
+      'summerofbitcoin',
+      'satoshinakamotoinstitute',
+      'bitcoindesign',
+      'bitshala',
+    ],
+  },
+  {
+    id: 'dev-tooling-testing',
+    title: 'Developer Tooling & Testing',
+    blurb:
+      'Libraries, kits, and workflow tools engineers use to build and ship.',
+    slugs: [
+      'bdk',
+      'rust-bitcoin',
+      'cdk',
+      'ndk',
+      'ngit',
+      'bitcoinfuzz',
+      'bitcoinresearchkit',
+    ],
+  },
+  {
+    id: 'wallets',
+    title: 'Wallets',
+    blurb: 'Self-custody software people actually use.',
+    slugs: ['cove', 'blixt', 'blitz-wallet', 'dana-wallet'],
+  },
+  {
+    id: 'lightning-payments',
+    title: 'Merchant Tooling & Payments',
+    blurb: 'Payments, point-of-sale, and merchant tooling on Lightning.',
+    slugs: ['btcpayserver', 'lnbits', 'mostro'],
+  },
+  {
+    id: 'chaumian-ecash',
+    title: 'Chaumian ecash',
+    blurb: 'Ecash wallets and mint software on Cashu.',
+    slugs: ['minibits', 'cashu', 'opencash'],
+  },
+  {
+    id: 'nostr-clients',
+    title: 'Nostr Clients',
+    blurb: 'How people read and post on nostr today.',
+    slugs: ['damus', 'amethyst', '0xchat', 'coracle', 'flotilla', 'soapbox'],
+  },
+  {
+    id: 'nostr-infra',
+    title: 'Nostr Infrastructure',
+    blurb: 'Relays, libraries, signers, and developer tooling.',
+    slugs: ['applesauce', 'citrine', 'frostr', 'amber', 'zapstore'],
+  },
+]
+
+export function buildClusters(allProjects: Project[]): ResolvedCluster[] {
+  const bySlug = new Map(allProjects.map((p) => [p.slug, p]))
+
+  const resolved = CLUSTERS.map(({ slugs, ...rest }) => ({
+    ...rest,
+    projects: slugs
+      .map((slug) => bySlug.get(slug))
+      .filter((p): p is Project => Boolean(p))
+      .sort((a, b) =>
+        a.title.localeCompare(b.title, undefined, { sensitivity: 'base' })
+      ),
+  })).filter((cluster) => cluster.projects.length > 0)
+
+  if (process.env.NODE_ENV !== 'production') {
+    const clustered = new Set(CLUSTERS.flatMap((cluster) => cluster.slugs))
+    const orphans = allProjects
+      .filter(
+        (project) => project.nym !== 'OpenSats' && !clustered.has(project.slug)
+      )
+      .map((project) => project.slug)
+
+    if (orphans.length > 0) {
+      console.warn(
+        `[projectClusters] ${orphans.length} project(s) not in any cluster:`,
+        orphans
+      )
+    }
+  }
+
+  return resolved
+}


### PR DESCRIPTION
This is an alternative direction for `/projects/showcase` that avoids the horizontal card layout from `#749` and presents the same curated selection as a quieter directory page.

- keeps the editorial project groupings while switching to simple text-first rows
- links each entry back to its project page instead of surfacing a wide card grid

---
Build preview:
- [/projects/showcase](https://os-website-git-feat-showcase-directory-layout-opensats.vercel.app/projects/showcase)
