### PR TITLE
docs(projects): update Coracle focus

### DIFF
--- a/data/projects/coracle.mdx
+++ b/data/projects/coracle.mdx
@@ -16,9 +16,9 @@ announcementLink: '/blog/nostr-grants-july-2023#coracle'
 ---
 
 Coracle is a nostr web client built by [Hodlbod][lts]. It started as a social
-feed reader but has grown to cover group chat, direct messages, communities,
-marketplaces, and classifieds. The client runs in the browser and works across
-desktop and mobile.
+feed reader and now focuses on broadcast social media, relay management, and
+web of trust. The client runs in the browser and works across desktop and
+mobile.
 
 > Much of nostr's novelty has to do with keys and digital signatures. But
 > focusing on the cryptographic aspects is, to me, actually something of a


### PR DESCRIPTION
Updates the Coracle project page to reflect the product feedback shared in `OpenSats/content#118`.

- narrows the description to Coracle's current focus on broadcast social media, relay management, and web of trust

Related to https://github.com/OpenSats/content/issues/118

---

Build preview:
- [/projects/coracle](https://os-website-git-content-update-coracle-feedback-opensats.vercel.app/projects/coracle)
