### PR TITLE
Add ContextVM support link

### DIFF
--- a/data/projects/contextvm.mdx
+++ b/data/projects/contextvm.mdx
@@ -4,6 +4,7 @@ dateAdded: '2026-02-17'
 summary: 'A nostr-routed MCP protocol with SDKs, relays, and gateways for exposing services by public key.'
 nym: 'ContextVM contributors'
 website: 'https://contextvm.org/'
+donationLink: 'https://njump.to/npub1dvmcpmefwtnn6dctsj3728n64xhrf06p9yude77echmrkgs5zmyqw33jdm'
 coverImage: '/static/images/projects/contextvm.svg'
 darkCoverImage: '/static/images/projects/contextvm-dark.svg'
 containCoverImage: true

--- a/data/projects/contextvm.mdx
+++ b/data/projects/contextvm.mdx
@@ -4,7 +4,7 @@ dateAdded: '2026-02-17'
 summary: 'A nostr-routed MCP protocol with SDKs, relays, and gateways for exposing services by public key.'
 nym: 'ContextVM contributors'
 website: 'https://contextvm.org/'
-donationLink: 'https://njump.to/npub1dvmcpmefwtnn6dctsj3728n64xhrf06p9yude77echmrkgs5zmyqw33jdm'
+donationLink: 'https://jumble.social/users/npub1dvmcpmefwtnn6dctsj3728n64xhrf06p9yude77echmrkgs5zmyqw33jdm'
 coverImage: '/static/images/projects/contextvm.svg'
 darkCoverImage: '/static/images/projects/contextvm-dark.svg'
 containCoverImage: true


### PR DESCRIPTION
Adds a direct support link to the `ContextVM` project page so readers can jump to the project's Jumble profile and support it there.

- adds `donationLink` using the project's verified `npub` on Jumble
- keeps the rest of the `ContextVM` page unchanged as a small follow-up to `#763`

Follow-up to `#763`

---

Build preview:
- [/projects/contextvm](https://os-website-git-content-add-contextvm-support-link-opensats.vercel.app/projects/contextvm)
