### PR TITLE
docs(projects): clarify Flotilla app availability

### DIFF
--- a/data/projects/flotilla.mdx
+++ b/data/projects/flotilla.mdx
@@ -21,7 +21,8 @@ for the relay. Members get chat, threads, events, voice rooms, zaps, and
 private messages without any of those features being routed through a central
 operator.
 
-The web app is a PWA. Users can join multiple communities at once, switch
+Flotilla is available as a web app and as native apps for Android and iOS. The
+web version is a PWA. Users can join multiple communities at once, switch
 between them like servers in Discord, and take part in synchronous chat or
 asynchronous threads on the same relays. Other features include a calendar of
 nostr events, [NIP-17](/topics/private-dms) gift-wrapped DMs, [web of


### PR DESCRIPTION
Updates the Flotilla project page to reflect the availability feedback shared in `OpenSats/content#118`.

- notes that Flotilla ships as a web app and native apps for Android and iOS

Related to https://github.com/OpenSats/content/issues/118

---

Build preview:
- [/projects/flotilla](https://os-website-git-content-update-flotilla-feedback-opensats.vercel.app/projects/flotilla)
