### PR TITLE
Add SDK topic page

### DIFF
--- a/data/blog/advancements-in-nostr-clients.mdx
+++ b/data/blog/advancements-in-nostr-clients.mdx
@@ -455,9 +455,9 @@ behaves consistently no matter which client their contacts use.
 
 NoStrudel also received a major internal upgrade through the [applesauce v4.x]
 releases, which packages its core components into a shared library for building
-nostr web clients. Maintained by hzrd149, the [applesauce] SDK provides relay
-connections, timelines, signing, contacts, mutes, bookmarks, and NIP-17
-direct-message support, along with newer protocol features such as more
+nostr web clients. Maintained by hzrd149, the [applesauce] [SDK](/topics/sdk)
+provides relay connections, timelines, signing, contacts, mutes, bookmarks, and
+NIP-17 direct-message support, along with newer protocol features such as more
 efficient syncing using [NIP-77] and improved counting with [NIP-45]. Because
 applesauce is a shared library, other developers can reuse it instead of
 rebuilding these parts from scratch, helping new clients ship stable features

--- a/data/blog/fifteenth-wave-of-nostr-grants.mdx
+++ b/data/blog/fifteenth-wave-of-nostr-grants.mdx
@@ -45,10 +45,10 @@ removes the need for domains, [OAuth], and port forwarding. Each service is
 identified by a public key and operates from any device with only an outbound
 internet connection. Nostr handles identity, authentication, discovery, and
 transport. The project grew out of the earlier [DVMCP] effort and now publishes
-a JavaScript/TypeScript software development kit ([SDK]), a [documentation
-site], and reference tooling for [relays] and [gateways]. A recent developer cohort demonstrated the protocol's practical
-utility, with [multiple new projects][SovEng 5 cohort] built directly on top of
-it.
+a JavaScript/TypeScript [software development kit](/topics/sdk) ([SDK]), a
+[documentation site], and reference tooling for [relays] and [gateways]. A
+recent developer cohort demonstrated the protocol's practical utility, with
+[multiple new projects][SovEng 5 cohort] built directly on top of it.
 
 This grant will support core protocol development, expand the SDK, and improve
 the reliability of shared infrastructure such as public relays. The team plans

--- a/data/blog/nostr-grants-july-2023.mdx
+++ b/data/blog/nostr-grants-july-2023.mdx
@@ -216,12 +216,13 @@ License: MIT
 
 ### Nostr SDK iOS
 
