### PR TITLE
Automate the grant application open/closed window

### DIFF
--- a/components/ClosedNotice.tsx
+++ b/components/ClosedNotice.tsx
@@ -1,6 +1,9 @@
 import Link from './Link'
+import { areApplicationsOpen } from '@/utils/applicationWindow'
 
 const ClosedNotice = () => {
+  if (areApplicationsOpen()) return null
+
   return (
     <div
       className="rounded-b border-t-4 border-orange-500 bg-yellow-100 px-4 py-3 text-yellow-900 shadow-md"

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -14,7 +14,6 @@ import ReferencesReview from './grant-application/steps/ReferencesReview'
 import AnythingElse from './grant-application/steps/AnythingElse'
 import Review from './grant-application/steps/Review'
 import { FormValues } from './grant-application/types'
-import { areApplicationsOpen } from '@/utils/applicationWindow'
 
 const STEPS = [
   {
@@ -164,10 +163,6 @@ export default function ApplicationForm() {
 
   const stepProps = { register, watch, errors }
 
-  // When applications are closed, only show the first step so applicants can
-  // still read the prerequisites and download the template to prepare.
-  const open = areApplicationsOpen()
-
   return (
     <form
       ref={formRef}
@@ -176,38 +171,32 @@ export default function ApplicationForm() {
     >
       <input type="hidden" {...register('general_fund', { value: true })} />
 
-      {open && (
-        <>
-          <StepIndicator
-            steps={STEPS}
-            currentStep={currentStep}
-            onStepClick={handleStepClick}
-          />
+      <StepIndicator
+        steps={STEPS}
+        currentStep={currentStep}
+        onStepClick={handleStepClick}
+      />
 
-          <hr />
-        </>
-      )}
+      <hr />
 
       {currentStep === 0 && <Prerequisites {...stepProps} />}
-      {open && currentStep === 1 && <ApplicantDetails {...stepProps} />}
-      {open && currentStep === 2 && <ProjectDetails {...stepProps} />}
-      {open && currentStep === 3 && <ReferencesReview {...stepProps} />}
-      {open && currentStep === 4 && <SourceCode {...stepProps} />}
-      {open && currentStep === 5 && <Timeline {...stepProps} />}
-      {open && currentStep === 6 && <Budget {...stepProps} />}
-      {open && currentStep === 7 && <AnythingElse {...stepProps} />}
-      {open && currentStep === 8 && <Review watch={watch} />}
+      {currentStep === 1 && <ApplicantDetails {...stepProps} />}
+      {currentStep === 2 && <ProjectDetails {...stepProps} />}
+      {currentStep === 3 && <ReferencesReview {...stepProps} />}
+      {currentStep === 4 && <SourceCode {...stepProps} />}
+      {currentStep === 5 && <Timeline {...stepProps} />}
+      {currentStep === 6 && <Budget {...stepProps} />}
+      {currentStep === 7 && <AnythingElse {...stepProps} />}
+      {currentStep === 8 && <Review watch={watch} />}
 
-      {open && (
-        <StepNavigation
-          currentStep={currentStep}
-          totalSteps={STEPS.length}
-          onBack={handleBack}
-          onNext={handleNext}
-          onSubmit={handleSubmit(onSubmit)}
-          loading={loading}
-        />
-      )}
+      <StepNavigation
+        currentStep={currentStep}
+        totalSteps={STEPS.length}
+        onBack={handleBack}
+        onNext={handleNext}
+        onSubmit={handleSubmit(onSubmit)}
+        loading={loading}
+      />
 
       {!!failureReason && (
         <p className="rounded bg-red-500 p-4 text-white">

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -14,6 +14,7 @@ import ReferencesReview from './grant-application/steps/ReferencesReview'
 import AnythingElse from './grant-application/steps/AnythingElse'
 import Review from './grant-application/steps/Review'
 import { FormValues } from './grant-application/types'
+import { areApplicationsOpen } from '@/utils/applicationWindow'
 
 const STEPS = [
   {
@@ -163,6 +164,10 @@ export default function ApplicationForm() {
 
   const stepProps = { register, watch, errors }
 
+  // When applications are closed, only show the first step so applicants can
+  // still read the prerequisites and download the template to prepare.
+  const open = areApplicationsOpen()
+
   return (
     <form
       ref={formRef}
@@ -171,32 +176,38 @@ export default function ApplicationForm() {
     >
       <input type="hidden" {...register('general_fund', { value: true })} />
 
-      <StepIndicator
-        steps={STEPS}
-        currentStep={currentStep}
-        onStepClick={handleStepClick}
-      />
+      {open && (
+        <>
+          <StepIndicator
+            steps={STEPS}
+            currentStep={currentStep}
+            onStepClick={handleStepClick}
+          />
 
-      <hr />
+          <hr />
+        </>
+      )}
 
       {currentStep === 0 && <Prerequisites {...stepProps} />}
-      {currentStep === 1 && <ApplicantDetails {...stepProps} />}
-      {currentStep === 2 && <ProjectDetails {...stepProps} />}
-      {currentStep === 3 && <ReferencesReview {...stepProps} />}
-      {currentStep === 4 && <SourceCode {...stepProps} />}
-      {currentStep === 5 && <Timeline {...stepProps} />}
-      {currentStep === 6 && <Budget {...stepProps} />}
-      {currentStep === 7 && <AnythingElse {...stepProps} />}
-      {currentStep === 8 && <Review watch={watch} />}
+      {open && currentStep === 1 && <ApplicantDetails {...stepProps} />}
+      {open && currentStep === 2 && <ProjectDetails {...stepProps} />}
+      {open && currentStep === 3 && <ReferencesReview {...stepProps} />}
+      {open && currentStep === 4 && <SourceCode {...stepProps} />}
+      {open && currentStep === 5 && <Timeline {...stepProps} />}
+      {open && currentStep === 6 && <Budget {...stepProps} />}
+      {open && currentStep === 7 && <AnythingElse {...stepProps} />}
+      {open && currentStep === 8 && <Review watch={watch} />}
 
-      <StepNavigation
-        currentStep={currentStep}
-        totalSteps={STEPS.length}
-        onBack={handleBack}
-        onNext={handleNext}
-        onSubmit={handleSubmit(onSubmit)}
-        loading={loading}
-      />
+      {open && (
+        <StepNavigation
+          currentStep={currentStep}
+          totalSteps={STEPS.length}
+          onBack={handleBack}
+          onNext={handleNext}
+          onSubmit={handleSubmit(onSubmit)}
+          loading={loading}
+        />
+      )}
 
       {!!failureReason && (
         <p className="rounded bg-red-500 p-4 text-white">

--- a/pages/apply/grant.tsx
+++ b/pages/apply/grant.tsx
@@ -2,6 +2,7 @@ import dynamic from 'next/dynamic'
 import PageSection from '@/components/PageSection'
 import { PageSEO } from '@/components/SEO'
 import ClosedNotice from '@/components/ClosedNotice'
+import { areApplicationsOpen } from '@/utils/applicationWindow'
 
 const GrantApplicationForm = dynamic(
   () => import('@/components/GrantApplicationForm'),
@@ -30,7 +31,7 @@ export default function Apply() {
           from OpenSats.
         </p>
         <ClosedNotice />
-        <GrantApplicationForm />
+        {areApplicationsOpen() && <GrantApplicationForm />}
       </PageSection>
     </>
   )

--- a/pages/apply/grant.tsx
+++ b/pages/apply/grant.tsx
@@ -2,7 +2,6 @@ import dynamic from 'next/dynamic'
 import PageSection from '@/components/PageSection'
 import { PageSEO } from '@/components/SEO'
 import ClosedNotice from '@/components/ClosedNotice'
-import { areApplicationsOpen } from '@/utils/applicationWindow'
 
 const GrantApplicationForm = dynamic(
   () => import('@/components/GrantApplicationForm'),
@@ -31,7 +30,7 @@ export default function Apply() {
           from OpenSats.
         </p>
         <ClosedNotice />
-        {areApplicationsOpen() && <GrantApplicationForm />}
+        <GrantApplicationForm />
       </PageSection>
     </>
   )

--- a/pages/apply/index.tsx
+++ b/pages/apply/index.tsx
@@ -85,7 +85,8 @@ export default function Apply({
         {!open && (
           <>
             <p className="mt-8">
-              Before you begin, please read our{' '}
+              We will accept applications again soon. To prepare your
+              application please read our{' '}
               <CustomLink href="/apply#criteria">
                 application criteria
               </CustomLink>{' '}

--- a/pages/apply/index.tsx
+++ b/pages/apply/index.tsx
@@ -49,39 +49,40 @@ export default function Apply({
           find answers to common questions.
         </p>
         <ClosedNotice />
-        <h2 className="mb-4 text-xl font-bold leading-normal md:text-2xl">
-          General Grant
-        </h2>
-        <p className="mb-8">
-          General grants are funded by donations to the OpenSats General Fund
-          and will be distributed periodically by our board. We evaluate and
-          assess all applications to make sure grants are awarded to high impact
-          projects in the Bitcoin space.
-        </p>
-        <Link
-          href={open ? '/apply/grant' : '#/apply/grant'}
-          className={`${
-            open ? '' : 'disabled'
-          } rounded border border-orange-500 bg-transparent px-4 py-2 font-semibold text-orange-500 no-underline hover:text-black dark:hover:text-white`}
-        >
-          Apply for an OpenSats General Grant
-        </Link>
-        <h2 className="mb-4 text-xl font-bold leading-normal md:text-2xl">
-          Long-Term Support
-        </h2>
-        <p className="mb-8">
-          We have a limited number of long-term support grants available for
-          projects that are critical to the Bitcoin ecosystem. These grants are
-          geared towards developers and maintainers of Bitcoin Core and similar.
-        </p>
-        <Link
-          href={open ? '/apply/lts' : '#/apply/lts'}
-          className={`${
-            open ? '' : 'disabled'
-          } rounded border border-orange-500 bg-transparent px-4 py-2 font-semibold text-orange-500 no-underline hover:text-black dark:hover:text-white`}
-        >
-          Apply for an OpenSats LTS Grant
-        </Link>
+        {open && (
+          <>
+            <h2 className="mb-4 text-xl font-bold leading-normal md:text-2xl">
+              General Grant
+            </h2>
+            <p className="mb-8">
+              General grants are funded by donations to the OpenSats General
+              Fund and will be distributed periodically by our board. We
+              evaluate and assess all applications to make sure grants are
+              awarded to high impact projects in the Bitcoin space.
+            </p>
+            <Link
+              href="/apply/grant"
+              className="rounded border border-orange-500 bg-transparent px-4 py-2 font-semibold text-orange-500 no-underline hover:text-black dark:hover:text-white"
+            >
+              Apply for an OpenSats General Grant
+            </Link>
+            <h2 className="mb-4 text-xl font-bold leading-normal md:text-2xl">
+              Long-Term Support
+            </h2>
+            <p className="mb-8">
+              We have a limited number of long-term support grants available for
+              projects that are critical to the Bitcoin ecosystem. These grants
+              are geared towards developers and maintainers of Bitcoin Core and
+              similar.
+            </p>
+            <Link
+              href="/apply/lts"
+              className="rounded border border-orange-500 bg-transparent px-4 py-2 font-semibold text-orange-500 no-underline hover:text-black dark:hover:text-white"
+            >
+              Apply for an OpenSats LTS Grant
+            </Link>
+          </>
+        )}
         {!open && (
           <>
             <p className="mt-8">

--- a/pages/apply/index.tsx
+++ b/pages/apply/index.tsx
@@ -82,31 +82,38 @@ export default function Apply({
         >
           Apply for an OpenSats LTS Grant
         </Link>
-        <p className="mt-8">
-          Before you begin, please read our{' '}
-          <CustomLink href="/apply#criteria">application criteria</CustomLink>{' '}
-          and <CustomLink href="/faq/application">Application FAQ</CustomLink>,
-          prepare at least two{' '}
-          <CustomLink href="/faq/application#what-are-you-looking-for-in-terms-of-references">
-            written reference letters
-          </CustomLink>
-          , and make sure your project uses a proper{' '}
-          <CustomLink href="/faq/grantee#what-does-it-mean-to-produce-work-under-a-free-and-open-source-license">
-            FOSS license
-          </CustomLink>
-          .
-        </p>
-        <p className="mt-8">
-          You can{' '}
-          <a
-            href="/static/opensats-grant-application-template.md"
-            download="opensats-grant-application-template.md"
-            className="text-orange-500"
-          >
-            download our application template
-          </a>{' '}
-          to prepare your answers offline before filling out the form.
-        </p>
+        {!open && (
+          <>
+            <p className="mt-8">
+              Before you begin, please read our{' '}
+              <CustomLink href="/apply#criteria">
+                application criteria
+              </CustomLink>{' '}
+              and{' '}
+              <CustomLink href="/faq/application">Application FAQ</CustomLink>,
+              prepare at least two{' '}
+              <CustomLink href="/faq/application#what-are-you-looking-for-in-terms-of-references">
+                written reference letters
+              </CustomLink>
+              , and make sure your project uses a proper{' '}
+              <CustomLink href="/faq/grantee#what-does-it-mean-to-produce-work-under-a-free-and-open-source-license">
+                FOSS license
+              </CustomLink>
+              .
+            </p>
+            <p className="mt-8">
+              You can{' '}
+              <a
+                href="/static/opensats-grant-application-template.md"
+                download="opensats-grant-application-template.md"
+                className="text-orange-500"
+              >
+                download our application template
+              </a>{' '}
+              to prepare your answers offline before filling out the form.
+            </p>
+          </>
+        )}
       </PageSection>
     </>
   )

--- a/pages/apply/index.tsx
+++ b/pages/apply/index.tsx
@@ -82,6 +82,17 @@ export default function Apply({
         >
           Apply for an OpenSats LTS Grant
         </Link>
+        <p className="mt-8">
+          You can{' '}
+          <a
+            href="/static/opensats-grant-application-template.md"
+            download="opensats-grant-application-template.md"
+            className="text-orange-500"
+          >
+            download our application template
+          </a>{' '}
+          to prepare your answers offline before filling out the form.
+        </p>
       </PageSection>
     </>
   )

--- a/pages/apply/index.tsx
+++ b/pages/apply/index.tsx
@@ -6,6 +6,7 @@ import { MDXComponents } from '@/components/MDXComponents'
 import PageSection from '@/components/PageSection'
 import CustomLink from '@/components/Link'
 import ClosedNotice from '@/components/ClosedNotice'
+import { areApplicationsOpen } from '@/utils/applicationWindow'
 
 const DEFAULT_LAYOUT = 'PageLayout'
 
@@ -17,6 +18,7 @@ export const getStaticProps = async () => {
 export default function Apply({
   apply,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
+  const open = areApplicationsOpen()
   return (
     <>
       <MDXLayoutRenderer
@@ -57,8 +59,10 @@ export default function Apply({
           projects in the Bitcoin space.
         </p>
         <Link
-          href="#/apply/grant"
-          className="disabled rounded border border-orange-500 bg-transparent px-4 py-2 font-semibold text-orange-500 no-underline hover:text-black dark:hover:text-white"
+          href={open ? '/apply/grant' : '#/apply/grant'}
+          className={`${
+            open ? '' : 'disabled'
+          } rounded border border-orange-500 bg-transparent px-4 py-2 font-semibold text-orange-500 no-underline hover:text-black dark:hover:text-white`}
         >
           Apply for an OpenSats General Grant
         </Link>
@@ -71,8 +75,10 @@ export default function Apply({
           geared towards developers and maintainers of Bitcoin Core and similar.
         </p>
         <Link
-          href="#/apply/lts"
-          className="disabled rounded border border-orange-500 bg-transparent px-4 py-2 font-semibold text-orange-500 no-underline hover:text-black dark:hover:text-white"
+          href={open ? '/apply/lts' : '#/apply/lts'}
+          className={`${
+            open ? '' : 'disabled'
+          } rounded border border-orange-500 bg-transparent px-4 py-2 font-semibold text-orange-500 no-underline hover:text-black dark:hover:text-white`}
         >
           Apply for an OpenSats LTS Grant
         </Link>

--- a/pages/apply/index.tsx
+++ b/pages/apply/index.tsx
@@ -83,6 +83,20 @@ export default function Apply({
           Apply for an OpenSats LTS Grant
         </Link>
         <p className="mt-8">
+          Before you begin, please read our{' '}
+          <CustomLink href="/apply#criteria">application criteria</CustomLink>{' '}
+          and <CustomLink href="/faq/application">Application FAQ</CustomLink>,
+          prepare at least two{' '}
+          <CustomLink href="/faq/application#what-are-you-looking-for-in-terms-of-references">
+            written reference letters
+          </CustomLink>
+          , and make sure your project uses a proper{' '}
+          <CustomLink href="/faq/grantee#what-does-it-mean-to-produce-work-under-a-free-and-open-source-license">
+            FOSS license
+          </CustomLink>
+          .
+        </p>
+        <p className="mt-8">
           You can{' '}
           <a
             href="/static/opensats-grant-application-template.md"

--- a/pages/apply/lts.tsx
+++ b/pages/apply/lts.tsx
@@ -4,6 +4,7 @@ import Link from '@/components/Link'
 import CustomLink from '@/components/Link'
 import { PageSEO } from '@/components/SEO'
 import ClosedNotice from '@/components/ClosedNotice'
+import { areApplicationsOpen } from '@/utils/applicationWindow'
 
 export default function Apply() {
   return (
@@ -52,7 +53,7 @@ export default function Apply() {
           <Link href="/apply/grant">General Grant</Link> instead.
         </p>
         <ClosedNotice />
-        <LTSApplicationForm />
+        {areApplicationsOpen() && <LTSApplicationForm />}
       </PageSection>
     </>
   )

--- a/utils/applicationWindow.ts
+++ b/utils/applicationWindow.ts
@@ -1,0 +1,4 @@
+// Closed during the third month of each quarter (Mar, Jun, Sep, Dec).
+export function areApplicationsOpen(date = new Date()): boolean {
+  return date.getMonth() % 3 !== 2
+}


### PR DESCRIPTION
This drives the grant application window from a single date-based helper instead of hardcoding the closed state across the apply pages. Applications now open and close automatically following the quarterly schedule (closed in March, June, September, and December), so no manual toggling is needed and the page content adapts on its own.

- Adds `areApplicationsOpen()` in `utils/applicationWindow.ts` as the single source of truth, consumed by `ClosedNotice`, the apply pages, and the grant form.
- When open, `/apply` shows the program sections with working buttons and the prerequisites live as page one of `/apply/grant`.
- When closed, `/apply` hides the program sections and instead shows the prerequisite links and template download, while `/apply/grant` and `/apply/lts` show only the closed notice.

Build preview:
- [/apply](https://opensats-website-git-close-applications-fix-opensats.vercel.app/apply)
- [/apply/grant](https://opensats-website-git-close-applications-fix-opensats.vercel.app/apply/grant)
