### PR TITLE
Add browser frame mockup for screenshots

### DIFF
--- a/components/BrowserFrame.tsx
+++ b/components/BrowserFrame.tsx
@@ -1,6 +1,12 @@
 import { ReactNode } from 'react'
 
-const BrowserFrame = ({ url, children }: { url?: string; children: ReactNode }) => {
+const BrowserFrame = ({
+  url,
+  children,
+}: {
+  url?: string
+  children: ReactNode
+}) => {
   return (
     <div className="overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700">
       <div className="flex items-center gap-2 border-b border-gray-200 bg-gray-100 px-3 py-2 dark:border-gray-700 dark:bg-gray-800">
@@ -13,7 +19,7 @@ const BrowserFrame = ({ url, children }: { url?: string; children: ReactNode }) 
           </div>
         )}
       </div>
-      {children}
+      <div className="[&_img]:my-0">{children}</div>
     </div>
   )
 }

--- a/components/BrowserFrame.tsx
+++ b/components/BrowserFrame.tsx
@@ -8,7 +8,7 @@ const BrowserFrame = ({
   children: ReactNode
 }) => {
   return (
-    <div className="my-8 overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700">
+    <div className="my-16 overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700">
       <div className="flex items-center gap-2 border-b border-gray-200 bg-gray-100 px-3 py-2 dark:border-gray-700 dark:bg-gray-800">
         <span className="h-3 w-3 rounded-full bg-[#ff5f57]" />
         <span className="h-3 w-3 rounded-full bg-[#febc2e]" />

--- a/components/BrowserFrame.tsx
+++ b/components/BrowserFrame.tsx
@@ -8,7 +8,7 @@ const BrowserFrame = ({
   children: ReactNode
 }) => {
   return (
-    <div className="overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700">
+    <div className="my-8 overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700">
       <div className="flex items-center gap-2 border-b border-gray-200 bg-gray-100 px-3 py-2 dark:border-gray-700 dark:bg-gray-800">
         <span className="h-3 w-3 rounded-full bg-[#ff5f57]" />
         <span className="h-3 w-3 rounded-full bg-[#febc2e]" />

--- a/components/BrowserFrame.tsx
+++ b/components/BrowserFrame.tsx
@@ -10,9 +10,9 @@ const BrowserFrame = ({
   return (
     <div className="overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700">
       <div className="flex items-center gap-2 border-b border-gray-200 bg-gray-100 px-3 py-2 dark:border-gray-700 dark:bg-gray-800">
-        <span className="h-3 w-3 rounded-full bg-gray-300 dark:bg-gray-600" />
-        <span className="h-3 w-3 rounded-full bg-gray-300 dark:bg-gray-600" />
-        <span className="h-3 w-3 rounded-full bg-gray-300 dark:bg-gray-600" />
+        <span className="h-3 w-3 rounded-full bg-[#ff5f57]" />
+        <span className="h-3 w-3 rounded-full bg-[#febc2e]" />
+        <span className="h-3 w-3 rounded-full bg-[#28c840]" />
         {url && (
           <div className="ml-3 flex-1 truncate rounded-md bg-white px-3 py-1 text-xs text-gray-500 dark:bg-gray-900 dark:text-gray-400">
             {url}

--- a/components/BrowserFrame.tsx
+++ b/components/BrowserFrame.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react'
+
+const BrowserFrame = ({ url, children }: { url?: string; children: ReactNode }) => {
+  return (
+    <div className="overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700">
+      <div className="flex items-center gap-2 border-b border-gray-200 bg-gray-100 px-3 py-2 dark:border-gray-700 dark:bg-gray-800">
+        <span className="h-3 w-3 rounded-full bg-gray-300 dark:bg-gray-600" />
+        <span className="h-3 w-3 rounded-full bg-gray-300 dark:bg-gray-600" />
+        <span className="h-3 w-3 rounded-full bg-gray-300 dark:bg-gray-600" />
+        {url && (
+          <div className="ml-3 flex-1 truncate rounded-md bg-white px-3 py-1 text-xs text-gray-500 dark:bg-gray-900 dark:text-gray-400">
+            {url}
+          </div>
+        )}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+export default BrowserFrame

--- a/components/MDXComponents.tsx
+++ b/components/MDXComponents.tsx
@@ -6,6 +6,7 @@ import { Pre } from 'pliny/ui/Pre'
 import { BlogNewsletterForm } from 'pliny/ui/NewsletterForm'
 
 import Image from './Image'
+import BrowserFrame from './BrowserFrame'
 import VideoPlayer from './VideoPlayer'
 import CustomLink from './Link'
 import DonateToGeneralFundForm from './DonateToGeneralFundForm'
@@ -33,6 +34,7 @@ export const Wrapper = ({ layout, content, ...rest }: MDXLayout) => {
 
 export const MDXComponents: ComponentMap = {
   Image,
+  BrowserFrame,
   VideoPlayer,
   TOCInline,
   a: CustomLink,

--- a/data/blog/developer-spotlight-codytseng-jumblesocial.mdx
+++ b/data/blog/developer-spotlight-codytseng-jumblesocial.mdx
@@ -42,14 +42,16 @@ that nothing has been curated before you arrive, and posts sit without scores
 beneath them. Jumble refuses the usual sugar rush of the social web. It asks a
 question most apps have long since answered for you: what do you want to read?
 
-<Image
-  src="/static/images/spotlight/cody-tseng/jumble-screenshot.png"
-  darkSrc="/static/images/spotlight/cody-tseng/jumble-screenshot-dark.png"
-  alt="The Jumble web client"
-  width={1920}
-  height={970}
-  className="w-full h-auto"
-/>
+<BrowserFrame url="https://jumble.social">
+  <Image
+    src="/static/images/spotlight/cody-tseng/jumble-screenshot.png"
+    darkSrc="/static/images/spotlight/cody-tseng/jumble-screenshot-dark.png"
+    alt="The Jumble web client"
+    width={1920}
+    height={970}
+    className="w-full h-auto"
+  />
+</BrowserFrame>
 
 Most social media is a building someone else owns. They built the walls, set the
 rules, and kept the keys. Your account, posts, and followers all live inside


### PR DESCRIPTION
Adds a reusable `BrowserFrame` component that wraps screenshots in minimal browser chrome and uses it around the Jumble screenshot in the Cody Tseng spotlight post. The frame works in light and dark mode through Tailwind `dark:` utilities, so it needs no extra image assets.

- new `components/BrowserFrame.tsx` with a top bar, macOS-style traffic-light dots, and an optional URL pill, registered in `components/MDXComponents.tsx`
- wraps the Jumble screenshot with `<BrowserFrame url="https://jumble.social">`, resetting the prose image margin so the screenshot sits flush in the frame
- adds vertical spacing around the frame so it breathes between paragraphs

Build preview:
- [/blog/developer-spotlight-codytseng-jumblesocial](https://os-website-git-feat-browser-mockup-opensats.vercel.app/blog/developer-spotlight-codytseng-jumblesocial)
