### PR TITLE
Update blog post reference link for assumeUTXO topic with OpenSats topic

### DIFF
--- a/data/blog/sjors-provoost-receives-opensats-lts-grant.mdx
+++ b/data/blog/sjors-provoost-receives-opensats-lts-grant.mdx
@@ -10,9 +10,8 @@ summary: 'Sjors Provoost receives long-term support from OpenSats.'
 
 New month, new LTS grantee! Sjors Provoost is the latest bitcoin core developer
 receiving long-term support from OpenSats, after [Marco
-Falke](https://opensats.org/blog/announcing-lts-grant-program-to-support-bitcoin-core-contributors)
-in July and [Josi
-Baker](https://opensats.org/blog/josi-baker-receives-opensats-lts-grant) in
+Falke](/blog/announcing-lts-grant-program-to-support-bitcoin-core-contributors)
+in July and [Josi Baker](/blog/josi-baker-receives-opensats-lts-grant) in
 August.
 
 Sjors is a Physicist turned bitcoin developer and self-proclaimed shadowy
@@ -23,9 +22,8 @@ Progress](https://www.btcwip.com/).
 
 He will continue to work in all areas of the codebase, as he has over the past
 five years. While Sjors is a generalist, he intends to focus on specific areas
-from time to time, such as [Stratum V2](https://opensats.org/projects/stratumv2)
-integration, [AssumeUTXO](https://bitcoinops.org/en/topics/assumeutxo/), and
-hardware wallet support.
+from time to time, such as [Stratum V2](/projects/stratumv2) integration,
+[AssumeUTXO](/topics/assumeutxo), and hardware wallet support.
 
 Sjors has reviewed almost a thousand pull requests since 2017, some of them
 in-depth reviews across many rebases.[^fn-reviews] He has opened about 160 pull
@@ -41,13 +39,13 @@ Taproot, `assumeutxo`, tests, and the GUI. You can follow his activity on
 Support for Sjors’ work is sourced from our General Fund and made possible by
 generous donors like you. If you would like to support the work of Sjors and
 other core developers, consider [donating to the
-fund](https://opensats.org/projects/general_fund).
+fund](/projects/general_fund).
 
 The OpenSats LTS program exists to provide sustainable funding for long-term
 contributors to critical open-source projects. You can apply for the program
 here:
 
-- [opensats.org/apply/lts](https://opensats.org/apply/lts)
+- [opensats.org/apply/lts](/apply/lts)
 
 [^fn-reviews]: [PR Reviews by Sjors](https://bitcoinacks.com/?flt1_reviewer_contains=sjors)
 [^fn-prs]: [PRs by Sjors](https://bitcoinacks.com/?flt2_author_contains=sjors)


### PR DESCRIPTION
Updated links in the blog post to use relative paths for better maintainability.
Added [/topics/assumeutxo](https://opensats.org/topics/assumeutxo)