### PR TITLE
Add Flutter topic page

### DIFF
--- a/data/blog/bitcoin-and-nostr-grants-august-2023.mdx
+++ b/data/blog/bitcoin-and-nostr-grants-august-2023.mdx
@@ -44,8 +44,8 @@ features for managing descriptor-based wallets, syncing wallets to the bitcoin
 blockchain, viewing transaction histories, managing and selecting UTXOs to
 create new transactions, signing, and more. The core BDK components are written
 in Rust, but the team also maintains Kotlin and Swift language bindings for use
-in mobile projects. There are also Python bindings, and React Native and Flutter
-support is being actively developed.
+in mobile projects. There are also Python bindings, and React Native and
+[Flutter](/topics/flutter) support is being actively developed.
 
 Repository: [bitcoindevkit/bdk](https://github.com/bitcoindevkit/bdk)  
 License: Apache 2.0 / MIT

--- a/data/blog/sixteenth-wave-of-nostr-grants.mdx
+++ b/data/blog/sixteenth-wave-of-nostr-grants.mdx
@@ -88,8 +88,8 @@ This project consists of four components: a [protocol
 specification][nostr-mail-protocol] for sending emails between nostr users with
 [Kind 1301][kind-1301] events, using [NIP-59] gift-wrapping for privacy, a [Dart
 SDK][dart-sdk] for developers who want to integrate nostr-based email into their
-own applications, a [Flutter client][flutter-client] for reading and sending
-email across iOS, Android, desktop, and web, and [SMTP bridge
+own applications, a [Flutter](/topics/flutter) [client][flutter-client] for
+reading and sending email across iOS, Android, desktop, and web, and [SMTP bridge
 servers][smtp-bridge] that provide backward compatibility with legacy email
 providers like Gmail and Outlook.
 

--- a/data/blog/thirteenth-wave-of-nostr-grants.mdx
+++ b/data/blog/thirteenth-wave-of-nostr-grants.mdx
@@ -79,8 +79,8 @@ passwords, digital wills, and cryptographic keys. Instead of storing full copies
 in one place, Keydex uses [Shamir’s Secret Sharing] to split a secret into
 pieces and distribute them to friends and family. Recovery happens only when
 enough participants consent to reassemble the secret. The app is built with
-[Flutter] for cross-platform delivery and is currently in the alpha stage of
-development.
+[Flutter](/topics/flutter) for cross-platform delivery and is currently in the
+alpha stage of development.
 
 Support from this grant will advance Keydex from an alpha prototype toward a
 dependable release by improving the secret-sharing and recovery flows, the
@@ -92,7 +92,6 @@ Repository: [mplorentz/keydex]
 License: MIT
 
 [Shamir’s Secret Sharing]: https://web.mit.edu/6.857/OldStuff/Fall03/ref/Shamir-HowToShareASecret.pdf
-[Flutter]: https://flutter.dev/
 [mplorentz/keydex]: https://github.com/mplorentz/keydex
 
 ### Bigbrotr

--- a/data/blog/twelfth-wave-of-nostr-grants.mdx
+++ b/data/blog/twelfth-wave-of-nostr-grants.mdx
@@ -91,11 +91,11 @@ Aegis is a lightweight, cross-platform nostr signer that offers a seamless and
 secure experience across mobile and desktop environments. Initially launched for
 iOS and available through TestFlight, Aegis enables persistent background
 connections, critical for maintaining uninterrupted signing sessions,
-especially on mobile devices. Built using
-[Flutter](https://github.com/flutter/flutter), it supports a variety of
-connection methods and introduces simple nostr key management in a user-friendly
-interface. The project fills a gap in the nostr ecosystem by offering a signer
-that's actively maintained and easy to integrate.
+especially on mobile devices. Built using [Flutter](/topics/flutter), it
+supports a variety of connection methods and introduces simple nostr key
+management in a user-friendly interface. The project fills a gap in the nostr
+ecosystem by offering a signer that's actively maintained and easy to
+integrate.
 
 With support from this grant, Aegis will expand to Android, macOS, Windows, and
 Linux platforms, bringing secure signing to a much broader user base.

--- a/data/projects/mostro.mdx
+++ b/data/projects/mostro.mdx
@@ -40,7 +40,7 @@ trade keys on every order to break linkability across trades, and the node's
 database encrypts private keys and sensitive columns at rest.
 
 Reference implementations include the [Mostro
-node](https://github.com/MostroP2P/mostro), a Flutter
+node](https://github.com/MostroP2P/mostro), a [Flutter](/topics/flutter)
 [mobile app](https://github.com/MostroP2P/mobile), a Ratatui
 terminal UI ([Mostrix](https://github.com/MostroP2P/mostrix)), a
 [CLI](https://github.com/MostroP2P/mostro-cli), and a browser-based

--- a/data/topics/flutter.mdx
+++ b/data/topics/flutter.mdx
@@ -1,0 +1,18 @@
+---
+title: 'Flutter'
+summary: 'An open-source UI toolkit for building iOS, Android, web, desktop, and embedded apps from one Dart codebase.'
+category: 'Open Source'
+aliases: ['Flutter SDK', 'Flutter framework']
+---
+
+Flutter is an open-source UI toolkit for building apps from one codebase. Developers write in Dart and use Flutter's widget and rendering system to target iOS, Android, web, desktop, and embedded devices with largely shared application code.
+
+It is popular with teams that want one cross-platform app layer without maintaining separate native interfaces for each platform. Hot reload, a large widget library, and a strong plugin ecosystem make it practical for rapid iteration, while native bridges still allow access to device features such as cameras, storage, notifications, and networking.
+
+In the OpenSats ecosystem, Flutter shows up most often in mobile-first wallets, signers, and messaging clients. It lets projects reuse the same interface code across phones and desktops while pairing with protocol libraries and backends written in Rust, Swift, Go, or other languages.
+
+## References
+
+- [flutter.dev](https://flutter.dev/)
+- [flutter/flutter](https://github.com/flutter/flutter)
+- [Introduction to declarative UI](https://docs.flutter.dev/flutter-for/declarative)


### PR DESCRIPTION
Adds a new `Flutter` topic page and links existing Flutter references to the new internal topic page.

- adds `data/topics/flutter.mdx` with a concise overview of Flutter as a cross-platform UI toolkit built on Dart
- links the new topic from Aegis, Keydex, Nostr Mail, Mostro, and the BDK August 2023 grants post

Closes https://github.com/OpenSats/content/issues/110

---

Build preview:
- [/topics/flutter](https://os-website-git-content-add-flutter-topic-page-110-opensats.vercel.app/topics/flutter)
