### PR TITLE
docs(topics): add nsite topic page

### DIFF
--- a/data/blog/the-libraries-behind-open-communication.mdx
+++ b/data/blog/the-libraries-behind-open-communication.mdx
@@ -560,8 +560,8 @@ alongside the library to give adopting developers a clearer reference, with new
 and updated pages covering private direct messages, tag management,
 getting-started instructions for trying the library in a browser, profile
 bootstrapping, and an in-progress NIP-19 guide. The documentation is also
-deployed on nostr as an nsite, where gateways serve the site from its nostr
-public key, including mirrors at [nsite.lol][nsite-lol] and
+deployed on nostr as an [nsite](/topics/nsite), where gateways serve the site
+from its nostr public key, including mirrors at [nsite.lol][nsite-lol] and
 [nostro.re][nostro-re], among other mirrors. A PHP library teaching its own
 users how to build on a censorship-resistant protocol by hosting its
 documentation on that protocol reflects the same principle that the library

--- a/data/projects/applesauce.mdx
+++ b/data/projects/applesauce.mdx
@@ -23,7 +23,7 @@ The SDK pairs with React via a small set of hooks for subscribing to observable 
 
 Every new nostr client used to reimplement the same basics from scratch: relay management, signing, contact lists, mute lists, NIP-17 wrappers, outbox-model relay selection. Applesauce moves that shared work into one set of packages so client developers can spend their time on the parts that make their app different. noStrudel is the largest public consumer, and the goal is for other client and tool authors to reuse the same primitives instead of rolling their own.
 
-OpenSats first supported hzrd149 in the [December 2023 wave of nostr grants][wave-1] for his work on noStrudel. He later received a [long-term support grant][lts], which is what funds the ongoing applesauce work alongside [Blossom](/topics/blossom), [nsite](https://nsyte.run/), and noStrudel itself.
+OpenSats first supported hzrd149 in the [December 2023 wave of nostr grants][wave-1] for his work on noStrudel. He later received a [long-term support grant][lts], which is what funds the ongoing applesauce work alongside [Blossom](/topics/blossom), [nsite](/topics/nsite), and noStrudel itself.
 
 ## What's next?
 

--- a/data/topics/nsite.mdx
+++ b/data/topics/nsite.mdx
@@ -15,3 +15,5 @@ Because the manifest lives on Nostr and the files can be mirrored across Blossom
 ## References
 
 - [NIP-5A](https://github.com/nostr-protocol/nips/blob/master/5A.md)
+- [nsyte.run](https://nsyte.run/)
+- [nostrver-se/awesome-nsite](https://github.com/nostrver-se/awesome-nsite)

--- a/data/topics/nsite.mdx
+++ b/data/topics/nsite.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'nsite'
-summary: 'A static website published on Nostr under NIP-5A, where a site manifest maps paths to files stored on Blossom servers and gateways serve the site from a pubkey.'
+summary: 'A static website on Nostr under NIP-5A, where a site manifest maps paths to files stored on Blossom servers.'
+ogSummary: 'A static website on Nostr where a site manifest maps paths to Blossom-hosted files.'
 category: 'Nostr'
 aliases: ['NIP-5A', 'Nostr website', 'site manifest', 'named site']
 ---

--- a/data/topics/nsite.mdx
+++ b/data/topics/nsite.mdx
@@ -1,0 +1,16 @@
+---
+title: 'nsite'
+summary: 'A static website published on Nostr under NIP-5A, where a site manifest maps paths to files stored on Blossom servers and gateways serve the site from a pubkey.'
+category: 'Nostr'
+aliases: ['NIP-5A', 'Nostr website', 'site manifest', 'named site']
+---
+
+`nsite` is a static website published on [Nostr](/topics/nostr). Under [NIP-5A](https://github.com/nostr-protocol/nips/blob/master/5A.md), an author publishes a site manifest event that maps absolute paths such as `/index.html` or `/blog/post/index.html` to SHA-256 hashes of files stored on [Blossom](/topics/blossom) servers.
+
+A gateway reads the manifest from relays, fetches the referenced files by hash, and serves the site from a URL derived from the author's pubkey. The spec supports a root site for one pubkey-wide site and named sites for smaller sites under the same pubkey, which is why mirrors often appear at domains like `npub...nsite-host.com`.
+
+Because the manifest lives on Nostr and the files can be mirrored across Blossom servers, an `nsite` can stay reachable through multiple gateways instead of depending on one web host. The model is still static: the site ships files, not server-side code, and gateways simply resolve the manifest and serve the matching blobs.
+
+## References
+
+- [NIP-5A](https://github.com/nostr-protocol/nips/blob/master/5A.md)


### PR DESCRIPTION
Adds a new `nsite` topic page and updates existing references so `nsite` points to the new internal topic page instead of a generic external link.

- adds `data/topics/nsite.mdx` with a concise overview of `NIP-5A`, site manifests, and Blossom-backed hosting
- links the new topic from the `nostr-php` libraries post and the `applesauce` project page

Closes https://github.com/OpenSats/website/issues/781

---

Build preview:
- [/topics/nsite](https://os-website-git-content-add-nsite-topic-reference-opensats.vercel.app/topics/nsite)
