### PR TITLE
docs(projects): update Dana Wallet roadmap

### DIFF
--- a/data/projects/dana-wallet.mdx
+++ b/data/projects/dana-wallet.mdx
@@ -27,7 +27,7 @@ OpenSats included Dana Wallet in the [fifteenth wave of Bitcoin grants][grant]. 
 
 ## What's next?
 
-Recent grant reports show steady progress toward a more usable, stable wallet: claimable Dana addresses, a contact list, local transaction storage in SQLite, offline wallet creation, multiple app flavors on the project's F-Droid repo, and releases through [v0.7.3][release]. The next steps include faster launch times, background syncing, a Blindbit V2 backend, an official F-Droid release, iOS investigation, and a more complete project website.
+Recent grant reports show steady progress toward a more usable, stable wallet: claimable Dana addresses, a contact list, local transaction storage in SQLite, offline wallet creation, multiple app flavors on the project's F-Droid repo, and releases through [v0.7.3][release]. The next steps include faster launch times, background scanning support in the upcoming `v0.8.0` release so the wallet can keep syncing while the app runs in the background, a Blindbit V2 backend, an official F-Droid release, iOS investigation, and a more complete project website.
 
 If you want to dig deeper, start with the [project site][site], the [main repository][repo], the [grant announcement][grant], or the [F-Droid repository][fdroid].
 


### PR DESCRIPTION
Updates the Dana Wallet project page to reflect the roadmap feedback shared in `OpenSats/content#118`.

- adds the upcoming `v0.8.0` background scanning support to the `What's next?` section

Related to https://github.com/OpenSats/content/issues/118

---

Build preview:
- [/projects/dana-wallet](https://os-website-git-content-update-dana-wallet-feedback-opensats.vercel.app/projects/dana-wallet)
