### PR TITLE
Update blog post reference link for eltoo with OpenSats topic

### DIFF
--- a/data/blog/fifteenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/fifteenth-wave-of-bitcoin-grants.mdx
@@ -258,7 +258,7 @@ Licenses: CC0-1.0, CC BY 4.0, MIT
 [CTV]: /topics/op-ctv
 [CSFS]: https://bitcoinops.org/en/topics/op_checksigfromstack/
 [LDK]: https://github.com/lightningdevkit
-[Ark-like protocols]: https://bitcoinops.org/en/topics/ark/
+[Ark-like protocols]: /topics/ark
 [bark]: https://docs.rs/bark-wallet/latest/bark/
 [Erk]: https://blog.second.tech/erk-update/
 [LNHANCE-Expedition]: https://github.com/LNHANCE-Expedition

--- a/data/blog/fifteenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/fifteenth-wave-of-bitcoin-grants.mdx
@@ -252,7 +252,7 @@ Repositories: [LNHANCE-Expedition]
 Licenses: CC0-1.0, CC BY 4.0, MIT
 
 [LNhance soft fork]: https://lnhance.org/
-[Eltoo]: https://bitcoinops.org/en/topics/eltoo/
+[Eltoo]: /topics/eltoo
 [hArk]: https://delvingbitcoin.org/t/evolving-the-ark-protocol-using-ctv-and-csfs/1602#p-4785-hark-hash-lock-ark-10
 [vaults]: https://bitcoinops.org/en/topics/vaults/
 [CTV]: https://bitcoinops.org/en/topics/op_checktemplateverify/

--- a/data/blog/fifteenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/fifteenth-wave-of-bitcoin-grants.mdx
@@ -255,7 +255,7 @@ Licenses: CC0-1.0, CC BY 4.0, MIT
 [Eltoo]: /topics/eltoo
 [hArk]: https://delvingbitcoin.org/t/evolving-the-ark-protocol-using-ctv-and-csfs/1602#p-4785-hark-hash-lock-ark-10
 [vaults]: https://bitcoinops.org/en/topics/vaults/
-[CTV]: https://bitcoinops.org/en/topics/op_checktemplateverify/
+[CTV]: /topics/op-ctv
 [CSFS]: https://bitcoinops.org/en/topics/op_checksigfromstack/
 [LDK]: https://github.com/lightningdevkit
 [Ark-like protocols]: https://bitcoinops.org/en/topics/ark/


### PR DESCRIPTION
Updated link for Eltoo, Ark, and CTV to use relative path.

- [/topics/eltoo](https://opensats.org/topics/eltoo)
- [/topics/op-ctv](https://opensats.org/topics/op-ctv)
- [/topics/ark](https://opensats.org/topics/ark)
