### PR TITLE
docs(topics): add bech32 topic page

### DIFF
--- a/data/blog/the-libraries-behind-open-communication.mdx
+++ b/data/blog/the-libraries-behind-open-communication.mdx
@@ -653,7 +653,7 @@ place, nostr remains accessible to Ruby developers who want to build
 applications, tooling, or integrations in the language.
 
 [nostr-ruby]: https://github.com/dtonon/nostr-ruby
-[bech32]: https://bitcoinops.org/en/topics/bech32/
+[bech32]: /topics/bech32
 [ruby]: https://www.ruby-lang.org/en/
 [rails]: https://rubyonrails.org/
 [dtonon-grant]: /blog/daniele-receives-lts-grant

--- a/data/topics/bech32.mdx
+++ b/data/topics/bech32.mdx
@@ -1,0 +1,20 @@
+---
+title: 'Bech32'
+summary: 'The checksummed base32 address format used for native SegWit outputs. Version 0 uses bech32 and version 1+ uses bech32m.'
+category: 'Bitcoin'
+aliases:
+  ['Bech32m', 'Bech32(m)', 'bc1', 'bc1q', 'bc1p', 'native SegWit address']
+---
+
+Bech32 is the checksummed base32 format introduced in BIP 173 for native [SegWit](/topics/segwit) addresses. On mainnet those addresses start with `bc1`, which is why people often call them `bc1 addresses`. The format avoids mixed case, uses a character set that works well in QR codes, and includes a checksum that catches almost all common typing errors.
+
+Version 0 witness outputs use the original Bech32 checksum. Those are the `bc1q...` addresses used for P2WPKH and P2WSH. When [Taproot](/topics/taproot) introduced version 1 witness outputs, Bitcoin adopted Bech32m through BIP 350. Those `bc1p...` addresses keep the same structure and character set but use a different checksum constant that fixes a weakness in the original design for future witness versions.
+
+In practice, Bech32 and Bech32m are one address family. Wallets need to decode both, enforce the right encoding for each witness version, and reject mixed-case or malformed strings. The distinction matters because version 0 outputs remain valid only under Bech32, while Taproot and later witness versions require Bech32m.
+
+## References
+
+- [BIP 173: Bech32](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)
+- [BIP 350: Bech32m](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki)
+- [Bitcoin Optech: Bech32(m)](https://bitcoinops.org/en/topics/bech32/)
+- [Bitcoin Wiki: Bech32](https://en.bitcoin.it/wiki/Bech32)

--- a/data/topics/nsec.mdx
+++ b/data/topics/nsec.mdx
@@ -5,7 +5,7 @@ category: 'Nostr'
 aliases: ['nostr private key', 'nostr secret key', 'nsec1']
 ---
 
-`nsec` is the standard human-readable encoding for a Nostr private key. [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) wraps the raw 32-byte secret in a [Bech32](https://en.bitcoin.it/wiki/Bech32) string that starts with the `nsec1` prefix. The matching public identity is usually shared as an `npub` string.
+`nsec` is the standard human-readable encoding for a Nostr private key. [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) wraps the raw 32-byte secret in a [Bech32](/topics/bech32) string that starts with the `nsec1` prefix. The matching public identity is usually shared as an `npub` string.
 
 Whoever has the `nsec` can sign events, publish notes, change profile metadata, authorize client connections, and decrypt content tied to the same keypair. In practice, the `nsec` is the account. Users should keep it in a dedicated signer such as [Amber](/projects/amber), hardware-backed storage, or a [remote-signing](/topics/remote-signing) setup instead of pasting it into every client.
 

--- a/data/topics/segwit.mdx
+++ b/data/topics/segwit.mdx
@@ -11,7 +11,7 @@ The change fixed third-party transaction malleability. In the old format, anyone
 
 SegWit also raised effective block capacity. A block's limit is now 4 million weight units, where each non-witness byte counts as four and each witness byte counts as one. Real blocks sit somewhere between 1 MB (no witness) and 4 MB (all witness), commonly around 2 MB. Transactions that use SegWit inputs pay less per signature because the witness bytes that hold the signature are cheaper to include.
 
-A SegWit transaction commits to its script through a witness program: a short push in an output that carries a version byte and a program. Version 0 programs cover P2WPKH (single-key) and P2WSH (script hash) outputs, and are addressed as bech32 strings beginning with `bc1q`. Some wallets wrap v0 programs inside a P2SH output (`3...` addresses) for compatibility with older software that cannot pay bech32 addresses directly. SegWit also defined a versioned address space for witness programs, which [Taproot](/topics/taproot) later used to deploy as version 1 without reworking the address format.
+A SegWit transaction commits to its script through a witness program: a short push in an output that carries a version byte and a program. Version 0 programs cover P2WPKH (single-key) and P2WSH (script hash) outputs, and are addressed as [bech32](/topics/bech32) strings beginning with `bc1q`. Some wallets wrap v0 programs inside a P2SH output (`3...` addresses) for compatibility with older software that cannot pay bech32 addresses directly. SegWit also defined a versioned address space for witness programs, which [Taproot](/topics/taproot) later used to deploy as version 1 without reworking the address format.
 
 ## References
 


### PR DESCRIPTION
Adds a new `bech32` topic page and updates existing references so `bech32` points to the new internal topic page.

- adds `data/topics/bech32.mdx` with a concise overview of `bech32`, `bech32m`, `bc1q`, and `bc1p`
- links the new topic from the `SegWit` and `nsec` topic pages plus `the-libraries-behind-open-communication`

Closes https://github.com/OpenSats/website/issues/809

---

Build preview:
- [/topics/bech32](https://os-website-git-content-add-bech32-topic-page-809-opensats.vercel.app/topics/bech32)
