### PR TITLE
fix: normalize project support button copy

### DIFF
--- a/pages/projects/[...slug].tsx
+++ b/pages/projects/[...slug].tsx
@@ -92,11 +92,7 @@ export default function ProjectPage({
                   : 'solid'
               }
             >
-              {project.donationLink.includes('geyser')
-                ? 'Support via Geyser'
-                : project.donationLink.includes('opencollective')
-                ? 'Support via OpenCollective'
-                : 'Support directly'}
+              Support directly
             </PageActionLink>
           )}
         </aside>

--- a/pages/projects/[...slug].tsx
+++ b/pages/projects/[...slug].tsx
@@ -83,15 +83,7 @@ export default function ProjectPage({
             ) : null
           })()}
           {project.donationLink && (
-            <PageActionLink
-              href={project.donationLink}
-              variant={
-                project.donationLink.includes('geyser') ||
-                project.donationLink.includes('opencollective')
-                  ? 'solidMuted'
-                  : 'solid'
-              }
-            >
+            <PageActionLink href={project.donationLink} variant="solid">
               Support directly
             </PageActionLink>
           )}


### PR DESCRIPTION
Normalizes project donation CTA copy so project pages always use `Support directly`, regardless of which donation portal the link points to.

- removes the portal-specific `Geyser` and `OpenCollective` button text
- keeps `Support directly` styled as the primary donation button in every case

Closes https://github.com/OpenSats/website/issues/785

---

Build preview:
- [/projects/bitcoindesign](https://os-website-git-fix-project-support-direct-label-opensats.vercel.app/projects/bitcoindesign)
