### PR TITLE
fix: redirect /spotlight to /tags/spotlight

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -146,6 +146,11 @@ module.exports = () => {
           permanent: true,
         },
         {
+          source: '/spotlight',
+          destination: '/tags/spotlight',
+          permanent: true,
+        },
+        {
           source: '/heartbeat',
           destination: 'https://heartbeat.opensats.org/',
           permanent: false,


### PR DESCRIPTION
Adds a short `/spotlight` route that permanently redirects to the existing `spotlight` tag archive until there is a dedicated spotlight landing page.

- points `/spotlight` to `/tags/spotlight`
- keeps the redirect in `next.config.js` alongside the other route aliases

Closes https://github.com/OpenSats/website/issues/788

---

Build preview:
- [/spotlight](https://os-website-git-content-add-spotlight-tag-redirect-opensats.vercel.app/spotlight)
