### PR TITLE
docs(projects): refresh Bitshala growth stats

### DIFF
--- a/data/projects/bitshala.mdx
+++ b/data/projects/bitshala.mdx
@@ -24,9 +24,9 @@ OpenSats announced support for Bitshala in [March 2025][announcement]. That supp
 
 ## What's next?
 
-As of the latest [developer training impact report][impact-report], Bitshala had more than 1,200 Discord members and more than 350 regular participants across cohorts, study clubs, summits, and workshops. In early 2025 it ran its Mastering Bitcoin and Bitcoin Protocol Development cohorts with 73 enrolled and 17 completing the full course, while fellows and alumni continued contributing to projects like Bitcoin Core and silent payments tooling.
+By the end of 2025, Bitshala had organized 15 study cohorts with 710 total registrations and 109 graduates, run 82 public and invite-only meetups across four cities, supported 27 fellows across dev, design, and education tracks, awarded four starter grants, and grown its Discord to 2,009 members. It also ran two BOSS summits, two Bitplebs conferences, and 5 weekly clubs that kept contributors meeting between larger programs.
 
-The next step is scale and reproducibility. Bitshala is expanding cohorts, fellowships, and local events while building public playbooks and lightweight internal tools that make its education model easier for other communities to copy.
+The next step is scale and reproducibility. Bitshala is expanding cohorts, fellowships, and local events while building public playbooks and lightweight internal tools that make its education model easier for other communities to copy. For earlier context on the program's direction, see the [developer training impact report][impact-report].
 
 [announcement]: /blog/let-a-thousand-flowers-bloom#bitshala
 [impact-report]: /blog/advancements-in-developer-training#bitshala


### PR DESCRIPTION
Refreshes the Bitshala project page with the updated impact data shared in `OpenSats/content#118`.

- replaces the older early-2025 figures with the broader 2025 impact snapshot
- keeps the existing direction section and points readers to the earlier impact report for context

Related to https://github.com/OpenSats/content/issues/118

---

Build preview:
- [/projects/bitshala](https://os-website-git-content-update-bitshala-feedback-opensats.vercel.app/projects/bitshala)
