### PR TITLE
Update blog post reference link for Output descriptors with OpenSats topics

### DIFF
--- a/data/blog/open-hardware-for-open-money.mdx
+++ b/data/blog/open-hardware-for-open-money.mdx
@@ -312,7 +312,7 @@ roadmap focused on open-source development.
 [Tadeubas]: https://github.com/tadeubas
 [25.03.0]: https://github.com/selfcustody/krux/releases/tag/v25.03.0
 [descriptor]: /topics/output-descriptors
-[PSBT]: https://bitcoinops.org/en/topics/psbt/
+[PSBT]: /topics/psbt/
 [25.09.0]: https://github.com/selfcustody/krux/releases/tag/v25.09.0
 [Jean Do]: https://github.com/jdlcdl
 [25.10.0]: https://github.com/selfcustody/krux/releases/tag/v25.10.0

--- a/data/blog/open-hardware-for-open-money.mdx
+++ b/data/blog/open-hardware-for-open-money.mdx
@@ -311,7 +311,7 @@ roadmap focused on open-source development.
 [Odudex]: https://github.com/odudex
 [Tadeubas]: https://github.com/tadeubas
 [25.03.0]: https://github.com/selfcustody/krux/releases/tag/v25.03.0
-[descriptor]: https://bitcoinops.org/en/topics/output-script-descriptors/
+[descriptor]: /topics/output-descriptors
 [PSBT]: https://bitcoinops.org/en/topics/psbt/
 [25.09.0]: https://github.com/selfcustody/krux/releases/tag/v25.09.0
 [Jean Do]: https://github.com/jdlcdl


### PR DESCRIPTION
Update blog post reference links with OpenSats topics, adding:

- [/topics/output-descriptors](https://opensats.org/topics/output-descriptors)
- [/topics/psbt](https://opensats.org/topics/psbt)