### PR TITLE
Add Negentropy topic

### DIFF
--- a/data/topics/negentropy.mdx
+++ b/data/topics/negentropy.mdx
@@ -6,11 +6,11 @@ category: 'Nostr'
 aliases: ['NIP-77', 'Negentropy Syncing']
 ---
 
-Negentropy is a set reconciliation protocol. It lets two sides compare large sets efficiently, learn which entries each side has that the other side needs, and then transfer only the missing records. [Nostr](/topics/nostr) uses it to sync events between clients and relays.
+Negentropy is a set reconciliation protocol. It lets two sides compare large sets efficiently, learn which entries one side has that the other side is missing, and then transfer only the missing records. [Nostr](/topics/nostr) uses it to sync events between clients and [relays](/topics/relays).
 
-In Nostr, NIP-77 brings Negentropy into the protocol so a client and relay can compare the events they have within a chosen filter and sync whatever is missing.
+In Nostr, NIP-77 brings Negentropy into the protocol so a client and relay can compare the events they have for a chosen filter and sync whatever is missing.
 
-This makes sync cheaper when both sides already share much of the same history. It is useful for client-relay sync, relay-relay sync, and other cases where bandwidth matters.
+This reduces bandwidth when both sides already share much of the same history. It is useful for client-relay sync and relay-relay sync.
 
 ## References
 

--- a/data/topics/negentropy.mdx
+++ b/data/topics/negentropy.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Negentropy'
 summary: 'A general set reconciliation protocol that Nostr uses to help clients and relays figure out which events each side is missing without exchanging every event ID.'
+ogSummary: 'A general set reconciliation protocol that Nostr uses for efficient event syncing.'
 category: 'Nostr'
 aliases: ['NIP-77', 'Negentropy Syncing']
 ---

--- a/data/topics/negentropy.mdx
+++ b/data/topics/negentropy.mdx
@@ -1,16 +1,16 @@
 ---
 title: 'Negentropy'
-summary: 'A general set reconciliation protocol that Nostr uses to help clients and relays figure out which events each side is missing without exchanging every event ID.'
-ogSummary: 'A general set reconciliation protocol that Nostr uses for efficient event syncing.'
+summary: 'A set reconciliation protocol for finding which records each side is missing without exchanging every ID.'
+ogSummary: 'A set reconciliation protocol for finding which records each side is missing.'
 category: 'Nostr'
 aliases: ['NIP-77', 'Negentropy Syncing']
 ---
 
-Negentropy is a general set reconciliation protocol for comparing large sets efficiently. [Nostr](/topics/nostr) uses it for syncing. Negentropy is not Nostr-specific and was not developed for Nostr. Instead of sending a full list of event IDs, both sides exchange compact messages that reveal which items overlap and which ones are missing on either side.
+Negentropy is an existing set reconciliation protocol. It lets two sides compare large sets efficiently, learn which IDs each side has that the other side needs, and then transfer only the missing records. [Nostr](/topics/nostr) uses it for syncing.
 
-In Nostr, Negentropy is used through NIP-77, one of the Nostr [NIPs](/topics/nips). NIP-77 adapts the underlying protocol to Nostr so a client and relay can compare the events they have within a chosen filter. Once both sides know what is missing, they can sync the actual events through the usual Nostr flow.
+In Nostr, NIP-77 brings Negentropy into the protocol so a client and relay can compare the events they have within a chosen filter and sync whatever is missing.
 
-This makes sync cheaper when a client and relay already share much of the same history. It is useful for client-relay sync, relay-relay sync, and other cases where bandwidth matters and both sides want to reconcile large event sets with minimal overhead.
+This makes sync cheaper when both sides already share much of the same history. It is useful for client-relay sync, relay-relay sync, and other cases where bandwidth matters.
 
 ## References
 

--- a/data/topics/negentropy.mdx
+++ b/data/topics/negentropy.mdx
@@ -6,7 +6,9 @@ category: 'Nostr'
 aliases: ['NIP-77', 'Negentropy Syncing']
 ---
 
-Negentropy is an efficient set reconciliation protocol. It helps two sides figure out which records are missing on each side, so they can transfer only those records. In [Nostr](/topics/nostr), clients and [relays](/topics/relays) often already share most of the same events. Negentropy lets them find the gaps without exchanging full event sets or long lists of event IDs, which cuts bandwidth during sync.
+Negentropy is an efficient set reconciliation protocol. It helps two sides figure out which records are missing on each side, so they can transfer only those records.
+
+In [Nostr](/topics/nostr), clients and [relays](/topics/relays) often already share most of the same events. Negentropy lets them find the gaps without exchanging full event sets or long lists of event IDs, which cuts bandwidth during sync.
 
 NIP-77 wraps Negentropy for Nostr, so a client and relay can compare the events they have for a chosen filter and sync what is missing. It also works for relay-relay sync.
 

