### PR TITLE
Fix rust-bitcoin support link

### DIFF
--- a/data/projects/rust-bitcoin.mdx
+++ b/data/projects/rust-bitcoin.mdx
@@ -4,6 +4,7 @@ dateAdded: '2026-05-07'
 summary: 'A low-level Rust Bitcoin library stack for protocol messages, transactions, scripts, keys, addresses, and PSBTs.'
 nym: 'rust-bitcoin Maintainers'
 website: 'https://rust-bitcoin.org/'
+donationLink: 'https://github.com/sponsors/tcharding'
 coverImage: '/static/images/projects/rust-bitcoin.svg'
 git: 'https://github.com/rust-bitcoin/rust-bitcoin'
 tags: ['Bitcoin', 'Library']


### PR DESCRIPTION
Updates the `rust-bitcoin` project page so the `Support directly` action points to Tobin Harding's GitHub Sponsors page.

---

Build preview:

- pending Vercel preview
