### PR TITLE
content(blog): reword Kurt Unger spotlight summary

### DIFF
--- a/data/blog/developer-spotlight-kurt-unger.mdx
+++ b/data/blog/developer-spotlight-kurt-unger.mdx
@@ -5,7 +5,7 @@ tags: ['OpenSats', 'bitcoin', 'hardware', 'spotlight']
 authors: ['ville']
 images: ['/static/images/spotlight/kurt-unger/featured.jpg', '/static/images/spotlight/kurt-unger/hero.jpg']
 draft: false
-summary: "A developer spotlight on Kurt Unger, an OpenSats grantee who's building Bitcoin mining hardware that's understandable, repairable, and open."
+summary: "Meet Kurt Unger, the OpenSats grantee who's building Bitcoin mining hardware that's understandable, repairable, and open."
 ---
 
 Somewhere far away from the Kenyan main roads, where the sounds of birds and the


### PR DESCRIPTION
Rewords the frontmatter summary on the Kurt Unger developer spotlight post so it opens with "Meet Kurt Unger, the OpenSats grantee" instead of the generic "A developer spotlight on" phrasing.

- Updates `summary` in `data/blog/developer-spotlight-kurt-unger.mdx`
- No other content or asset changes

Build preview:
- [/blog/developer-spotlight-kurt-unger](https://os-website-git-kurt-followup-opensats.vercel.app/blog/developer-spotlight-kurt-unger)
