### PR TITLE
Update blog post reference links for five topics with OpenSats topics

### DIFF
--- a/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
@@ -113,7 +113,7 @@ License: MIT
 [testnet]: https://bitcoinops.org/en/topics/testnet/
 [HTLC]: topics/htlc
 [CoinJoin]: /topics/coinjoin
-[PSBT]: https://bitcoinops.org/en/topics/psbt/
+[PSBT]: /topics/psbt
 [covenant]: https://bitcoinops.org/en/topics/covenants/
 [rawBit-io/rawbit]: https://github.com/rawBit-io/rawbit
 

--- a/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
@@ -111,7 +111,7 @@ License: MIT
 [SegWit]: /topics/segwit
 [Taproot]: /topics/taproot
 [testnet]: https://bitcoinops.org/en/topics/testnet/
-[HTLC]: https://bitcoinops.org/en/topics/htlc/
+[HTLC]: topics/htlc
 [CoinJoin]: https://bitcoinops.org/en/topics/coinjoin/
 [PSBT]: https://bitcoinops.org/en/topics/psbt/
 [covenant]: https://bitcoinops.org/en/topics/covenants/

--- a/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
@@ -108,7 +108,7 @@ Repository: [rawBit-io/rawbit]
 License: MIT
 
 [rawBit]: https://rawbit.io/
-[SegWit]: https://bitcoinops.org/en/topics/segregated-witness/
+[SegWit]: /topics/segwit
 [Taproot]: https://bitcoinops.org/en/topics/taproot/
 [testnet]: https://bitcoinops.org/en/topics/testnet/
 [HTLC]: https://bitcoinops.org/en/topics/htlc/

--- a/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
@@ -109,7 +109,7 @@ License: MIT
 
 [rawBit]: https://rawbit.io/
 [SegWit]: /topics/segwit
-[Taproot]: https://bitcoinops.org/en/topics/taproot/
+[Taproot]: /topics/taproot
 [testnet]: https://bitcoinops.org/en/topics/testnet/
 [HTLC]: https://bitcoinops.org/en/topics/htlc/
 [CoinJoin]: https://bitcoinops.org/en/topics/coinjoin/

--- a/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
@@ -111,7 +111,7 @@ License: MIT
 [SegWit]: /topics/segwit
 [Taproot]: /topics/taproot
 [testnet]: https://bitcoinops.org/en/topics/testnet/
-[HTLC]: topics/htlc
+[HTLC]: /topics/htlc
 [CoinJoin]: /topics/coinjoin
 [PSBT]: /topics/psbt
 [covenant]: https://bitcoinops.org/en/topics/covenants/

--- a/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
@@ -112,7 +112,7 @@ License: MIT
 [Taproot]: /topics/taproot
 [testnet]: https://bitcoinops.org/en/topics/testnet/
 [HTLC]: topics/htlc
-[CoinJoin]: https://bitcoinops.org/en/topics/coinjoin/
+[CoinJoin]: /topics/coinjoin
 [PSBT]: https://bitcoinops.org/en/topics/psbt/
 [covenant]: https://bitcoinops.org/en/topics/covenants/
 [rawBit-io/rawbit]: https://github.com/rawBit-io/rawbit


### PR DESCRIPTION
Update blog post reference links for five topics with OpenSats topics:

1. [/topics/segwit](https://opensats.org/topics/segwit)
2. [/topics/taproot](https://opensats.org/topics/taproot)
3. [/topics/htlc](https://opensats.org/topics/htlc)
4. [/topics/coinjoin](https://opensats.org/topics/coinjoin)
5. [/topics/psbt](https://opensats.org/topics/psbt)