### PR TITLE
docs(topics): add covenant topic page

### DIFF
--- a/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
@@ -114,7 +114,7 @@ License: MIT
 [HTLC]: /topics/htlc
 [CoinJoin]: /topics/coinjoin
 [PSBT]: /topics/psbt
-[covenant]: https://bitcoinops.org/en/topics/covenants/
+[covenant]: /topics/covenant
 [rawBit-io/rawbit]: https://github.com/rawBit-io/rawbit
 
 ### Specter DIY

--- a/data/topics/covenant.mdx
+++ b/data/topics/covenant.mdx
@@ -1,0 +1,18 @@
+---
+title: 'Covenants'
+summary: 'A category of Bitcoin proposals that restrict how coins can be spent in future transactions.'
+ogSummary: 'Bitcoin proposals that restrict how coins can be spent in future transactions.'
+category: 'Bitcoin'
+aliases: ['covenant', 'Bitcoin covenant']
+---
+
+Covenants are proposed changes to Bitcoin's spending rules that let an output constrain some part of a future spend, most commonly the scripts or destinations that the spending transaction may create. Instead of only checking whether the current spender is authorized, a covenant also narrows what an authorized spender is allowed to do next.
+
+Bitcoin does not currently support general covenants on mainnet. The term describes a family of proposals rather than one specific feature. [OP_CTV](/topics/op-ctv), for example, is a minimal covenant proposal that commits an output to one specific future transaction template.
+
+People are interested in covenants because they could enable vaults, congestion-controlled batching, payment pools, and other constructions that trade some future spending flexibility for stronger safety or coordination guarantees. The main debate is over how much expressiveness is useful, how much complexity is acceptable, and which design keeps the security model understandable for wallets and node software.
+
+## References
+
+- [Bitcoin Optech: Covenants](https://bitcoinops.org/en/topics/covenants/)
+- [BIP 119: OP_CHECKTEMPLATEVERIFY](https://github.com/bitcoin/bips/blob/master/bip-0119.mediawiki)

--- a/data/topics/op-ctv.mdx
+++ b/data/topics/op-ctv.mdx
@@ -7,7 +7,7 @@ aliases: ['CHECKTEMPLATEVERIFY', 'CTV', 'BIP 119']
 
 OP_CTV (CheckTemplateVerify) is a proposed opcode described in BIP 119. It lets an output commit to a hash of one specific future transaction. The coins can only be spent by a transaction that matches that hash.
 
-This is a minimal form of covenant. Useful applications include congestion-controlled payment batching, vaults, non-interactive payment channels, and shared UTXO constructions such as payment pools.
+This is a minimal form of [covenant](/topics/covenant). Useful applications include congestion-controlled payment batching, vaults, non-interactive payment channels, and shared UTXO constructions such as payment pools.
 
 Further reading: the [utxos.org](https://utxos.org/) landing page, the reference implementation in [bitcoin-inquisition](https://github.com/bitcoin-inquisition/bitcoin), and the BIP itself.
 


### PR DESCRIPTION
Adds a new `covenant` topic page and updates existing references so covenant mentions point to the new internal topic page.

- adds `data/topics/covenant.mdx` with a concise overview of the covenant design space and the `OP_CTV` example
- links the new topic from the `OP_CTV` page and the `seventeenth-wave-of-bitcoin-grants` post

Closes https://github.com/OpenSats/website/issues/829

---

Build preview:
- [/topics/covenant](https://os-website-git-content-add-covenant-topic-page-opensats.vercel.app/topics/covenant)
