### PR TITLE
Close grant applications again

### DIFF
--- a/components/ClosedNotice.tsx
+++ b/components/ClosedNotice.tsx
@@ -1,0 +1,44 @@
+import Link from './Link'
+
+const ClosedNotice = () => {
+  return (
+    <div
+      className="rounded-b border-t-4 border-orange-500 bg-yellow-100 px-4 py-3 text-yellow-900 shadow-md"
+      role="alert"
+    >
+      <div className="flex">
+        <div className="py-1">
+          <svg
+            className="mr-4 h-6 w-6 fill-current text-orange-500"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+          >
+            <path d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zm12.73-1.41A8 8 0 1 0 4.34 4.34a8 8 0 0 0 11.32 11.32zM9 11V9h2v6H9v-4zm0-6h2v2H9V5z" />
+          </svg>
+        </div>
+        <div>
+          <p className="font-bold">Applications are currently closed!</p>
+          <p className="text-sm">
+            Grant applications are currently closed as per our{' '}
+            <Link href="/faq#when-is-the-best-time-to-apply">
+              quarterly schedule
+            </Link>
+            . Please have a look at{' '}
+            <Link href="/blog/2025-year-in-review">last year's report</Link> to
+            see what kind of projects we support.
+          </p>
+          <p className="text-sm">
+            If you want to prepare a submission, please get familiar with our{' '}
+            <Link href="/apply#criteria">application criteria</Link> as well as
+            our <Link href="/selection">grant selection process</Link>.
+          </p>
+          <p className="text-sm">
+            We will re-open applications on the 1st week of next month.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ClosedNotice

--- a/components/LTSApplicationForm.tsx
+++ b/components/LTSApplicationForm.tsx
@@ -11,13 +11,11 @@ export default function ApplicationForm() {
   const [formLoadedAt] = useState(() => Date.now())
   const router = useRouter()
   const {
-    watch,
     register,
     handleSubmit,
     formState: { errors },
   } = useForm()
 
-  const isFLOSS = watch('free_open_source', false)
   const [failureReason, setFailureReason] = useState<string>()
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -273,9 +271,9 @@ export default function ApplicationForm() {
       </div>
 
       <FormButton
-        variant={isFLOSS && !loading ? 'enabled' : 'disabled'}
+        variant="disabled"
         type="submit"
-        disabled={loading || !isFLOSS}
+        disabled={true}
         aria-busy={loading}
       >
         {loading ? 'Submitting…' : 'Submit LTS Application'}

--- a/components/grant-application/StepNavigation.tsx
+++ b/components/grant-application/StepNavigation.tsx
@@ -40,11 +40,9 @@ export default function StepNavigation({
         <button
           type="button"
           onClick={onSubmit}
-          disabled={loading}
+          disabled={true}
           aria-busy={loading}
-          className={`rounded-md bg-orange-500 px-6 py-2 text-sm font-semibold text-white hover:bg-orange-600 ${
-            loading ? 'cursor-not-allowed opacity-50' : ''
-          }`}
+          className="cursor-not-allowed rounded-md bg-orange-500 px-6 py-2 text-sm font-semibold text-white opacity-50"
         >
           {loading ? 'Submitting...' : 'Submit Grant Application'}
         </button>

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -70,6 +70,12 @@ button.secondary {
   margin-bottom: 0;
 }
 
+.disabled {
+  pointer-events: none;
+  cursor: default;
+  opacity: 0.6;
+}
+
 .prose a[data-external]:not([class]) {
   color: inherit !important;
   text-decoration: underline dotted;

--- a/data/headerNavLinks.ts
+++ b/data/headerNavLinks.ts
@@ -4,7 +4,7 @@ const headerNavLinks = [
   { href: '/about', title: 'About' },
   { href: '/blog', title: 'Blog' },
   { href: '/faq', title: 'FAQ' },
-  { href: '/apply', title: 'Apply', isButton: true },
+  { href: '/donate', title: 'Donate', isButton: true },
 ]
 
 export default headerNavLinks

--- a/pages/apply/grant.tsx
+++ b/pages/apply/grant.tsx
@@ -1,6 +1,7 @@
 import dynamic from 'next/dynamic'
 import PageSection from '@/components/PageSection'
 import { PageSEO } from '@/components/SEO'
+import ClosedNotice from '@/components/ClosedNotice'
 
 const GrantApplicationForm = dynamic(
   () => import('@/components/GrantApplicationForm'),
@@ -28,6 +29,7 @@ export default function Apply() {
           similar payment information that is required to receive grant payouts
           from OpenSats.
         </p>
+        <ClosedNotice />
         <GrantApplicationForm />
       </PageSection>
     </>

--- a/pages/apply/index.tsx
+++ b/pages/apply/index.tsx
@@ -5,6 +5,7 @@ import { MDXLayoutRenderer } from 'pliny/mdx-components'
 import { MDXComponents } from '@/components/MDXComponents'
 import PageSection from '@/components/PageSection'
 import CustomLink from '@/components/Link'
+import ClosedNotice from '@/components/ClosedNotice'
 
 const DEFAULT_LAYOUT = 'PageLayout'
 
@@ -45,6 +46,7 @@ export default function Apply({
           <CustomLink href="/faq/application">Application FAQ</CustomLink> to
           find answers to common questions.
         </p>
+        <ClosedNotice />
         <h2 className="mb-4 text-xl font-bold leading-normal md:text-2xl">
           General Grant
         </h2>
@@ -55,8 +57,8 @@ export default function Apply({
           projects in the Bitcoin space.
         </p>
         <Link
-          href="/apply/grant"
-          className="rounded border border-orange-500 bg-transparent px-4 py-2 font-semibold text-orange-500 no-underline hover:text-black dark:hover:text-white"
+          href="#/apply/grant"
+          className="disabled rounded border border-orange-500 bg-transparent px-4 py-2 font-semibold text-orange-500 no-underline hover:text-black dark:hover:text-white"
         >
           Apply for an OpenSats General Grant
         </Link>
@@ -69,8 +71,8 @@ export default function Apply({
           geared towards developers and maintainers of Bitcoin Core and similar.
         </p>
         <Link
-          href="/apply/lts"
-          className="rounded border border-orange-500 bg-transparent px-4 py-2 font-semibold text-orange-500 no-underline hover:text-black dark:hover:text-white"
+          href="#/apply/lts"
+          className="disabled rounded border border-orange-500 bg-transparent px-4 py-2 font-semibold text-orange-500 no-underline hover:text-black dark:hover:text-white"
         >
           Apply for an OpenSats LTS Grant
         </Link>

--- a/pages/apply/lts.tsx
+++ b/pages/apply/lts.tsx
@@ -3,6 +3,7 @@ import LTSApplicationForm from '@/components/LTSApplicationForm'
 import Link from '@/components/Link'
 import CustomLink from '@/components/Link'
 import { PageSEO } from '@/components/SEO'
+import ClosedNotice from '@/components/ClosedNotice'
 
 export default function Apply() {
   return (
@@ -50,6 +51,7 @@ export default function Apply() {
           If the above does not apply to you, please consider applying for a{' '}
           <Link href="/apply/grant">General Grant</Link> instead.
         </p>
+        <ClosedNotice />
         <LTSApplicationForm />
       </PageSection>
     </>


### PR DESCRIPTION
## Summary
- re-apply the quarterly close-applications behavior reverted by PR #589
- restore the closed notice, Donate header CTA, disabled apply links, and disabled submit controls
- keep the current multi-step application flow intact for the next reopen

## Validation
- npx next lint --dir pages --dir components
- checked /apply, /apply/grant, and /apply/lts locally for the closed notice and disabled submission state