### PR TITLE
Update blog post reference links for three topics with OpenSats topics

### DIFF
--- a/data/blog/twelfth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/twelfth-wave-of-bitcoin-grants.mdx
@@ -85,10 +85,10 @@ over 70% test coverage.
 
 Support from this grant will fund further implementation of BOLT 4, BOLT 5, and
 BOLT 7. The project aims to complete a full Lightning daemon with channel
-operations, [HTLC](https://bitcoinops.org/en/topics/htlc/) handling, and payment
-routing. Additional work will improve data structures, backup systems, developer
-tooling, and documentation. One of the upcoming goals of the project is to
-expand test coverage and fuzz testing to make the implementation more robust and
+operations, [HTLC](/topics/htlc) handling, and payment routing. Additional work
+will improve data structures, backup systems, developer tooling, and
+documentation. One of the upcoming goals of the project is to expand test
+coverage and fuzz testing to make the implementation more robust and
 production-ready.
 
 Repository: [ipms-io/nlightning](https://github.com/ipms-io/nlightning)  
@@ -101,12 +101,12 @@ License: MIT
 [Swift Bitcoin](https://swiftbitcoin.org/) is an open-source software
 development kit (SDK) and network client written entirely in
 [Swift](https://www.swift.org/documentation/). It offers a full node
-implementation with [PSBT](https://bitcoinops.org/en/topics/psbt/) support,
-[miniscript](https://bitcoinops.org/en/topics/miniscript/) domain-specific
-language, and [non-blocking I/O](https://github.com/apple/swift-nio#). The
-project has evolved over three years and already syncs and validates blocks,
-processes transactions, and matches Bitcoin Core on regtest. It delivers modular
-libraries for crypto, base protocol, wallet, blockchain, transport, and RPC use.
+implementation with [PSBT](/topics/psbt) support,
+[miniscript](/topics/miniscript) domain-specific language, and [non-blocking
+I/O](https://github.com/apple/swift-nio#). The project has evolved over three
+years and already syncs and validates blocks, processes transactions, and
+matches Bitcoin Core on regtest. It delivers modular libraries for crypto, base
+protocol, wallet, blockchain, transport, and RPC use.
 
 Support from this grant will fund
 [testnet4](https://bitcoinops.org/en/topics/testnet/) syncing and completion of


### PR DESCRIPTION
Updated links to use relative paths for consistency.

Added:

- https://opensats.org/topics/htlc
- https://opensats.org/topics/psbt
- https://opensats.org/topics/miniscript