--- a/data/topics/negentropy.mdx
+++ b/data/topics/negentropy.mdx
@@ -6,7 +6,7 @@ category: 'Nostr'
 aliases: ['NIP-77', 'Negentropy Syncing']
 ---
 
-Negentropy is a set reconciliation protocol. It lets two sides compare large sets efficiently, learn which IDs each side has that the other side needs, and then transfer only the missing records. [Nostr](/topics/nostr) uses it for syncing.
+Negentropy is a set reconciliation protocol. It lets two sides compare large sets efficiently, learn which entries each side has that the other side needs, and then transfer only the missing records. [Nostr](/topics/nostr) uses it to sync events between clients and relays.
 
 In Nostr, NIP-77 brings Negentropy into the protocol so a client and relay can compare the events they have within a chosen filter and sync whatever is missing.
 

--- a/data/topics/negentropy.mdx
+++ b/data/topics/negentropy.mdx
@@ -6,7 +6,7 @@ category: 'Nostr'
 aliases: ['NIP-77', 'Negentropy Syncing']
 ---
 
-Negentropy is an existing set reconciliation protocol. It lets two sides compare large sets efficiently, learn which IDs each side has that the other side needs, and then transfer only the missing records. [Nostr](/topics/nostr) uses it for syncing.
+Negentropy is a set reconciliation protocol. It lets two sides compare large sets efficiently, learn which IDs each side has that the other side needs, and then transfer only the missing records. [Nostr](/topics/nostr) uses it for syncing.
 
 In Nostr, NIP-77 brings Negentropy into the protocol so a client and relay can compare the events they have within a chosen filter and sync whatever is missing.
 

--- a/data/topics/negentropy.mdx
+++ b/data/topics/negentropy.mdx
@@ -1,13 +1,13 @@
 ---
 title: 'Negentropy'
-summary: 'A set reconciliation protocol that lets Nostr clients and relays figure out which events each side is missing without exchanging every event ID.'
+summary: 'A general set reconciliation protocol that Nostr uses to help clients and relays figure out which events each side is missing without exchanging every event ID.'
 category: 'Nostr'
 aliases: ['NIP-77', 'Negentropy Syncing']
 ---
 
-Negentropy is a syncing method for [Nostr](/topics/nostr) that helps a client and a [relay](/topics/relays) compare event sets efficiently. Instead of sending a full list of event IDs, both sides exchange compact messages that reveal which events overlap and which ones are missing on either side.
+Negentropy is a general set reconciliation protocol for comparing large sets efficiently. [Nostr](/topics/nostr) uses it for syncing. Negentropy is not Nostr-specific and was not developed for Nostr. Instead of sending a full list of event IDs, both sides exchange compact messages that reveal which items overlap and which ones are missing on either side.
 
-In Nostr, Negentropy is defined in NIP-77, one of the Nostr [NIPs](/topics/nips). NIP-77 wraps the underlying binary Negentropy protocol in hex-encoded `NEG-OPEN`, `NEG-MSG`, and `NEG-CLOSE` messages, scoped to a normal Nostr filter. Once both sides learn which event IDs are missing, they can use ordinary Nostr messages such as `REQ` and `EVENT` to download or upload the actual events.
+In Nostr, Negentropy is used through NIP-77, one of the Nostr [NIPs](/topics/nips). NIP-77 is a Nostr-friendly wrapper around the underlying binary Negentropy protocol. It hex-encodes the protocol in `NEG-OPEN`, `NEG-MSG`, and `NEG-CLOSE` messages, scoped to a normal Nostr filter. Once both sides learn which event IDs are missing, they can use ordinary Nostr messages such as `REQ` and `EVENT` to download or upload the actual events.
 
 This makes sync cheaper when a client and relay already share much of the same history. It is useful for client-relay sync, relay-relay sync, and other cases where bandwidth matters and both sides want to reconcile large event sets with minimal overhead.
 

--- a/data/topics/negentropy.mdx
+++ b/data/topics/negentropy.mdx
@@ -1,16 +1,16 @@
 ---
 title: 'Negentropy'
