### PR TITLE
feat(blog): add sidebar pull quotes to spotlight posts

### DIFF
--- a/components/post/PostArticleBody.tsx
+++ b/components/post/PostArticleBody.tsx
@@ -7,6 +7,7 @@ import Image from '@/components/Image'
 import Tag from '@/components/Tag'
 import siteMetadata from '@/data/siteMetadata'
 import { discussUrl, editUrl } from '@/components/post/postShared'
+import SpotlightPullQuotes from '@/components/post/SpotlightPullQuotes'
 
 interface Props {
   content: CoreContent<Blog>
@@ -37,14 +38,15 @@ const postArticleBodyClasses = {
   spotlight: {
     wrapper:
       'grid-rows-[auto_1fr] divide-y divide-gray-200 pb-8 dark:divide-gray-700 min-[1000px]:grid min-[1000px]:grid-cols-4 min-[1000px]:gap-x-6 min-[1000px]:divide-y-0',
-    authorBlock:
-      'pb-10 pt-6 min-[1000px]:border-b min-[1000px]:border-gray-200 min-[1000px]:pt-11 min-[1000px]:dark:border-gray-700',
+    sidebar:
+      'min-[1000px]:col-start-1 min-[1000px]:row-span-2 min-[1000px]:flex min-[1000px]:flex-col',
+    authorBlock: 'pb-10 pt-6 min-[1000px]:pt-11',
     authorList:
       'justify-start min-[1000px]:block min-[1000px]:space-x-0 min-[1000px]:space-y-8',
     contentBlock:
       'divide-y divide-gray-200 dark:divide-gray-700 min-[1000px]:col-span-3 min-[1000px]:row-span-2 min-[1000px]:pb-0',
     footerBlock:
-      'divide-gray-200 text-sm font-medium leading-5 dark:divide-gray-700 min-[1000px]:col-start-1 min-[1000px]:row-start-2 min-[1000px]:divide-y',
+      'divide-gray-200 text-sm font-medium leading-5 dark:divide-gray-700 min-[1000px]:divide-y',
     tagsBlock: 'py-4 min-[1000px]:py-8',
     paginationBlock:
       'flex justify-between py-4 min-[1000px]:block min-[1000px]:space-y-8 min-[1000px]:py-8',
@@ -60,130 +62,150 @@ export default function PostArticleBody({
   children,
   spotlight = false,
 }: Props) {
-  const { filePath, path, slug, tags } = content
+  const { filePath, path, slug, tags, pullQuotes } = content
   const basePath = path.split('/')[0]
   const [loadComments, setLoadComments] = useState(false)
   const classes = spotlight
     ? postArticleBodyClasses.spotlight
     : postArticleBodyClasses.default
 
-  return (
-    <div className={classes.wrapper}>
-      <dl className={classes.authorBlock}>
-        <dt className="sr-only">Authors</dt>
-        <dd>
-          <ul className={`flex flex-wrap gap-4 ${classes.authorList}`}>
-            {authorDetails.map((author) => (
-              <li className="flex items-center space-x-2" key={author.name}>
-                {author.avatar && (
-                  <Link href={`/about/${author.slug}`}>
-                    <Image
-                      src={author.avatar}
-                      width={38}
-                      height={38}
-                      alt="avatar"
-                      className="h-10 w-10 rounded-full"
-                    />
-                  </Link>
-                )}
-                <dl className="whitespace-nowrap text-sm font-medium leading-5">
-                  <dt className="sr-only">Name</dt>
-                  <dd className="text-gray-900 dark:text-gray-100">
-                    {author.name}
-                  </dd>
-                  <dt className="sr-only">Twitter</dt>
-                  <dd>
-                    {author.nym && (
-                      <Link
-                        href={`/about/${author.slug}`}
-                        className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
-                      >
-                        @{author.nym}
-                      </Link>
-                    )}
-                  </dd>
-                </dl>
-              </li>
-            ))}
-          </ul>
-        </dd>
-      </dl>
-      <div className={classes.contentBlock}>
-        <div className="prose max-w-none pb-8 pt-10 dark:prose-dark">
-          {children}
-        </div>
-        <div className="pb-6 pt-6 text-sm text-gray-700 dark:text-gray-300">
-          <Link href={discussUrl()} rel="nofollow">
-            Discuss on nostr
-          </Link>
-          {` • `}
-          <Link href={editUrl(filePath)}>View on GitHub</Link>
-        </div>
-        {siteMetadata.comments && (
-          <div
-            className="pb-6 pt-6 text-center text-gray-700 dark:text-gray-300"
-            id="comment"
-          >
-            {!loadComments && (
-              <button onClick={() => setLoadComments(true)}>
-                Load Comments
-              </button>
+  const authorBlock = (
+    <dl className={classes.authorBlock}>
+      <dt className="sr-only">Authors</dt>
+      <dd>
+        <ul className={`flex flex-wrap gap-4 ${classes.authorList}`}>
+          {authorDetails.map((author) => (
+            <li className="flex items-center space-x-2" key={author.name}>
+              {author.avatar && (
+                <Link href={`/about/${author.slug}`}>
+                  <Image
+                    src={author.avatar}
+                    width={38}
+                    height={38}
+                    alt="avatar"
+                    className="h-10 w-10 rounded-full"
+                  />
+                </Link>
+              )}
+              <dl className="whitespace-nowrap text-sm font-medium leading-5">
+                <dt className="sr-only">Name</dt>
+                <dd className="text-gray-900 dark:text-gray-100">
+                  {author.name}
+                </dd>
+                <dt className="sr-only">Twitter</dt>
+                <dd>
+                  {author.nym && (
+                    <Link
+                      href={`/about/${author.slug}`}
+                      className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+                    >
+                      @{author.nym}
+                    </Link>
+                  )}
+                </dd>
+              </dl>
+            </li>
+          ))}
+        </ul>
+      </dd>
+    </dl>
+  )
+
+  const sidebarFooter = (
+    <footer>
+      <div className={classes.footerBlock}>
+        {tags && (
+          <div className={classes.tagsBlock}>
+            <h2 className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Tags
+            </h2>
+            <div className="flex flex-wrap">
+              {tags.map((tag) => (
+                <Tag key={tag} text={tag} />
+              ))}
+            </div>
+          </div>
+        )}
+        {(next || prev) && (
+          <div className={classes.paginationBlock}>
+            {prev && (
+              <div>
+                <h2 className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  Previous Post
+                </h2>
+                <div className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400">
+                  <Link href={`/${prev.path}`}>{prev.title}</Link>
+                </div>
+              </div>
             )}
-            {loadComments && (
-              <Comments commentsConfig={siteMetadata.comments} slug={slug} />
+            {next && (
+              <div>
+                <h2 className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  Next Post
+                </h2>
+                <div className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400">
+                  <Link href={`/${next.path}`}>{next.title}</Link>
+                </div>
+              </div>
             )}
           </div>
         )}
       </div>
-      <footer>
-        <div className={classes.footerBlock}>
-          {tags && (
-            <div className={classes.tagsBlock}>
-              <h2 className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                Tags
-              </h2>
-              <div className="flex flex-wrap">
-                {tags.map((tag) => (
-                  <Tag key={tag} text={tag} />
-                ))}
-              </div>
-            </div>
+      <div className={classes.backLinkBlock}>
+        <Link
+          href={`/${basePath}`}
+          className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+          aria-label="Back to the blog"
+        >
+          &larr; Back to the blog
+        </Link>
+      </div>
+    </footer>
+  )
+
+  const contentBlock = (
+    <div className={classes.contentBlock}>
+      <div className="prose max-w-none pb-8 pt-10 dark:prose-dark">
+        {children}
+      </div>
+      <div className="pb-6 pt-6 text-sm text-gray-700 dark:text-gray-300">
+        <Link href={discussUrl()} rel="nofollow">
+          Discuss on nostr
+        </Link>
+        {` • `}
+        <Link href={editUrl(filePath)}>View on GitHub</Link>
+      </div>
+      {siteMetadata.comments && (
+        <div
+          className="pb-6 pt-6 text-center text-gray-700 dark:text-gray-300"
+          id="comment"
+        >
+          {!loadComments && (
+            <button onClick={() => setLoadComments(true)}>Load Comments</button>
           )}
-          {(next || prev) && (
-            <div className={classes.paginationBlock}>
-              {prev && (
-                <div>
-                  <h2 className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                    Previous Post
-                  </h2>
-                  <div className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400">
-                    <Link href={`/${prev.path}`}>{prev.title}</Link>
-                  </div>
-                </div>
-              )}
-              {next && (
-                <div>
-                  <h2 className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                    Next Post
-                  </h2>
-                  <div className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400">
-                    <Link href={`/${next.path}`}>{next.title}</Link>
-                  </div>
-                </div>
-              )}
-            </div>
+          {loadComments && (
+            <Comments commentsConfig={siteMetadata.comments} slug={slug} />
           )}
         </div>
-        <div className={classes.backLinkBlock}>
-          <Link
-            href={`/${basePath}`}
-            className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
-            aria-label="Back to the blog"
-          >
-            &larr; Back to the blog
-          </Link>
-        </div>
-      </footer>
+      )}
+    </div>
+  )
+
+  return (
+    <div className={classes.wrapper}>
+      {spotlight ? (
+        <aside className={classes.sidebar}>
+          {authorBlock}
+          {sidebarFooter}
+          {pullQuotes && pullQuotes.length > 0 && (
+            <SpotlightPullQuotes quotes={pullQuotes} />
+          )}
+        </aside>
+      ) : (
+        authorBlock
+      )}
+      {contentBlock}
+      {!spotlight && sidebarFooter}
     </div>
   )
 }

--- a/components/post/PostArticleBody.tsx
+++ b/components/post/PostArticleBody.tsx
@@ -39,7 +39,7 @@ const postArticleBodyClasses = {
     wrapper:
       'grid-rows-[auto_1fr] divide-y divide-gray-200 pb-8 dark:divide-gray-700 min-[1000px]:grid min-[1000px]:grid-cols-4 min-[1000px]:gap-x-6 min-[1000px]:divide-y-0',
     sidebar:
-      'min-[1000px]:col-start-1 min-[1000px]:row-span-2 min-[1000px]:flex min-[1000px]:flex-col',
+      'min-[1000px]:col-start-1 min-[1000px]:row-span-2 min-[1000px]:flex min-[1000px]:min-h-0 min-[1000px]:flex-col',
     authorBlock: 'pb-10 pt-6 min-[1000px]:pt-11',
     authorList:
       'justify-start min-[1000px]:block min-[1000px]:space-x-0 min-[1000px]:space-y-8',

--- a/components/post/PostArticleBody.tsx
+++ b/components/post/PostArticleBody.tsx
@@ -194,7 +194,7 @@ export default function PostArticleBody({
   return (
     <div className={classes.wrapper}>
       {spotlight ? (
-        <aside className={classes.sidebar}>
+        <aside className={postArticleBodyClasses.spotlight.sidebar}>
           {authorBlock}
           {sidebarFooter}
           {pullQuotes && pullQuotes.length > 0 && (

--- a/components/post/SpotlightPullQuotes.tsx
+++ b/components/post/SpotlightPullQuotes.tsx
@@ -30,12 +30,12 @@ export default function SpotlightPullQuotes({ quotes }: Props) {
           style={{ top: `${getQuoteTopPercent(index)}%` }}
         >
           <span
-            className="block text-6xl leading-none text-gray-300 dark:text-gray-600"
+            className="block text-8xl leading-none text-gray-300 dark:text-gray-600"
             aria-hidden="true"
           >
             &ldquo;
           </span>
-          <p className="mt-1 text-[1.35rem] font-normal leading-relaxed text-gray-800 dark:text-gray-200">
+          <p className="mt-2 text-3xl font-normal leading-snug text-gray-800 dark:text-gray-200">
             {quote}
           </p>
         </blockquote>

--- a/components/post/SpotlightPullQuotes.tsx
+++ b/components/post/SpotlightPullQuotes.tsx
@@ -1,0 +1,24 @@
+interface Props {
+  quotes: string[]
+}
+
+export default function SpotlightPullQuotes({ quotes }: Props) {
+  if (!quotes.length) {
+    return null
+  }
+
+  return (
+    <div className="hidden min-[1000px]:flex min-[1000px]:flex-col min-[1000px]:gap-24 min-[1000px]:py-12">
+      {quotes.map((quote) => (
+        <blockquote
+          key={quote}
+          className="border-l-4 border-primary-500 pl-4 not-italic"
+        >
+          <p className="text-xl font-semibold leading-snug text-gray-900 dark:text-gray-100">
+            {quote}
+          </p>
+        </blockquote>
+      ))}
+    </div>
+  )
+}

--- a/components/post/SpotlightPullQuotes.tsx
+++ b/components/post/SpotlightPullQuotes.tsx
@@ -39,7 +39,7 @@ export default function SpotlightPullQuotes({ quotes }: Props) {
           >
             &ldquo;
           </span>
-          <p className="-mt-6 text-3xl font-normal leading-snug text-gray-800 dark:text-gray-200">
+          <p className="-mt-6 text-pretty text-3xl font-normal leading-snug text-gray-800 dark:text-gray-200">
             {quote}
           </p>
         </blockquote>

--- a/components/post/SpotlightPullQuotes.tsx
+++ b/components/post/SpotlightPullQuotes.tsx
@@ -7,13 +7,13 @@ const quoteFont = Lora({
   display: 'swap',
 })
 
-const QUOTE_RANGE = { start: 21, end: 79 } as const
+const QUOTE_RANGE = { start: 20, end: 90 } as const
 
 interface Props {
   quotes: string[]
 }
 
-/** Evenly distribute quote tops from 21% to 79% based on count. */
+/** Evenly distribute quote tops from 20% to 90% based on count. */
 function getQuoteTopPercents(total: number): number[] {
   if (total <= 0) {
     return []

--- a/components/post/SpotlightPullQuotes.tsx
+++ b/components/post/SpotlightPullQuotes.tsx
@@ -1,3 +1,12 @@
+import { Lora } from 'next/font/google'
+
+const quoteFont = Lora({
+  subsets: ['latin'],
+  weight: ['400', '500'],
+  style: ['italic'],
+  display: 'swap',
+})
+
 interface Props {
   quotes: string[]
 }
@@ -17,16 +26,16 @@ export default function SpotlightPullQuotes({ quotes }: Props) {
       {quotes.map((quote, index) => (
         <blockquote
           key={quote}
-          className="absolute left-0 right-0 not-italic pl-10"
+          className={`absolute left-0 right-0 pl-12 ${quoteFont.className}`}
           style={{ top: `${getQuoteTopPercent(index)}%` }}
         >
           <span
-            className="absolute left-0 top-0 font-serif text-6xl leading-none text-gray-300 dark:text-gray-600"
+            className="absolute left-0 top-[-0.15em] text-7xl leading-none text-gray-300 dark:text-gray-600"
             aria-hidden="true"
           >
             &ldquo;
           </span>
-          <p className="text-xl font-semibold leading-snug text-gray-900 dark:text-gray-100">
+          <p className="text-[1.35rem] font-normal leading-relaxed text-gray-800 dark:text-gray-200">
             {quote}
           </p>
         </blockquote>

--- a/components/post/SpotlightPullQuotes.tsx
+++ b/components/post/SpotlightPullQuotes.tsx
@@ -7,17 +7,33 @@ const quoteFont = Lora({
   display: 'swap',
 })
 
+const QUOTE_RANGE = { start: 21, end: 79 } as const
+
 interface Props {
   quotes: string[]
 }
 
-/** Spread quotes evenly from 21% to 79% of the sidebar quote area. */
-function getQuoteTopPercent(index: number, total: number) {
-  if (total <= 1) {
-    return 50
+/** Evenly distribute quote tops from 21% to 79% based on count. */
+function getQuoteTopPercents(total: number): number[] {
+  if (total <= 0) {
+    return []
   }
 
-  return 21 + (index * 58) / (total - 1)
+  if (total === 1) {
+    return [(QUOTE_RANGE.start + QUOTE_RANGE.end) / 2]
+  }
+
+  const span = QUOTE_RANGE.end - QUOTE_RANGE.start
+
+  return Array.from(
+    { length: total },
+    (_, index) => QUOTE_RANGE.start + (index * span) / (total - 1)
+  )
+}
+
+/** Taller quote lists need more vertical room so blocks do not overlap. */
+function getQuoteAreaMinHeight(total: number): string {
+  return `${Math.max(28, total * 9)}rem`
 }
 
 export default function SpotlightPullQuotes({ quotes }: Props) {
@@ -25,13 +41,18 @@ export default function SpotlightPullQuotes({ quotes }: Props) {
     return null
   }
 
+  const topPercents = getQuoteTopPercents(quotes.length)
+
   return (
-    <div className="relative hidden min-h-[32rem] w-full min-[1000px]:block min-[1000px]:flex-1">
+    <div
+      className="relative hidden w-full min-[1000px]:block min-[1000px]:flex-1"
+      style={{ minHeight: getQuoteAreaMinHeight(quotes.length) }}
+    >
       {quotes.map((quote, index) => (
         <blockquote
           key={quote}
           className={`absolute left-0 right-0 ${quoteFont.className}`}
-          style={{ top: `${getQuoteTopPercent(index, quotes.length)}%` }}
+          style={{ top: `${topPercents[index]}%` }}
         >
           <span
             className="block text-[6rem] leading-[0.55] text-gray-300 dark:text-gray-600"

--- a/components/post/SpotlightPullQuotes.tsx
+++ b/components/post/SpotlightPullQuotes.tsx
@@ -60,7 +60,7 @@ export default function SpotlightPullQuotes({ quotes }: Props) {
           >
             &ldquo;
           </span>
-          <p className="-mt-4 text-pretty text-xl font-normal leading-snug text-gray-800 dark:text-gray-200 xl:-mt-6 xl:text-3xl">
+          <p className="-mt-4 text-pretty text-justify text-xl font-normal leading-snug text-gray-800 dark:text-gray-200 xl:-mt-6 xl:text-3xl">
             {quote}
           </p>
         </blockquote>

--- a/components/post/SpotlightPullQuotes.tsx
+++ b/components/post/SpotlightPullQuotes.tsx
@@ -2,15 +2,24 @@ interface Props {
   quotes: string[]
 }
 
+/** Place quotes at 10%, 30%, 50%, … down the sidebar quote area. */
+function getQuoteTopPercent(index: number) {
+  return Math.min(10 + index * 20, 90)
+}
+
 export default function SpotlightPullQuotes({ quotes }: Props) {
   if (!quotes.length) {
     return null
   }
 
   return (
-    <div className="hidden min-[1000px]:flex min-[1000px]:flex-col min-[1000px]:gap-24 min-[1000px]:py-12">
-      {quotes.map((quote) => (
-        <blockquote key={quote} className="relative not-italic pl-10">
+    <div className="relative hidden min-h-[32rem] w-full min-[1000px]:block min-[1000px]:flex-1">
+      {quotes.map((quote, index) => (
+        <blockquote
+          key={quote}
+          className="absolute left-0 right-0 not-italic pl-10"
+          style={{ top: `${getQuoteTopPercent(index)}%` }}
+        >
           <span
             className="absolute left-0 top-0 font-serif text-6xl leading-none text-gray-300 dark:text-gray-600"
             aria-hidden="true"

--- a/components/post/SpotlightPullQuotes.tsx
+++ b/components/post/SpotlightPullQuotes.tsx
@@ -60,7 +60,7 @@ export default function SpotlightPullQuotes({ quotes }: Props) {
           >
             &ldquo;
           </span>
-          <p className="-mt-4 text-pretty text-justify text-xl font-normal leading-snug text-gray-800 dark:text-gray-200 xl:-mt-6 xl:text-3xl">
+          <p className="-mt-4 text-pretty text-xl font-normal leading-snug text-gray-800 dark:text-gray-200 xl:-mt-6 xl:text-3xl">
             {quote}
           </p>
         </blockquote>

--- a/components/post/SpotlightPullQuotes.tsx
+++ b/components/post/SpotlightPullQuotes.tsx
@@ -55,12 +55,12 @@ export default function SpotlightPullQuotes({ quotes }: Props) {
           style={{ top: `${topPercents[index]}%` }}
         >
           <span
-            className="block text-[4.5rem] leading-[0.55] text-gray-300 dark:text-gray-600 xl:text-[6rem]"
+            className="block text-[4rem] leading-[0.55] text-gray-300 dark:text-gray-600 xl:text-[5rem]"
             aria-hidden="true"
           >
             &ldquo;
           </span>
-          <p className="-mt-4 text-pretty text-xl font-normal leading-snug text-gray-800 dark:text-gray-200 xl:-mt-6 xl:text-3xl">
+          <p className="-mt-3 text-pretty text-lg font-normal leading-snug text-gray-800 dark:text-gray-200 xl:-mt-5 xl:text-2xl">
             {quote}
           </p>
         </blockquote>

--- a/components/post/SpotlightPullQuotes.tsx
+++ b/components/post/SpotlightPullQuotes.tsx
@@ -26,16 +26,16 @@ export default function SpotlightPullQuotes({ quotes }: Props) {
       {quotes.map((quote, index) => (
         <blockquote
           key={quote}
-          className={`absolute left-0 right-0 pl-12 ${quoteFont.className}`}
+          className={`absolute left-0 right-0 ${quoteFont.className}`}
           style={{ top: `${getQuoteTopPercent(index)}%` }}
         >
           <span
-            className="absolute left-0 top-[-0.15em] text-7xl leading-none text-gray-300 dark:text-gray-600"
+            className="block text-6xl leading-none text-gray-300 dark:text-gray-600"
             aria-hidden="true"
           >
             &ldquo;
           </span>
-          <p className="text-[1.35rem] font-normal leading-relaxed text-gray-800 dark:text-gray-200">
+          <p className="mt-1 text-[1.35rem] font-normal leading-relaxed text-gray-800 dark:text-gray-200">
             {quote}
           </p>
         </blockquote>

--- a/components/post/SpotlightPullQuotes.tsx
+++ b/components/post/SpotlightPullQuotes.tsx
@@ -30,12 +30,12 @@ export default function SpotlightPullQuotes({ quotes }: Props) {
           style={{ top: `${getQuoteTopPercent(index)}%` }}
         >
           <span
-            className="block text-8xl leading-none text-gray-300 dark:text-gray-600"
+            className="block text-[6rem] leading-[0.55] text-gray-300 dark:text-gray-600"
             aria-hidden="true"
           >
             &ldquo;
           </span>
-          <p className="mt-2 text-3xl font-normal leading-snug text-gray-800 dark:text-gray-200">
+          <p className="-mt-6 text-3xl font-normal leading-snug text-gray-800 dark:text-gray-200">
             {quote}
           </p>
         </blockquote>

--- a/components/post/SpotlightPullQuotes.tsx
+++ b/components/post/SpotlightPullQuotes.tsx
@@ -11,9 +11,13 @@ interface Props {
   quotes: string[]
 }
 
-/** Place quotes at 10%, 30%, 50%, … down the sidebar quote area. */
-function getQuoteTopPercent(index: number) {
-  return Math.min(10 + index * 20, 90)
+/** Spread quotes evenly from 10% to 90% of the sidebar quote area. */
+function getQuoteTopPercent(index: number, total: number) {
+  if (total <= 1) {
+    return 10
+  }
+
+  return 10 + (index * 80) / (total - 1)
 }
 
 export default function SpotlightPullQuotes({ quotes }: Props) {
@@ -27,7 +31,7 @@ export default function SpotlightPullQuotes({ quotes }: Props) {
         <blockquote
           key={quote}
           className={`absolute left-0 right-0 ${quoteFont.className}`}
-          style={{ top: `${getQuoteTopPercent(index)}%` }}
+          style={{ top: `${getQuoteTopPercent(index, quotes.length)}%` }}
         >
           <span
             className="block text-[6rem] leading-[0.55] text-gray-300 dark:text-gray-600"

--- a/components/post/SpotlightPullQuotes.tsx
+++ b/components/post/SpotlightPullQuotes.tsx
@@ -45,7 +45,7 @@ export default function SpotlightPullQuotes({ quotes }: Props) {
 
   return (
     <div
-      className="relative hidden w-full min-[1000px]:block min-[1000px]:flex-1"
+      className="relative hidden w-full min-[1000px]:block min-[1000px]:flex-1 xl:pr-4"
       style={{ minHeight: getQuoteAreaMinHeight(quotes.length) }}
     >
       {quotes.map((quote, index) => (

--- a/components/post/SpotlightPullQuotes.tsx
+++ b/components/post/SpotlightPullQuotes.tsx
@@ -10,10 +10,13 @@ export default function SpotlightPullQuotes({ quotes }: Props) {
   return (
     <div className="hidden min-[1000px]:flex min-[1000px]:flex-col min-[1000px]:gap-24 min-[1000px]:py-12">
       {quotes.map((quote) => (
-        <blockquote
-          key={quote}
-          className="border-l-4 border-primary-500 pl-4 not-italic"
-        >
+        <blockquote key={quote} className="relative not-italic pl-10">
+          <span
+            className="absolute left-0 top-0 font-serif text-6xl leading-none text-gray-300 dark:text-gray-600"
+            aria-hidden="true"
+          >
+            &ldquo;
+          </span>
           <p className="text-xl font-semibold leading-snug text-gray-900 dark:text-gray-100">
             {quote}
           </p>

--- a/components/post/SpotlightPullQuotes.tsx
+++ b/components/post/SpotlightPullQuotes.tsx
@@ -11,13 +11,13 @@ interface Props {
   quotes: string[]
 }
 
-/** Spread quotes evenly from 10% to 90% of the sidebar quote area. */
+/** Spread quotes evenly from 21% to 79% of the sidebar quote area. */
 function getQuoteTopPercent(index: number, total: number) {
   if (total <= 1) {
-    return 10
+    return 50
   }
 
-  return 10 + (index * 80) / (total - 1)
+  return 21 + (index * 58) / (total - 1)
 }
 
 export default function SpotlightPullQuotes({ quotes }: Props) {

--- a/components/post/SpotlightPullQuotes.tsx
+++ b/components/post/SpotlightPullQuotes.tsx
@@ -55,12 +55,12 @@ export default function SpotlightPullQuotes({ quotes }: Props) {
           style={{ top: `${topPercents[index]}%` }}
         >
           <span
-            className="block text-[6rem] leading-[0.55] text-gray-300 dark:text-gray-600"
+            className="block text-[4.5rem] leading-[0.55] text-gray-300 dark:text-gray-600 xl:text-[6rem]"
             aria-hidden="true"
           >
             &ldquo;
           </span>
-          <p className="-mt-6 text-pretty text-3xl font-normal leading-snug text-gray-800 dark:text-gray-200">
+          <p className="-mt-4 text-pretty text-xl font-normal leading-snug text-gray-800 dark:text-gray-200 xl:-mt-6 xl:text-3xl">
             {quote}
           </p>
         </blockquote>

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -57,6 +57,7 @@ export const Blog = defineDocumentType(() => ({
     layout: { type: 'string' },
     bibliography: { type: 'string' },
     canonicalUrl: { type: 'string' },
+    pullQuotes: { type: 'list', of: { type: 'string' } },
   },
   computedFields,
 }))

--- a/data/blog/developer-spotlight-codytseng-jumblesocial.mdx
+++ b/data/blog/developer-spotlight-codytseng-jumblesocial.mdx
@@ -11,7 +11,7 @@ pullQuotes:
   - "The design of Nostr is extremely simple. You can describe its core principles in just a few sentences."
   - "Personally, I think improving the Nostr ecosystem itself is ultimately more important."
   - "I think the meaning of Nostr is that it provides another option. It shows people that another kind of network is possible."
-  - "随心而动. Follow your heart."
+  - "随心而动 — Follow your heart."
 ---
 
 SHENZHEN, China — Cody Tseng is folded into the evening rush the way everyone

--- a/data/blog/developer-spotlight-codytseng-jumblesocial.mdx
+++ b/data/blog/developer-spotlight-codytseng-jumblesocial.mdx
@@ -6,6 +6,11 @@ authors: ['ville']
 images: ['/static/images/spotlight/cody-tseng/featured.jpg', '/static/images/spotlight/cody-tseng/hero.jpg']
 draft: false
 summary: "Cody Tseng is an OpenSats grantee behind Jumble, a Nostr client for the open social web"
+pullQuotes:
+  - "Like many people, I dislike being controlled and want to truly own certain things. I think many Nostr users feel similarly. They want to truly own their data instead of having it locked inside the databases of large companies."
+  - "The design of Nostr is extremely simple. You can describe its core principles in just a few sentences, but at the same time it is incredibly powerful, enough to build full social applications on top of it."
+  - "Personally, I think improving the Nostr ecosystem itself is ultimately more important. Network access problems can usually be worked around one way or another, but whether the ecosystem is actually useful and interesting matters more."
+  - "My vision is that in the future, when people talk about Nostr social applications, they will naturally think of Jumble."
 ---
 
 SHENZHEN, China — Cody Tseng is folded into the evening rush the way everyone

--- a/data/blog/developer-spotlight-codytseng-jumblesocial.mdx
+++ b/data/blog/developer-spotlight-codytseng-jumblesocial.mdx
@@ -11,6 +11,7 @@ pullQuotes:
   - "The design of Nostr is extremely simple. You can describe its core principles in just a few sentences."
   - "Personally, I think improving the Nostr ecosystem itself is ultimately more important."
   - "I think the meaning of Nostr is that it provides another option. It shows people that another kind of network is possible."
+  - "随心而动. Follow your heart."
 ---
 
 SHENZHEN, China — Cody Tseng is folded into the evening rush the way everyone

--- a/data/blog/developer-spotlight-codytseng-jumblesocial.mdx
+++ b/data/blog/developer-spotlight-codytseng-jumblesocial.mdx
@@ -7,10 +7,10 @@ images: ['/static/images/spotlight/cody-tseng/featured.jpg', '/static/images/spo
 draft: false
 summary: "Cody Tseng is an OpenSats grantee behind Jumble, a Nostr client for the open social web"
 pullQuotes:
-  - "Like many people, I dislike being controlled and want to truly own certain things. I think many Nostr users feel similarly. They want to truly own their data instead of having it locked inside the databases of large companies."
-  - "The design of Nostr is extremely simple. You can describe its core principles in just a few sentences, but at the same time it is incredibly powerful, enough to build full social applications on top of it."
-  - "Personally, I think improving the Nostr ecosystem itself is ultimately more important. Network access problems can usually be worked around one way or another, but whether the ecosystem is actually useful and interesting matters more."
-  - "My vision is that in the future, when people talk about Nostr social applications, they will naturally think of Jumble."
+  - "Like many people, I dislike being controlled and want to truly own certain things."
+  - "The design of Nostr is extremely simple. You can describe its core principles in just a few sentences."
+  - "Personally, I think improving the Nostr ecosystem itself is ultimately more important."
+  - "I think the meaning of Nostr is that it provides another option. It shows people that another kind of network is possible."
 ---
 
 SHENZHEN, China — Cody Tseng is folded into the evening rush the way everyone

--- a/data/blog/developer-spotlight-kurt-unger.mdx
+++ b/data/blog/developer-spotlight-kurt-unger.mdx
@@ -6,6 +6,11 @@ authors: ['ville']
 images: ['/static/images/spotlight/kurt-unger/featured.jpg', '/static/images/spotlight/kurt-unger/hero.jpg']
 draft: false
 summary: "Meet Kurt Unger, the OpenSats grantee who's building Bitcoin mining hardware that's understandable, repairable, and open."
+pullQuotes:
+  - "The Bitshoka project aimed to reverse engineer MicroBT's WhatsMiner chips and make them open-source."
+  - "My own, smaller, a-ha moment came when I realized how truly open-source Bitcoin was."
+  - "Those initial \"Hello ASIC\" moments were amazing!"
+  - "Hardware development is hard; hardware development in Africa is even harder for a myriad of reasons."
 ---
 
 Somewhere far away from the Kenyan main roads, where the sounds of birds and the

--- a/data/blog/developer-spotlight-kurt-unger.mdx
+++ b/data/blog/developer-spotlight-kurt-unger.mdx
@@ -7,10 +7,10 @@ images: ['/static/images/spotlight/kurt-unger/featured.jpg', '/static/images/spo
 draft: false
 summary: "Meet Kurt Unger, the OpenSats grantee who's building Bitcoin mining hardware that's understandable, repairable, and open."
 pullQuotes:
-  - "The Bitshoka project aimed to reverse engineer MicroBT's WhatsMiner chips and make them open-source."
-  - "My own, smaller, a-ha moment came when I realized how truly open-source Bitcoin was."
-  - "Those initial \"Hello ASIC\" moments were amazing!"
-  - "Hardware development is hard; hardware development in Africa is even harder for a myriad of reasons."
+  - "Every technology adoption brings compromises that we may or may not be aware of."
+  - "After spending more than 10 years thinking about rural electrification, actually seeing small communities thrive because they finally have stable, reliable power is deeply satisfying."
+  - "My proudest moments were when I confirmed that the hardware could communicate with the ASIC."
+  - "Hardware development is hard; hardware development in Africa is even harder."
 ---
 
 Somewhere far away from the Kenyan main roads, where the sounds of birds and the


### PR DESCRIPTION
Adds curated sidebar pull quotes to developer spotlight posts. Quotes are defined in frontmatter via `pullQuotes`, rendered in the left column below tags and navigation on desktop (`min-[1000px]`), with Lora italic typography, percentage-based vertical spacing, and responsive sizing at `xl`.

- Introduces `SpotlightPullQuotes` and restructures the spotlight sidebar in `PostArticleBody`
- Adds `pullQuotes` to contentlayer and seeds quotes for the Cody Tseng and Kurt Unger spotlights
- Scales quote size and spacing by viewport width and quote count

Build preview:
- [/blog/developer-spotlight-codytseng-jumblesocial](https://os-website-git-spotlight-layout-experiment-opensats.vercel.app/blog/developer-spotlight-codytseng-jumblesocial)
- [/blog/developer-spotlight-kurt-unger](https://os-website-git-spotlight-layout-experiment-opensats.vercel.app/blog/developer-spotlight-kurt-unger)
