### PR TITLE
docs(projects): refresh BRK roadmap

### DIFF
--- a/data/projects/bitcoinresearchkit.mdx
+++ b/data/projects/bitcoinresearchkit.mdx
@@ -23,7 +23,7 @@ OpenSats highlighted BRK in the [twelfth wave of Bitcoin grants][announce]. That
 
 ## What's next?
 
-The grant announcement laid out the near-term roadmap: explorer views for blocks, addresses, and transactions, support for mempool.space and Electrum protocols, prebuilt binaries and integrated `bitcoind` support for self-hosters, a terminal view for more complex queries, a toggle for disabling price data, and Prometheus monitoring. The public BRK stack already includes Bitview, a documented API, and language clients. The next stretch is making that same data pipeline easier to run and more useful for researchers, miners, node operators, and analysts.
+The public BRK stack already includes Bitview, a documented API, language clients, working explorer views, chain-derived price data, and dedicated health and status endpoints for monitoring. The next stretch is operator ergonomics: better Docker support, Start9 and Umbrel plugins, a future auto-generated terminal client, and a plugin system that keeps the HTTP-first workflow fast, cacheable, and light on dependencies. The focus is making the same data pipeline easier to run without bloating the stack.
 
 [announce]: /blog/twelfth-wave-of-bitcoin-grants#bitcoin-research-kit
 [bitview]: https://bitview.space/


### PR DESCRIPTION
Refreshes the Bitcoin Research Kit project page to match the implementation feedback shared in `OpenSats/content#118`.

- replaces the older roadmap language with the current BRK stack status
- updates the next-step section to match the project's current operator-focused priorities

Related to https://github.com/OpenSats/content/issues/118

---

Build preview:
- [/projects/bitcoinresearchkit](https://os-website-git-content-update-bitcoinresearchki-db2ed9-opensats.vercel.app/projects/bitcoinresearchkit)
