### PR TITLE
Add bitcoin node topic page

### DIFF
--- a/data/blog/bitcoin-grants-december-2023.mdx
+++ b/data/blog/bitcoin-grants-december-2023.mdx
@@ -185,12 +185,13 @@ locks that the current Core GUI is plagued with, all without disturbing the need
 to further modularize the different components of Bitcoin Core.
 
 The effort aims to keep Bitcoin Core accessible to run, and the features that
-full-node software can provide are easy and intuitive to use by non-technical
-people. Additionally, by exploring how Core behaves on mobile devices, we can
-reshape how we think about full-node software and further democratize
-enforcement of the network rules to those with mobile devices. With Core running
-as a background process on phones and tablets, apps and services can be built to
-use the local node instead of relying on remote nodes or a centralized server.
+[full-node software](/topics/bitcoin-node) can provide are easy and intuitive
+to use by non-technical people. Additionally, by exploring how Core behaves on
+mobile devices, we can reshape how we think about full-node software and
+further democratize enforcement of the network rules to those with mobile
+devices. With Core running as a background process on phones and tablets, apps
+and services can be built to use the local node instead of relying on remote
+nodes or a centralized server.
 
 Repository: [bitcoin-core/gui-qml](https://github.com/bitcoin-core/gui-qml)  
 License: MIT

--- a/data/blog/bitcoin-grants-july-2023.mdx
+++ b/data/blog/bitcoin-grants-july-2023.mdx
@@ -94,8 +94,9 @@ License: BSD-MIT
 ### Raspiblitz
 
 Raspiblitz is a do-it-yourself node stack that allows you to run a Lightning
-Node together with a Bitcoin Core full node on your Raspberry Pi. While the
-Raspberry Pi is the most common hardware running this particular software, it
+Node together with a Bitcoin Core [full node](/topics/bitcoin-node) on your
+Raspberry Pi. While the Raspberry Pi is the most common hardware running this
+particular software, it
 was developed to support multiple hardware platforms and can run on bare metal
 servers too.
 

--- a/data/blog/fourteenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/fourteenth-wave-of-bitcoin-grants.mdx
@@ -77,8 +77,9 @@ License: MIT
 
 ### Floresta
 
-Floresta is a modular and lightweight Bitcoin full node written in Rust that
-uses the [Utreexo dynamic accumulator][utreexo], a cryptographic technique that
+Floresta is a modular and lightweight [Bitcoin full node](/topics/bitcoin-node)
+written in Rust that uses the [Utreexo dynamic accumulator][utreexo], a
+cryptographic technique that
 maintains a compact set of unspent coins (the UTXO set). While
 [Floresta][floresta] has previously received OpenSats' support, this is
 contributor [Jaoleal][jaoleal]'s first grant for his work on the project. To

--- a/data/projects/bitcoin-core.mdx
+++ b/data/projects/bitcoin-core.mdx
@@ -13,7 +13,7 @@ fund: general
 announcementLink: '/blog/announcing-lts-grant-program-to-support-bitcoin-core-contributors'
 ---
 
-Bitcoin Core is the reference full node software for Bitcoin. It validates blocks and transactions, enforces consensus rules, and relays data across the peer-to-peer network. Running it is how anyone can verify Bitcoin without trusting a third party.
+Bitcoin Core is the reference [full node](/topics/bitcoin-node) software for Bitcoin. It validates blocks and transactions, enforces consensus rules, and relays data across the peer-to-peer network. Running it is how anyone can verify Bitcoin without trusting a third party.
 
 OpenSats began funding Bitcoin Core contributors in 2023 through its [LTS program][lts-announce]. LTS grantees include Marco Falke, Josie Baker, Sjors Provoost, Vasil Dimov, Gleb Naumenko, Furszy, Will Clark, 0xB10C, Bruno Garcia, Jon Atack, and Andrew Toth. Additional contributors joined through [Caring for Core][caring], [More for Core][more-for-core], and [5 Grants to Strengthen Bitcoin Development][five-grants]: tdb3, David Gumberg, Hodlinator, L0rinc, kevkevinpal, Daniela Brozzoni, janb84, Naiyoma, and Daniel Pfeifer.
 

--- a/data/topics/bitcoin-node.mdx
+++ b/data/topics/bitcoin-node.mdx
@@ -1,0 +1,20 @@
+---
+title: 'Bitcoin node'
+summary: 'Software that connects to the Bitcoin network, validates blocks and transactions, tracks chain state, and helps enforce the protocol rules.'
+category: 'Bitcoin'
+aliases: ['full node', 'full nodes', 'Bitcoin full node', 'Bitcoin node software']
+---
+
+A Bitcoin node is software that speaks Bitcoin's peer-to-peer protocol. It connects to other nodes, downloads blocks and transactions, checks them against the rules, and keeps track of the current chain state.
+
+In practice, people usually mean a **full node**: software that independently verifies every block and transaction instead of trusting a third-party server. Running one is how a user checks Bitcoin's rules for themselves, including the supply limit, script validity, and whether a payment really confirmed.
+
+Nodes can be packaged in different ways. Some are general-purpose implementations like [Bitcoin Core](/projects/bitcoin-core). Some are lightweight or specialized designs such as [Floresta](/projects/floresta). Some are pruned, which means they discard old block data after validation to save disk space. Pruned nodes are still full nodes because they still verify the chain themselves.
+
+Wallets, Lightning apps, block explorers, mining software, and other services often depend on a node for trustworthy chain data and transaction broadcast. Without enough people running their own nodes, more users end up relying on centralized infrastructure to tell them what Bitcoin says.
+
+## References
+
+- [Running a full node](https://bitcoin.org/en/full-node)
+- [Bitcoin Core validation](https://bitcoin.org/en/bitcoin-core/features/validation)
+- [bitcoin/bitcoin](https://github.com/bitcoin/bitcoin)

--- a/data/topics/mempool.mdx
+++ b/data/topics/mempool.mdx
@@ -5,7 +5,7 @@ category: 'Bitcoin'
 aliases: ['memory pool', 'transaction pool', 'tx pool']
 ---
 
-Every Bitcoin full node validates transactions it hears on the network and keeps accepted, non-conflicting ones in its **mempool** until they confirm in a block or expire under local policy. There is no global mempool: each peer maintains its own view based on what it saw, in which order, and which feerate rules it applies. Wallets ask their node (or a service like [mempool.space](https://mempool.space)) for a snapshot of that view when they estimate fees or when they show "pending" activity to a user.
+Every [Bitcoin full node](/topics/bitcoin-node) validates transactions it hears on the network and keeps accepted, non-conflicting ones in its **mempool** until they confirm in a block or expire under local policy. There is no global mempool: each peer maintains its own view based on what it saw, in which order, and which feerate rules it applies. Wallets ask their node (or a service like [mempool.space](https://mempool.space)) for a snapshot of that view when they estimate fees or when they show "pending" activity to a user.
 
 Miners and mining pools pull work from their own mempool (or from a pool template builder) when they assemble candidate blocks. [Stratum V2](/topics/stratum-v2) discussions often assume miners can see enough of the fee market to pick transactions with less blind trust in the pool operator. Policy changes such as package relay and feerate-based eviction adjust how those candidates enter and leave the set without changing consensus rules for confirmed blocks.
 


### PR DESCRIPTION
Adds a new `Bitcoin node` topic page and links existing full-node references to the new internal topic page.

- adds `data/topics/bitcoin-node.mdx` with a concise overview of what a Bitcoin node does, what people mean by a full node, and why running one matters
- links the new topic from the Bitcoin Core project page, the Floresta grant post, the Bitcoin Core App grant writeup, the Raspiblitz grant post, and the `Mempool` topic page

Closes https://github.com/OpenSats/content/issues/115

---

Build preview:
- [/topics/bitcoin-node](https://os-website-git-content-add-bitcoin-node-topic-page-115-opensats.vercel.app/topics/bitcoin-node)