-summary: 'A set reconciliation protocol for finding which records each side is missing without exchanging every ID.'
-ogSummary: 'A set reconciliation protocol for finding which records each side is missing.'
+summary: 'A set reconciliation protocol for finding missing records without sending every ID.'
+ogSummary: 'A set reconciliation protocol for finding missing records.'
 category: 'Nostr'
 aliases: ['NIP-77', 'Negentropy Syncing']
 ---
 
-Negentropy is a set reconciliation protocol. It lets two sides compare large sets efficiently, learn which entries one side has that the other side is missing, and then transfer only the missing records. [Nostr](/topics/nostr) uses it to sync events between clients and [relays](/topics/relays).
+Negentropy is a set reconciliation protocol. It helps two sides figure out which records are missing on each side, so they can transfer only those records. When both sides already share many records, this uses less bandwidth than sending the full set of records or even a full list of IDs. [Nostr](/topics/nostr) uses it to sync events between clients and [relays](/topics/relays).
 
-In Nostr, NIP-77 brings Negentropy into the protocol so a client and relay can compare the events they have for a chosen filter and sync whatever is missing.
+In Nostr, NIP-77 wraps Negentropy so a client and relay can compare the events they have for a chosen filter and sync what is missing.
 
-This reduces bandwidth when both sides already share much of the same history. It is useful for client-relay sync and relay-relay sync.
+It works for client-relay sync and relay-relay sync.
 
 ## References
 

--- a/data/topics/negentropy.mdx
+++ b/data/topics/negentropy.mdx
@@ -8,7 +8,7 @@ aliases: ['NIP-77', 'Negentropy Syncing']
 
 Negentropy is a general set reconciliation protocol for comparing large sets efficiently. [Nostr](/topics/nostr) uses it for syncing. Negentropy is not Nostr-specific and was not developed for Nostr. Instead of sending a full list of event IDs, both sides exchange compact messages that reveal which items overlap and which ones are missing on either side.
 
-In Nostr, Negentropy is used through NIP-77, one of the Nostr [NIPs](/topics/nips). NIP-77 is a Nostr-friendly wrapper around the underlying binary Negentropy protocol. It hex-encodes the protocol in `NEG-OPEN`, `NEG-MSG`, and `NEG-CLOSE` messages, scoped to a normal Nostr filter. Once both sides learn which event IDs are missing, they can use ordinary Nostr messages such as `REQ` and `EVENT` to download or upload the actual events.
+In Nostr, Negentropy is used through NIP-77, one of the Nostr [NIPs](/topics/nips). NIP-77 adapts the underlying protocol to Nostr so a client and relay can compare the events they have within a chosen filter. Once both sides know what is missing, they can sync the actual events through the usual Nostr flow.
 
 This makes sync cheaper when a client and relay already share much of the same history. It is useful for client-relay sync, relay-relay sync, and other cases where bandwidth matters and both sides want to reconcile large event sets with minimal overhead.
 

