### PR TITLE
Add Bitaxe support link

### DIFF
--- a/data/projects/bitaxe.mdx
+++ b/data/projects/bitaxe.mdx
@@ -4,6 +4,7 @@ dateAdded: '2026-05-17'
 summary: 'Open-source Bitcoin mining hardware and firmware built for home and small-scale miners.'
 nym: 'skot'
 website: 'https://www.bitaxe.org/'
+donationLink: 'https://donate.osmu.xyz/'
 coverImage: '/static/images/projects/bitaxe.png'
 darkCoverImage: '/static/images/projects/bitaxe-dark.png'
 containCoverImage: true

--- a/data/projects/bitaxe.mdx
+++ b/data/projects/bitaxe.mdx
@@ -4,7 +4,7 @@ dateAdded: '2026-05-17'
 summary: 'Open-source Bitcoin mining hardware and firmware built for home and small-scale miners.'
 nym: 'skot'
 website: 'https://www.bitaxe.org/'
-donationLink: 'https://donate.osmu.xyz/'
+donationLink: 'https://www.bitaxe.org/#donation'
 coverImage: '/static/images/projects/bitaxe.png'
 darkCoverImage: '/static/images/projects/bitaxe-dark.png'
 containCoverImage: true


### PR DESCRIPTION
Adds Bitaxe's direct support link so the project page shows a `Support directly` CTA that points to the donation section on `bitaxe.org`.

- adds `donationLink: 'https://www.bitaxe.org/#donation'` to `data/projects/bitaxe.mdx`

Closes OpenSats/website#783

---

Build preview:
- [/projects/bitaxe](https://os-website-git-content-add-bitaxe-support-link-opensats.vercel.app/projects/bitaxe)