-The nostr SDK for iOS is a native Swift library that will enable developers to
-quickly and easily build nostr-based apps for Apple devices. The library plans
-to implement all approved NIPs and will follow Apple's API patterns, so that iOS
-developers feel comfortable using it from the start. The SDK aims to be simple
-in its public interface, abstracting away as much complexity as possible so that
-developers can focus on what makes their specific application unique.
+The nostr [SDK](/topics/sdk) for iOS is a native Swift library that will enable
+developers to quickly and easily build nostr-based apps for Apple devices. The
+library plans to implement all approved NIPs and will follow Apple's API
+patterns, so that iOS developers feel comfortable using it from the start. The
+SDK aims to be simple in its public interface, abstracting away as much
+complexity as possible so that developers can focus on what makes their
+specific application unique.
 
 Repository: [nostr-sdk/nostr-sdk-ios](https://github.com/nostr-sdk/nostr-sdk-ios)  
 License: MIT

--- a/data/blog/twelfth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/twelfth-wave-of-bitcoin-grants.mdx
@@ -98,8 +98,8 @@ License: MIT
 
 ### Swift Bitcoin
 
-[Swift Bitcoin](https://swiftbitcoin.org/) is an open-source software
-development kit (SDK) and network client written entirely in
+[Swift Bitcoin](https://swiftbitcoin.org/) is an open-source [software
+development kit (SDK)](/topics/sdk) and network client written entirely in
 [Swift](https://www.swift.org/documentation/). It offers a full node
 implementation with [PSBT](/topics/psbt) support,
 [miniscript](/topics/miniscript) domain-specific language, and [non-blocking

--- a/data/projects/applesauce.mdx
+++ b/data/projects/applesauce.mdx
@@ -11,7 +11,7 @@ fund: nostr
 announcementLink: '/blog/hzrd149-receives-lts-grant'
 ---
 
-Applesauce is a TypeScript SDK for building [nostr](/topics/nostr) web clients, maintained by [hzrd149][lts]. It started as the cleaned-up internals of [noStrudel](https://nostrudel.ninja/) and has grown into a set of small, independent packages that other client developers can pick and choose from. The packages cover relay connections, timeline management, signing, and the building blocks for common nostr features like contacts, mutes, bookmarks, [NIP-17](https://github.com/nostr-protocol/nips/blob/master/17.md) direct messages, [NIP-60](https://github.com/nostr-protocol/nips/blob/master/60.md) cashu wallets, and more.
+Applesauce is a TypeScript [SDK](/topics/sdk) for building [nostr](/topics/nostr) web clients, maintained by [hzrd149][lts]. It started as the cleaned-up internals of [noStrudel](https://nostrudel.ninja/) and has grown into a set of small, independent packages that other client developers can pick and choose from. The packages cover relay connections, timeline management, signing, and the building blocks for common nostr features like contacts, mutes, bookmarks, [NIP-17](https://github.com/nostr-protocol/nips/blob/master/17.md) direct messages, [NIP-60](https://github.com/nostr-protocol/nips/blob/master/60.md) cashu wallets, and more.
 
 > The biggest achievement has been building out the applesauce SDK to be the core of the app. This has allowed me to build and test features in isolation and then integrate them back into the app when I know they are working.
 >

--- a/data/topics/sdk.mdx
+++ b/data/topics/sdk.mdx
@@ -13,9 +13,14 @@ An SDK is related to an API, but the two terms describe different layers. The AP
 
 Good SDKs make ecosystems easier to extend. When maintainers publish solid SDKs, more wallets, clients, services, and experiments can build on the same foundation without starting from zero.
 
+## OpenSats SDK project pages
+
+OpenSats currently has project pages for two SDK-style projects:
+
+- [BDK](/projects/bdk), a Rust toolkit for building Bitcoin wallets
+- [NDK](/projects/ndk), a TypeScript toolkit for building nostr applications
+
 ## References
 
 - [What is an SDK?](https://www.redhat.com/en/topics/cloud-native-apps/what-is-SDK)
 - [Software development kit](https://en.wikipedia.org/wiki/Software_development_kit)
-- [LDK](/topics/ldk)
-- [NDK](/topics/ndk)

--- a/data/topics/sdk.mdx
+++ b/data/topics/sdk.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'SDK'
-summary: 'A software development kit: the libraries, docs, examples, and helper tools that help developers build apps for a platform, protocol, or service.'
+summary: 'A software development kit: the libraries, docs, examples, and tools that help developers build apps for a platform, protocol, or service.'
 category: 'Open Source'
 aliases: ['software development kit', 'software development kits', 'devkit']
 ---

--- a/data/topics/sdk.mdx
+++ b/data/topics/sdk.mdx
@@ -1,0 +1,21 @@
+---
+title: 'SDK'
+summary: 'A software development kit: the libraries, docs, examples, and helper tools that help developers build apps for a platform, protocol, or service.'
+category: 'Open Source'
+aliases: ['software development kit', 'software development kits', 'devkit']
+---
+
+SDK stands for software development kit. It is the package a project ships for developers who want to build on top of a platform, protocol, or service. A typical SDK includes client libraries, type definitions, documentation, examples, and helper code for common tasks such as authentication, networking, storage, or event handling.
+
+The goal is simple: give developers the parts they need so they can build product logic instead of rewriting the same plumbing in every app. In the OpenSats ecosystem, that can mean a wallet SDK that handles signing and node connectivity, a Bitcoin library that exposes reusable protocol code, or a Nostr SDK that manages relays, events, and message formats.
+
+An SDK is related to an API, but the two terms describe different layers. The API is the interface itself. The SDK is the developer package built around that interface, usually including code, docs, and utilities that make the interface easier to use.
+
+Good SDKs make ecosystems easier to extend. When maintainers publish solid SDKs, more wallets, clients, services, and experiments can build on the same foundation without starting from zero.
+
+## References
+
+- [What is an SDK?](https://www.redhat.com/en/topics/cloud-native-apps/what-is-SDK)
+- [Software development kit](https://en.wikipedia.org/wiki/Software_development_kit)
+- [LDK](/topics/ldk)
+- [NDK](/topics/ndk)


### PR DESCRIPTION
Adds a new `SDK` topic page and links existing SDK references to the new internal topic page.

- adds `data/topics/sdk.mdx` with a concise explanation of software development kits and how they differ from APIs
- links the new topic from Applesauce, the Nostr clients impact report, the ContextVM grant post, the Nostr SDK iOS grant writeup, and the Swift Bitcoin grant post

Closes https://github.com/OpenSats/content/issues/109

---

Build preview:
- [/topics/sdk](https://os-website-git-content-add-sdk-topic-page-109-opensats.vercel.app/topics/sdk)
