### PR TITLE
docs(topics): add nsec topic reference

### DIFF
--- a/data/projects/amber.mdx
+++ b/data/projects/amber.mdx
@@ -14,17 +14,20 @@ announcementLink: '/blog/greenart7c3-receives-lts-grant'
 ---
 
 Amber is a [nostr](/topics/nostr) signer for Android built by
-[Greenart7c3][lts]. It is the app that holds your `nsec` so other apps do not
-have to. Other nostr clients on the device, and nostr web apps in any browser, ask
-Amber to sign events for them over [NIP-46 remote signing](/topics/remote-signing)
-or [NIP-55](https://github.com/nostr-protocol/nips/blob/master/55.md), the
+[Greenart7c3][lts]. It is the app that holds your [`nsec`](/topics/nsec) so
+other apps do not have to. Other nostr clients on the device, and nostr web
+apps in any browser, ask Amber to sign events for them over [NIP-46 remote
+signing](/topics/remote-signing) or
+[NIP-55](https://github.com/nostr-protocol/nips/blob/master/55.md), the
 on-device equivalent for Android. The secret never leaves Amber, and the user
 gets a per-app prompt the first time a new client wants to sign on its behalf.
 
 > Private keys should be exposed to as few systems as possible as each system
 > adds to the attack surface.
 >
-> <cite>—[NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md)</cite>
+> <cite>
+>   —[NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md)
+> </cite>
 
 Amber supports multiple accounts, remembered per-permission decisions for
 common kinds, signing in the background through Android content providers, and
@@ -37,12 +40,12 @@ artifacts and a published verification guide.
 
 ## Why fund it?
 
-The default key model on nostr puts one `nsec` into every client a user
-touches. Each app then becomes a place the key can leak: a malicious update, a
-stolen phone, an exfiltrated backup. Putting all signing through one dedicated
-app shrinks the attack surface to a single binary that the user explicitly
-trusts and updates, and makes it possible to revoke an individual client's
-access without rotating the key.
+The default key model on nostr puts one [`nsec`](/topics/nsec) into every
+client a user touches. Each app then becomes a place the key can leak: a
+malicious update, a stolen phone, an exfiltrated backup. Putting all signing
+through one dedicated app shrinks the attack surface to a single binary that
+the user explicitly trusts and updates, and makes it possible to revoke an
+individual client's access without rotating the key.
 
 OpenSats first funded Amber in [August 2023](/blog/bitcoin-and-nostr-grants-august-2023#amber-nostr-event-signer)
 and later announced [long-term support][lts] for Greenart7c3 in October 2024,

--- a/data/topics/nostr.mdx
+++ b/data/topics/nostr.mdx
@@ -6,7 +6,7 @@ category: 'Nostr'
 aliases: ['Notes and Other Stuff Transmitted by Relays']
 ---
 
-Nostr is a simple protocol for publishing and reading signed messages. A user's identity is a public key. A user's content is a list of "events" signed by his private key. Events are stored and served by "relays", which are small servers that anyone can run.
+Nostr is a simple protocol for publishing and reading signed messages. A user's identity is a public key, often shared in `npub` form. A user's content is a list of "events" signed by an [`nsec`](/topics/nsec), the matching private key. Events are stored and served by "relays", which are small servers that anyone can run.
 
 There is no central server and no account system. A client connects to several relays at once, publishes events to all of them, and reads events from all of them. If a relay disappears or starts censoring, the client switches to another. The same identity and the same content keep working.
 

--- a/data/topics/nsec.mdx
+++ b/data/topics/nsec.mdx
@@ -1,0 +1,18 @@
+---
+title: 'nsec'
+summary: 'A Nostr private key encoded as a Bech32 string under NIP-19. Whoever controls the `nsec` controls the account.'
+category: 'Nostr'
+aliases: ['nostr private key', 'nostr secret key', 'nsec1']
+---
+
+`nsec` is the standard human-readable encoding for a Nostr private key. [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) wraps the raw 32-byte secret in a [Bech32](https://en.bitcoin.it/wiki/Bech32) string that starts with the `nsec1` prefix. The matching public identity is usually shared as an `npub` string.
+
+Whoever has the `nsec` can sign events, publish notes, change profile metadata, authorize client connections, and decrypt content tied to the same keypair. In practice, the `nsec` is the account. Users should keep it in a dedicated signer such as [Amber](/projects/amber), hardware-backed storage, or a [remote-signing](/topics/remote-signing) setup instead of pasting it into every client.
+
+Good clients derive the public key locally, request signatures as needed, and let the user approve or revoke access per app. That model shrinks the attack surface and makes it easier to try new clients without copying the secret around.
+
+## References
+
+- [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md)
+- [Bitcoin Wiki: Bech32](https://en.bitcoin.it/wiki/Bech32)
+- [Amber](https://github.com/greenart7c3/Amber)


### PR DESCRIPTION
Adds a new `nsec` topic reference that explains what a Nostr secret key is, how it relates to an `npub`, and why it should stay in a dedicated signer.

- adds `data/topics/nsec.mdx` with NIP-19 and Bech32 context plus links to `remote signing` and `Amber`
- links existing `nsec` mentions from the `nostr` topic and the `Amber` project page to the new reference

Closes https://github.com/OpenSats/website/issues/807

---

Build preview:
- [/topics/nsec](https://os-website-git-content-add-nsec-topic-reference-opensats.vercel.app/topics/nsec)
