### PR TITLE
docs(topics): add Signet topic page

### DIFF
--- a/data/blog/bitcoin-grants-feb-2024.mdx
+++ b/data/blog/bitcoin-grants-feb-2024.mdx
@@ -149,7 +149,7 @@ License: GPL 3.0
 ### Braidpool
 
 Braidpool is a decentralized bitcoin mining pool. Braidpool aims to ship an
-implementation working on signet with hashrate donated by interested miners. The
+implementation working on [Signet](/topics/signet) with hashrate donated by interested miners. The
 project will also publish their specifications and engage the mining community
 for wider adoption of Braidpool.
 

--- a/data/blog/fourteenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/fourteenth-wave-of-bitcoin-grants.mdx
@@ -135,7 +135,7 @@ License: MIT
 [alt-signetfaucet]: https://signet257.bublina.eu.org/about.html
 [posix]: https://standards.ieee.org/ieee/1003.1/7700/
 [mempool-explorer]: https://mempool.space/signet
-[signet]: https://bitcoinops.org/en/topics/signet/
+[signet]: /topics/signet
 [faucet-repo]: https://github.com/jsarenik/bitcoin-faucet-shell
 
 ### Lightning Detective

--- a/data/projects/floresta.mdx
+++ b/data/projects/floresta.mdx
@@ -81,7 +81,7 @@ The next big item is
 [SwiftSync](https://delvingbitcoin.org/t/swiftsync-speeding-up-ibd-with-pre-generated-hints/1562).
 It pairs implicit deletion in the Utreexo accumulator with pre-generated hints
 so blocks can be validated out of order without downloading proofs. In one
-test, syncing signet to block 290,000 on a home connection went from 1h 15min
+test, syncing [Signet](/topics/signet) to block 290,000 on a home connection went from 1h 15min
 with plain Utreexo to 6 minutes with witnessless SwiftSync. The
 [Utreexo BIP draft](https://github.com/bitcoin/bips/pull/1923) is under review.
 Other open work includes evaluating [BDK](/projects/bdk) as the watch-only wallet,

--- a/data/topics/signet.mdx
+++ b/data/topics/signet.mdx
@@ -1,0 +1,25 @@
+---
+title: 'Signet'
+summary: 'Bitcoin’s signed test network, defined by BIP 325, for more predictable multi-party testing than testnet.'
+category: 'Bitcoin'
+aliases:
+  [
+    'BIP 325',
+    'default signet',
+    'global signet',
+    'custom signet',
+    'signet test network',
+  ]
+---
+
+Signet is a Bitcoin test network defined by [BIP 325](https://github.com/bitcoin/bips/blob/master/bip-0325.mediawiki). In addition to proof of work, each block must satisfy a challenge chosen for that signet. That extra rule lets operators coordinate block production, planned reorgs, and other test conditions much more predictably than on testnet.
+
+The public default signet is the network most developers mean when they say `signet`. Bitcoin Core supports it directly, and anyone can also launch a custom signet with a different challenge and seed nodes. That makes signet useful for wallet testing, integration testing between independent services, and protocol experiments that need a shared network without the chaos of testnet.
+
+Signet sits between testnet and regtest. Testnet is open and often unstable. Regtest is fully local and easy to control. Signet gives multiple independent parties a shared environment with controlled unreliability, which is why teams use it to rehearse software changes before mainnet.
+
+## References
+
+- [BIP 325: Signet](https://github.com/bitcoin/bips/blob/master/bip-0325.mediawiki)
+- [Bitcoin Optech: Signet](https://bitcoinops.org/en/topics/signet/)
+- [Bitcoin Wiki: Signet](https://en.bitcoin.it/wiki/Signet)


### PR DESCRIPTION
Adds a new `Signet` topic page and links existing signet references to the new internal topic page.

- adds `data/topics/signet.mdx` with a concise overview of `BIP 325`, the default signet, and custom signets
- links the new topic from the `Alt Signetfaucet` grant writeup, the `Braidpool` grants post, and the `Floresta` project page

Closes https://github.com/OpenSats/content/issues/126

---

Build preview:
- [/topics/signet](https://os-website-git-content-add-signet-topic-page-126-opensats.vercel.app/topics/signet)
