### PR TITLE
Add NDK topic page

### DIFF
--- a/data/blog/2023-year-in-review.mdx
+++ b/data/blog/2023-year-in-review.mdx
@@ -276,8 +276,7 @@ We gave out four waves of nostr grants, as announced in
 [December](/blog/nostr-grants-december-2023).
 
 The following nostr projects received support from OpenSats in 2023:
-[NDK](https://github.com/nostr-dev-kit/ndk),
-[Habla](https://github.com/verbiricha/habla.news),
+[NDK](/topics/ndk), [Habla](https://github.com/verbiricha/habla.news),
 [Coracle](https://github.com/coracle-social/coracle),
 [Iris](https://github.com/irislib/iris-messenger),
 [Damus](https://github.com/damus-io/damus),

--- a/data/blog/nostr-grants-december-2023.mdx
+++ b/data/blog/nostr-grants-december-2023.mdx
@@ -81,9 +81,9 @@ rather than dark patterns.
 
 While the client is currently focused on short kind:1 notes, support for
 long-form content and communities is to be added in future versions. Camelus is
-built upon [NDK](https://github.com/nostr-dev-kit/) and the
-[NIP-65](https://github.com/nostr-protocol/nips/blob/master/65.md) gossip model,
-allowing the client to focus on higher-level functionality and features.
+built upon [NDK](/topics/ndk) and the [NIP-65](https://github.com/nostr-protocol/nips/blob/master/65.md)
+gossip model, allowing the client to focus on higher-level functionality and
+features.
 
 Repository: [leo-lox/camelus](https://github.com/leo-lox/camelus)  
 License: GPL-3.0

--- a/data/blog/pablofz7-receives-lts-grant.mdx
+++ b/data/blog/pablofz7-receives-lts-grant.mdx
@@ -13,9 +13,9 @@ LTS grantee.
 
 Pablo is one of the most prolific developers within the Nostr community, with
 notable projects like [nsecBunker](https://github.com/kind-0/nsecbunkerd), [Nostr Development
-Kit (NDK)](https://github.com/nostr-dev-kit/ndk),
-[Shipyard](https://shipyard.pub/), [Highlighter](https://highlighter.com/),
-[Wikifreedia](https://wikifreedia.vercel.app/), and more.
+Kit (NDK)](/topics/ndk), [Shipyard](https://shipyard.pub/),
+[Highlighter](https://highlighter.com/), [Wikifreedia](https://wikifreedia.vercel.app/),
+and more.
 
 Long-Term Support will allow Pablo to continue his journey through the uncharted
 waters of Nostr. He will remain focused on the “other stuff” to ensure that the

--- a/data/blog/the-libraries-behind-open-communication.mdx
+++ b/data/blog/the-libraries-behind-open-communication.mdx
@@ -315,7 +315,7 @@ Together, OpenSats' support for NDK, NDKSwift, and Dart NDK helped extend a
 common development approach across web, Apple, and Flutter/Dart apps, giving
 more nostr builders maintained tools in the environments they already use.
 
-[ndk]: https://github.com/nostr-dev-kit/ndk
+[ndk]: /topics/ndk
 [ndkswift]: https://github.com/pablof7z/NDKSwift
 [dart-ndk]: https://github.com/relaystr/ndk
 [pablof7z-grant]: /blog/pablofz7-receives-lts-grant

--- a/data/topics/ndk.mdx
+++ b/data/topics/ndk.mdx
@@ -1,0 +1,19 @@
+---
+title: 'NDK'
+summary: 'A modular TypeScript toolkit for building Nostr apps, with relay routing, caching, signing flows, and higher-level client features.'
+category: 'Nostr'
+aliases: ['Nostr Development Kit', 'nostr-dev-kit']
+---
+
+NDK usually refers to PabloF7z's Nostr Development Kit, a TypeScript toolkit for building [Nostr](/topics/nostr) apps. It packages the work every client has to do anyway: connect to [relays](/topics/relays), subscribe to and publish events, sign and verify messages, cache data locally, and route traffic with the [outbox model](/topics/outbox).
+
+Instead of shipping one giant framework, NDK is split into packages. The core library handles relay connections and event flows. Companion packages add higher-level tools for [private DMs](/topics/private-dms), [remote signing](/topics/remote-signing), [web of trust](/topics/web-of-trust) filtering, [Nostr Wallet Connect](/topics/nostr-wallet-connect), and [Blossom](/topics/blossom). Framework bindings for React, Svelte, React Native, and other environments let app developers keep the protocol plumbing out of their UI code.
+
+The name also points to a broader family of related libraries. NDKSwift brings the same general approach to Apple platforms, and Dart NDK does similar work for Flutter and Dart apps. On OpenSats, the main [NDK project page](/projects/ndk) tracks the original TypeScript implementation maintained by [PabloF7z](/blog/pablofz7-receives-lts-grant).
+
+NDK matters because it lowers the cost of building serious Nostr software. When relay selection, event parsing, signing adapters, and caching are handled in a shared library, app developers can spend more time on product decisions and less time re-implementing protocol basics.
+
+## References
+
+- [NDK docs](https://nostr-dev-kit.github.io/ndk/)
+- [nostr-dev-kit/ndk](https://github.com/nostr-dev-kit/ndk)


### PR DESCRIPTION
Adds a new `NDK` topic page and links existing NDK references to the new internal topic page.

- adds `data/topics/ndk.mdx` with a concise overview of the TypeScript toolkit, its modular packages, and the broader NDK family
- links the new topic from PabloF7z's LTS post, the 2023 year-in-review grants recap, Camelus in the December grants post, and the NDK section of the libraries impact report

Closes https://github.com/OpenSats/content/issues/108

---

Build preview:
- [/topics/ndk](https://os-website-git-content-add-ndk-topic-page-108-opensats.vercel.app/topics/ndk)
