### PR TITLE
docs(projects): update Minibits iOS availability

### DIFF
--- a/data/projects/minibits.mdx
+++ b/data/projects/minibits.mdx
@@ -63,12 +63,10 @@ report.
 ## What's next?
 
 Android builds ship through
-[Zapstore](https://zapstore.dev/apps/com.minibits_wallet). iOS is now
-publicly available to EU users through
-[Freedom Store](https://freedomstore.io/) (cooperation with the Vexl
-foundation), with [TestFlight](https://testflight.apple.com/join/defJQgTD)
-still serving the rest of the world. Recent work added the compact v4 token
-format, animated QR codes for large tokens
+[Zapstore](https://zapstore.dev/apps/com.minibits_wallet). iOS is now live on
+the main App Store, so the wallet no longer depends on TestFlight or EU-only
+alternative distribution. Recent work added the compact v4 token format,
+animated QR codes for large tokens
 ([NUT-16](https://github.com/cashubtc/nuts/blob/main/16.md)), payment requests
 ([NUT-18](https://github.com/cashubtc/nuts/blob/main/18.md)), WebSocket
 subscriptions for instant balance updates


### PR DESCRIPTION
Updates the Minibits project page to reflect the current iOS distribution status shared in `OpenSats/content#118`.

- removes the outdated TestFlight and EU-only distribution wording
- notes that Minibits is live on the main App Store

Related to https://github.com/OpenSats/content/issues/118

---

Build preview:
- [/projects/minibits](https://os-website-git-content-update-minibits-feedback-opensats.vercel.app/projects/minibits)