--- a/data/topics/negentropy.mdx
+++ b/data/topics/negentropy.mdx
@@ -1,0 +1,17 @@
+---
+title: 'Negentropy'
+summary: 'A set reconciliation protocol that lets Nostr clients and relays figure out which events each side is missing without exchanging every event ID.'
+category: 'Nostr'
+aliases: ['NIP-77', 'Negentropy Syncing']
+---
+
+Negentropy is a syncing method for [Nostr](/topics/nostr) that helps a client and a [relay](/topics/relays) compare event sets efficiently. Instead of sending a full list of event IDs, both sides exchange compact messages that reveal which events overlap and which ones are missing on either side.
+
+In Nostr, Negentropy is defined in NIP-77, one of the Nostr [NIPs](/topics/nips). NIP-77 wraps the underlying binary Negentropy protocol in hex-encoded `NEG-OPEN`, `NEG-MSG`, and `NEG-CLOSE` messages, scoped to a normal Nostr filter. Once both sides learn which event IDs are missing, they can use ordinary Nostr messages such as `REQ` and `EVENT` to download or upload the actual events.
+
+This makes sync cheaper when a client and relay already share much of the same history. It is useful for client-relay sync, relay-relay sync, and other cases where bandwidth matters and both sides want to reconcile large event sets with minimal overhead.
+
+## References
+
+- [NIP-77: Negentropy Syncing](https://github.com/nostr-protocol/nips/blob/master/77.md)
+- [hoytech/negentropy](https://github.com/hoytech/negentropy)

--- a/data/topics/negentropy.mdx
+++ b/data/topics/negentropy.mdx
@@ -6,7 +6,7 @@ category: 'Nostr'
 aliases: ['NIP-77', 'Negentropy Syncing']
 ---
 
-Negentropy is an efficient set reconciliation protocol. It helps two sides figure out which records are missing on each side, so they can transfer only those records.
+Negentropy is an efficient set reconciliation protocol used by modern Nostr clients and relays. It helps two sides figure out which records are missing on each side, so they can transfer only those records.
 
 In [Nostr](/topics/nostr), clients and [relays](/topics/relays) often already share most of the same events. Negentropy lets them find the gaps without exchanging full event sets or long lists of event IDs, which cuts bandwidth during sync.
 

--- a/data/topics/negentropy.mdx
+++ b/data/topics/negentropy.mdx
@@ -6,9 +6,7 @@ category: 'Nostr'
 aliases: ['NIP-77', 'Negentropy Syncing']
 ---
 
-Negentropy is an efficient set reconciliation protocol. It helps two sides figure out which records are missing on each side, so they can transfer only those records.
-
-In [Nostr](/topics/nostr), clients and [relays](/topics/relays) often already share most of the same events. Negentropy lets them find the gaps without exchanging full event sets or long lists of event IDs, which cuts bandwidth during sync.
+Negentropy is an efficient set reconciliation protocol. It helps two sides figure out which records are missing on each side, so they can transfer only those records. In [Nostr](/topics/nostr), clients and [relays](/topics/relays) often already share most of the same events. Negentropy lets them find the gaps without exchanging full event sets or long lists of event IDs, which cuts bandwidth during sync.
 
 NIP-77 wraps Negentropy for Nostr, so a client and relay can compare the events they have for a chosen filter and sync what is missing. It also works for relay-relay sync.
 

--- a/data/topics/negentropy.mdx
+++ b/data/topics/negentropy.mdx
@@ -6,11 +6,11 @@ category: 'Nostr'
 aliases: ['NIP-77', 'Negentropy Syncing']
 ---
 
-Negentropy is an efficient set reconciliation protocol. It helps two sides figure out which records are missing on each side, so they can transfer only those records. When both sides already share many records, this uses less bandwidth than sending the full set of records or even a full list of IDs. [Nostr](/topics/nostr) uses it to sync events between clients and [relays](/topics/relays).
+Negentropy is an efficient set reconciliation protocol. It helps two sides figure out which records are missing on each side, so they can transfer only those records.
 
-In Nostr, NIP-77 wraps Negentropy so a client and relay can compare the events they have for a chosen filter and sync what is missing.
+In [Nostr](/topics/nostr), clients and [relays](/topics/relays) often already share most of the same events. Negentropy lets them find the gaps without exchanging full event sets or long lists of event IDs, which cuts bandwidth during sync.
 
-It works for client-relay sync and relay-relay sync.
+NIP-77 wraps Negentropy for Nostr, so a client and relay can compare the events they have for a chosen filter and sync what is missing. It also works for relay-relay sync.
 
 ## References
 

--- a/data/topics/negentropy.mdx
+++ b/data/topics/negentropy.mdx
@@ -6,7 +6,7 @@ category: 'Nostr'
 aliases: ['NIP-77', 'Negentropy Syncing']
 ---
 
-Negentropy is a set reconciliation protocol. It helps two sides figure out which records are missing on each side, so they can transfer only those records. When both sides already share many records, this uses less bandwidth than sending the full set of records or even a full list of IDs. [Nostr](/topics/nostr) uses it to sync events between clients and [relays](/topics/relays).
+Negentropy is an efficient set reconciliation protocol. It helps two sides figure out which records are missing on each side, so they can transfer only those records. When both sides already share many records, this uses less bandwidth than sending the full set of records or even a full list of IDs. [Nostr](/topics/nostr) uses it to sync events between clients and [relays](/topics/relays).
 
 In Nostr, NIP-77 wraps Negentropy so a client and relay can compare the events they have for a chosen filter and sync what is missing.
 


### PR DESCRIPTION
Adds a new `Negentropy` topic page with verified copy and references for the Nostr event syncing protocol.

- explains the NIP-77 sync flow in plain language
- links to the upstream NIP and `negentropy` reference repo

Closes https://github.com/OpenSats/website/issues/776

---

Build preview:
- [/topics/negentropy](https://os-website-git-content-add-negentropy-topic-opensats.vercel.app/topics/negentropy)
