### PR TITLE
docs(projects): add cashu-ts to Cashu page

### DIFF
--- a/data/projects/cashu.mdx
+++ b/data/projects/cashu.mdx
@@ -62,12 +62,15 @@ Cashu is free, open-source software with no business model. Protocol work, the
 reference mint, the web wallet, and ecosystem coordination all depend on grants.
 
 OpenSats has been supporting Cashu since the
-[first wave of Bitcoin grants](/blog/bitcoin-grants-july-2023#cashu) in July
-2023. A [long-term support grant](/blog/cashu-calle-receives-lts-grant) followed
+[first wave of Bitcoin grants](/blog/bitcoin-grants-july-2023#cashu) in July 2023. A [long-term support grant](/blog/cashu-calle-receives-lts-grant) followed
 in June 2024. Separate grants went to
 [Nutshell](/blog/8th-wave-of-bitcoin-grants#cashu-nutshell) (8th wave),
 [Nutstash](/blog/ninth-wave-of-bitcoin-grants#nutstash) (9th wave), and
 [OpenCash](/projects/opencash) for broader ecosystem coordination.
+
+OpenSats has also funded multiple Cashu ecosystem projects. The
+[sixteenth wave of Bitcoin grants](/blog/sixteenth-wave-of-bitcoin-grants#cashu-ts-and-coco)
+included `cashu-ts`, a TypeScript library for Cashu wallets and apps.
 
 ## What's next?
 

--- a/data/projects/cashu.mdx
+++ b/data/projects/cashu.mdx
@@ -66,11 +66,10 @@ OpenSats has been supporting Cashu since the
 in June 2024. Separate grants went to
 [Nutshell](/blog/8th-wave-of-bitcoin-grants#cashu-nutshell) (8th wave),
 [Nutstash](/blog/ninth-wave-of-bitcoin-grants#nutstash) (9th wave), and
-[OpenCash](/projects/opencash) for broader ecosystem coordination.
-
-OpenSats has also funded multiple Cashu ecosystem projects. The
+[OpenCash](/projects/opencash) for broader ecosystem coordination. The
 [sixteenth wave of Bitcoin grants](/blog/sixteenth-wave-of-bitcoin-grants#cashu-ts-and-coco)
-included `cashu-ts`, a TypeScript library for Cashu wallets and apps.
+also included [`cashu-ts`](https://cashu-ts.dev/), a TypeScript library for
+Cashu wallets and apps.
 
 ## What's next?
 


### PR DESCRIPTION
Adds a short funding note to the Cashu project page that mentions `cashu-ts` and makes the broader Cashu ecosystem support more explicit.

- notes that the sixteenth wave of Bitcoin grants included `cashu-ts`
- keeps the new context on the existing Cashu project page alongside the current grant history

Closes https://github.com/OpenSats/website/issues/792

---

Build preview:
- [/projects/cashu](https://os-website-git-content-add-cashu-ts-to-cashu-page-opensats.vercel.app/projects/cashu)
