### PR TITLE
Add eclipse attacks topic page

### DIFF
--- a/data/blog/bitcoin-grants-september-2024-7th-wave.mdx
+++ b/data/blog/bitcoin-grants-september-2024-7th-wave.mdx
@@ -146,8 +146,8 @@ License: MIT
 
 [ASmap](https://asmap.org/) is a project focused on mapping IP address blocks to
 their Autonomous Systems (AS) to enhance Bitcoin Core's defense against [eclipse
-attacks](https://bitcoinops.org/en/topics/eclipse-attacks/) by preventing nodes
-from being overly connected to peers controlled by a single entity. By improving
+attacks](/topics/eclipse-attacks) by preventing nodes from being overly
+connected to peers controlled by a single entity. By improving
 the accuracy and performance of ASmap generation, ASmap helps Bitcoin Core better manage
 peer distribution at the AS level, reducing the risk of network attacks. [Future
 efforts](https://github.com/fjahr/kartograf/issues/11) include optimizing the

--- a/data/blog/bruno-garcia-receives-lts-grant.mdx
+++ b/data/blog/bruno-garcia-receives-lts-grant.mdx
@@ -27,8 +27,8 @@ existing ones.
 He is also the creator of `bitcoinfuzz`, a differential fuzzing tool essential
 for detecting bugs within Bitcoin libraries and implementations, and is
 contributing to [ASMap](https://asmap.org/), a feature designed to fortify the Bitcoin network's
-resilience by encouraging nodes to diversify their connections across various
-Autonomous Systems. Our LTS grant will now help him to work, among other things,
+resilience against [eclipse attacks](/topics/eclipse-attacks) by encouraging
+nodes to diversify their connections across various Autonomous Systems. Our LTS grant will now help him to work, among other things,
 on making `ASMap` default in Bitcoin Core.
 
 Beyond technical contributions, he plays a vital role in mentoring the next

--- a/data/topics/eclipse-attacks.mdx
+++ b/data/topics/eclipse-attacks.mdx
@@ -5,13 +5,13 @@ category: 'Bitcoin'
 aliases: ['eclipse attack', 'network eclipse', 'peer eclipse']
 ---
 
-Eclipse attacks isolate a Bitcoin node from honest peers while keeping it connected to attacker-controlled ones. Once the victim is cut off, the attacker can delay blocks, filter transactions, and shape what the node learns about the network.
+Eclipse attacks isolate a [Bitcoin node](/topics/bitcoin-node) from honest peers while keeping it connected to attacker-controlled ones. Once the victim is cut off, the attacker can delay blocks, filter transactions, and shape what the node learns about the network.
 
 That creates several risks. A merchant or service can be shown stale chain state for longer than expected. A wallet or Lightning node can miss time-sensitive events. The attacker can also learn which transactions came from the victim, which weakens privacy.
 
 The key weakness is connectivity. The eclipsed node still checks Bitcoin's rules, yet it does so against a filtered view of the network. That is why peer diversity matters so much for [Bitcoin Core](/projects/bitcoin-core) and other node implementations.
 
-Mitigations focus on making peer selection harder to monopolize. [ASmap](https://asmap.org/) helps Bitcoin Core avoid concentrating too many peers inside a single autonomous system, and [Erlay](/topics/erlay) makes it cheaper for honest nodes to keep more connections. Operators can also reduce risk by using diverse network paths and maintaining trusted connections where appropriate.
+Mitigations focus on making peer selection harder to monopolize. [ASmap](/projects/asmap) helps Bitcoin Core avoid concentrating too many peers inside a single autonomous system, and [Erlay](/topics/erlay) makes it cheaper for honest nodes to keep more connections. Operators can also reduce risk by using diverse network paths and maintaining trusted connections where appropriate.
 
 ## References
 

--- a/data/topics/eclipse-attacks.mdx
+++ b/data/topics/eclipse-attacks.mdx
@@ -1,0 +1,20 @@
+---
+title: 'Eclipse attacks'
+summary: 'Attacks that isolate a Bitcoin node behind malicious peers, letting the attacker control the node’s view of blocks and transactions.'
+category: 'Bitcoin'
+aliases: ['eclipse attack', 'network eclipse', 'peer eclipse']
+---
+
+Eclipse attacks isolate a Bitcoin node from honest peers while keeping it connected to attacker-controlled ones. Once the victim is cut off, the attacker can delay blocks, filter transactions, and shape what the node learns about the network.
+
+That creates several risks. A merchant or service can be shown stale chain state for longer than expected. A wallet or Lightning node can miss time-sensitive events. The attacker can also learn which transactions came from the victim, which weakens privacy.
+
+The key weakness is connectivity. The eclipsed node still checks Bitcoin's rules, yet it does so against a filtered view of the network. That is why peer diversity matters so much for [Bitcoin Core](/projects/bitcoin-core) and other node implementations.
+
+Mitigations focus on making peer selection harder to monopolize. [ASmap](https://asmap.org/) helps Bitcoin Core avoid concentrating too many peers inside a single autonomous system, and [Erlay](/topics/erlay) makes it cheaper for honest nodes to keep more connections. Operators can also reduce risk by using diverse network paths and maintaining trusted connections where appropriate.
+
+## References
+
+- [Bitcoin Optech: Eclipse attacks](https://bitcoinops.org/en/topics/eclipse-attacks/)
+- [ASmap.org](https://asmap.org/)
+- [Bitcoin Developer Guide: P2P Network](https://developer.bitcoin.org/devguide/p2p_network.html)

--- a/data/topics/erlay.mdx
+++ b/data/topics/erlay.mdx
@@ -9,7 +9,7 @@ Erlay is a transaction relay protocol for Bitcoin full nodes that replaces flood
 
 Erlay breaks the relay into two stages. Nodes still flood transactions to a small number of outbound peers. For the rest of the network, they exchange short sketches of their mempools and reconcile the difference using the [minisketch](https://github.com/bitcoin-core/minisketch) library. Two nodes that already share most transactions exchange only a few kilobytes to agree on the few they do not share.
 
-The practical result is that a well-connected node can keep many more peers without a big jump in bandwidth. That in turn makes the network more resistant to eclipse attacks. Erlay is specified in BIP 330, with implementation work in Bitcoin Core tracked across several pull requests.
+The practical result is that a well-connected node can keep many more peers without a big jump in bandwidth. That in turn makes the network more resistant to [eclipse attacks](/topics/eclipse-attacks). Erlay is specified in BIP 330, with implementation work in Bitcoin Core tracked across several pull requests.
 
 Whether Erlay is worth shipping is still an open question. As of early 2026, Bitcoin Core developers are re-evaluating its trade-offs and goals in [bitcoin/bitcoin#34542](https://github.com/bitcoin/bitcoin/issues/34542), so the design described here may yet change or be dropped.
 


### PR DESCRIPTION
Adds a new `Eclipse attacks` topic page and links existing references to the new internal topic page.

- adds `data/topics/eclipse-attacks.mdx` with a concise overview of how eclipse attacks isolate a node and why that matters for stale chain state, privacy, and Lightning safety
- links the new topic from the ASmap grant post, Bruno Garcia's LTS grant post, and the `Erlay` topic page

Closes https://github.com/OpenSats/content/issues/123

---

Build preview:
- [/topics/eclipse-attacks](https://os-website-git-content-add-eclipse-attacks-topi-7182a0-opensats.vercel.app/topics/eclipse-attacks)
