### PR TITLE
feat(showcase): refine project showcase

### DIFF
--- a/data/blog/2024-year-in-review.mdx
+++ b/data/blog/2024-year-in-review.mdx
@@ -529,7 +529,7 @@ for your time, care, and attention. You could be spending it on anything else,
 but you choose to spend it on bitcoin and freedom tech. Thank you. We are beyond
 grateful for the support we received, both monetarily as well as in the form of
 community and [volunteer efforts](/about#volunteers), and it's exhilarating to
-see the technical progress across [projects we support](/projects/showcase). You
+see the technical progress across [projects we support](/projects). You
 are what makes all of this work, and we couldn't be doing it without you.
 
 Here's to freedom, and an even better 2025. Onwards!

--- a/next.config.js
+++ b/next.config.js
@@ -101,13 +101,13 @@ module.exports = () => {
           permanent: true,
         },
         {
-          source: '/projects',
-          destination: '/funds',
+          source: '/projects/showcase',
+          destination: '/projects',
           permanent: true,
         },
         {
           source: '/projects/all',
-          destination: '/projects/showcase',
+          destination: '/projects',
           permanent: true,
         },
         {

--- a/pages/funds/index.tsx
+++ b/pages/funds/index.tsx
@@ -307,7 +307,7 @@ const FundsIndex: NextPage<FundsIndexProps> = ({ funds, lifetimeStats }) => {
 
       <div className="flex justify-end pt-8 text-base font-medium leading-6">
         <Link
-          href="/projects/showcase"
+          href="/projects"
           className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
           aria-label="Showcase of funded projects"
         >

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -316,7 +316,7 @@ export default function Home({
           <ProjectList projects={projects} />
           <div className="flex justify-end pt-4 text-base font-medium leading-6">
             <Link
-              href="/projects/showcase"
+              href="/projects"
               className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
               aria-label="View All Projects"
             >

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -60,7 +60,7 @@ const ProjectShowcase: NextPage<ShowcaseProps> = ({ clusters }) => {
           Project Showcase
         </h1>
         <p className="max-w-3xl pt-3 text-lg leading-7 text-gray-500 dark:text-gray-400">
-          The below is a showcase of various projects we are funding or have
+         Below is a showcase of various projects we are funding or have
           funded in the past. Please keep in mind that the list is not
           exhaustive. For the full list, see our{' '}
           <Link

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -60,9 +60,9 @@ const ProjectShowcase: NextPage<ShowcaseProps> = ({ clusters }) => {
           Project Showcase
         </h1>
         <p className="max-w-3xl pt-3 text-lg leading-7 text-gray-500 dark:text-gray-400">
-         Below is a showcase of various projects we are funding or have
-          funded in the past. Please keep in mind that the list is not
-          exhaustive. For the full list, see our{' '}
+          Below is a showcase of various projects we are funding or have funded
+          in the past. Please keep in mind that the list is not exhaustive. For
+          the full list, see our{' '}
           <Link
             href="/tags/grants"
             className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -60,8 +60,9 @@ const ProjectShowcase: NextPage<ShowcaseProps> = ({ clusters }) => {
           Project Showcase
         </h1>
         <p className="max-w-3xl pt-3 text-lg leading-7 text-gray-500 dark:text-gray-400">
-          Below is a showcase of projects we fund or have funded in the past.
-          The list is not exhaustive. For the full list, see our{' '}
+          The below is a showcase of various projects we are funding or have
+          funded in the past. Please keep in mind that the list is not
+          exhaustive. For the full list, see our{' '}
           <Link
             href="/tags/grants"
             className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -60,13 +60,8 @@ const ProjectShowcase: NextPage<ShowcaseProps> = ({ clusters }) => {
           Project Showcase
         </h1>
         <p className="max-w-3xl pt-3 text-lg leading-7 text-gray-500 dark:text-gray-400">
-          OpenSats has funded work across Bitcoin and Nostr, from full node
-          infrastructure to wallets, payments, and education. This page groups a
-          selection of those projects by the part of the stack they help
-          strengthen.
-        </p>
-        <p className="max-w-3xl pt-3 text-lg leading-7 text-gray-500 dark:text-gray-400">
-          For the full list, see our{' '}
+          Below is a showcase of projects we fund or have funded in the past.
+          The list is not exhaustive. For the full list, see our{' '}
           <Link
             href="/tags/grants"
             className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"

--- a/utils/projectClusters.ts
+++ b/utils/projectClusters.ts
@@ -22,7 +22,7 @@ export const CLUSTERS: Cluster[] = [
     id: 'privacy',
     title: 'Privacy',
     blurb: 'Wallet and payment tools built for more private Bitcoin use.',
-    slugs: ['pdk', 'dana-wallet'],
+    slugs: ['pdk', 'dana-wallet', 'mostro'],
   },
   {
     id: 'core',
@@ -74,7 +74,7 @@ export const CLUSTERS: Cluster[] = [
     id: 'lightning-payments',
     title: 'Merchant Tooling & Payments',
     blurb: 'Payments, point-of-sale, and merchant tooling on Lightning.',
-    slugs: ['btcpayserver', 'lnbits', 'mostro'],
+    slugs: ['btcpayserver', 'lnbits'],
   },
   {
     id: 'chaumian-ecash',

--- a/utils/projectClusters.ts
+++ b/utils/projectClusters.ts
@@ -13,10 +13,16 @@ export type ResolvedCluster = Omit<Cluster, 'slugs'> & {
 
 export const CLUSTERS: Cluster[] = [
   {
-    id: 'privacy-infra',
-    title: 'Privacy & Infrastructure',
-    blurb: 'The plumbing that keeps the rest of the stack honest.',
-    slugs: ['tor', 'grapheneos', 'pdk', 'wireguard'],
+    id: 'infrastructure',
+    title: 'Infrastructure',
+    blurb: 'Operating systems, anonymity networks, and secure networking.',
+    slugs: ['tor', 'grapheneos', 'wireguard'],
+  },
+  {
+    id: 'privacy',
+    title: 'Privacy',
+    blurb: 'Wallet and payment tools built for more private Bitcoin use.',
+    slugs: ['pdk', 'dana-wallet'],
   },
   {
     id: 'core',
@@ -63,7 +69,7 @@ export const CLUSTERS: Cluster[] = [
     id: 'wallets',
     title: 'Wallets',
     blurb: 'Self-custody software people actually use.',
-    slugs: ['cove', 'blixt', 'blitz-wallet', 'dana-wallet'],
+    slugs: ['cove', 'blixt', 'blitz-wallet'],
   },
   {
     id: 'lightning-payments',

--- a/utils/projectClusters.ts
+++ b/utils/projectClusters.ts
@@ -60,14 +60,7 @@ export const CLUSTERS: Cluster[] = [
     title: 'Developer Tooling & Testing',
     blurb:
       'Libraries, kits, and workflow tools engineers use to build and ship.',
-    slugs: [
-      'bdk',
-      'rust-bitcoin',
-      'ndk',
-      'ngit',
-      'bitcoinfuzz',
-      'bitcoinresearchkit',
-    ],
+    slugs: ['bdk', 'rust-bitcoin', 'bitcoinfuzz', 'bitcoinresearchkit'],
   },
   {
     id: 'wallets',
@@ -94,10 +87,16 @@ export const CLUSTERS: Cluster[] = [
     slugs: ['damus', 'amethyst', '0xchat', 'coracle', 'flotilla', 'soapbox'],
   },
   {
+    id: 'nostr-dev-tooling',
+    title: 'Nostr Developer Tooling',
+    blurb: 'SDKs and tools for building on nostr.',
+    slugs: ['applesauce', 'ndk', 'ngit'],
+  },
+  {
     id: 'nostr-infra',
     title: 'Nostr Infrastructure',
-    blurb: 'Relays, libraries, signers, and developer tooling.',
-    slugs: ['applesauce', 'citrine', 'frostr', 'amber', 'zapstore'],
+    blurb: 'Relays, signers, and core infrastructure for nostr.',
+    slugs: ['citrine', 'frostr', 'amber', 'zapstore'],
   },
 ]
 

--- a/utils/projectClusters.ts
+++ b/utils/projectClusters.ts
@@ -22,20 +22,12 @@ export const CLUSTERS: Cluster[] = [
     id: 'core',
     title: 'Protocol Maintenance & Development',
     blurb: 'The full node, validation, and the protocol underneath.',
-    slugs: [
-      'bitcoin-core',
-      'libbitcoin',
-      'floresta',
-      'utreexod',
-      'splicing',
-      'vls',
-      'asmap',
-    ],
+    slugs: ['bitcoin-core', 'libbitcoin', 'floresta', 'utreexod', 'asmap'],
   },
   {
     id: 'education',
     title: 'Education & Research',
-    blurb: 'People bringing in the next wave of contributors.',
+    blurb: 'Projects that bring in the next wave of contributors.',
     slugs: [
       'summerofbitcoin',
       'satoshinakamotoinstitute',
@@ -55,6 +47,12 @@ export const CLUSTERS: Cluster[] = [
     title: 'Mining',
     blurb: 'Mining protocols and infrastructure.',
     slugs: ['stratumv2'],
+  },
+  {
+    id: 'lightning',
+    title: 'Lightning',
+    blurb: 'Lightning protocols, security, and infrastructure.',
+    slugs: ['splicing', 'vls'],
   },
   {
     id: 'dev-tooling-testing',

--- a/utils/projectClusters.ts
+++ b/utils/projectClusters.ts
@@ -58,7 +58,6 @@ export const CLUSTERS: Cluster[] = [
     slugs: [
       'bdk',
       'rust-bitcoin',
-      'cdk',
       'ndk',
       'ngit',
       'bitcoinfuzz',
@@ -81,7 +80,7 @@ export const CLUSTERS: Cluster[] = [
     id: 'chaumian-ecash',
     title: 'Chaumian ecash',
     blurb: 'Ecash wallets and mint software on Cashu.',
-    slugs: ['minibits', 'cashu', 'opencash'],
+    slugs: ['minibits', 'cashu', 'cdk', 'opencash'],
   },
   {
     id: 'nostr-clients',

--- a/utils/projectClusters.ts
+++ b/utils/projectClusters.ts
@@ -27,7 +27,6 @@ export const CLUSTERS: Cluster[] = [
       'libbitcoin',
       'floresta',
       'utreexod',
-      'stratumv2',
       'splicing',
       'vls',
       'asmap',
@@ -49,6 +48,12 @@ export const CLUSTERS: Cluster[] = [
     title: 'Privacy',
     blurb: 'Wallet and payment tools built for more private Bitcoin use.',
     slugs: ['pdk', 'dana-wallet', 'mostro'],
+  },
+  {
+    id: 'mining',
+    title: 'Mining',
+    blurb: 'Mining protocols and infrastructure.',
+    slugs: ['stratumv2'],
   },
   {
     id: 'dev-tooling-testing',

--- a/utils/projectClusters.ts
+++ b/utils/projectClusters.ts
@@ -46,7 +46,8 @@ export const CLUSTERS: Cluster[] = [
   {
     id: 'privacy',
     title: 'Privacy',
-    blurb: 'Wallet and payment tools built for more private Bitcoin use.',
+    blurb:
+      'Wallet and payment tools built to make privacy best practices easier and more user-friendly.',
     slugs: ['pdk', 'dana-wallet', 'mostro'],
   },
   {

--- a/utils/projectClusters.ts
+++ b/utils/projectClusters.ts
@@ -64,7 +64,7 @@ export const CLUSTERS: Cluster[] = [
   {
     id: 'wallets',
     title: 'Wallets',
-    blurb: 'Self-custody software people actually use.',
+    blurb: 'Self-custody software built for everyday use.',
     slugs: ['cove', 'blixt', 'blitz-wallet'],
   },
   {

--- a/utils/projectClusters.ts
+++ b/utils/projectClusters.ts
@@ -21,7 +21,7 @@ export const CLUSTERS: Cluster[] = [
   {
     id: 'core',
     title: 'Protocol Maintenance & Development',
-    blurb: 'The full node, validation, and the protocol underneath.',
+    blurb: 'Full nodes, validation, and core protocol work.',
     slugs: ['bitcoin-core', 'libbitcoin', 'floresta', 'utreexod', 'asmap'],
   },
   {

--- a/utils/projectClusters.ts
+++ b/utils/projectClusters.ts
@@ -19,12 +19,6 @@ export const CLUSTERS: Cluster[] = [
     slugs: ['tor', 'grapheneos', 'wireguard'],
   },
   {
-    id: 'privacy',
-    title: 'Privacy',
-    blurb: 'Wallet and payment tools built for more private Bitcoin use.',
-    slugs: ['pdk', 'dana-wallet', 'mostro'],
-  },
-  {
     id: 'core',
     title: 'Protocol Maintenance & Development',
     blurb: 'The full node, validation, and the protocol underneath.',
@@ -49,6 +43,12 @@ export const CLUSTERS: Cluster[] = [
       'bitcoindesign',
       'bitshala',
     ],
+  },
+  {
+    id: 'privacy',
+    title: 'Privacy',
+    blurb: 'Wallet and payment tools built for more private Bitcoin use.',
+    slugs: ['pdk', 'dana-wallet', 'mostro'],
   },
   {
     id: 'dev-tooling-testing',


### PR DESCRIPTION
This follow-up makes `/projects` the main showcase page and tightens the first pass on the project groupings and intro copy.

- adds a dedicated `Privacy` section for Payjoin Dev Kit and Dana Wallet
- moves the showcase from `/projects/showcase` to `/projects` and keeps redirect coverage for old paths
- updates internal links to point at `/projects`

---
Build preview:
- [/projects](https://os-website-git-feat-showcase-refinements-opensats.vercel.app/projects)
- [/projects/showcase](https://os-website-git-feat-showcase-refinements-opensats.vercel.app/projects/showcase)
