### PR TITLE
Add vaults topic page

### DIFF
--- a/data/blog/fifteenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/fifteenth-wave-of-bitcoin-grants.mdx
@@ -254,7 +254,7 @@ Licenses: CC0-1.0, CC BY 4.0, MIT
 [LNhance soft fork]: https://lnhance.org/
 [Eltoo]: /topics/eltoo
 [hArk]: https://delvingbitcoin.org/t/evolving-the-ark-protocol-using-ctv-and-csfs/1602#p-4785-hark-hash-lock-ark-10
-[vaults]: https://bitcoinops.org/en/topics/vaults/
+[vaults]: /topics/vaults
 [CTV]: /topics/op-ctv
 [CSFS]: https://bitcoinops.org/en/topics/op_checksigfromstack/
 [LDK]: https://github.com/lightningdevkit

--- a/data/blog/sixteenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/sixteenth-wave-of-bitcoin-grants.mdx
@@ -93,8 +93,7 @@ Thousands of public repositories depend on BitcoinerLAB, including Ledger APIs,
 Bitcoin Keeper, LN Markets, and RewindBitcoin.
 
 [RewindBitcoin] is another project by Landabaso. It is a self-custody mobile
-wallet for iOS and Android that applies vault-style spending controls. It uses
-timelocks, pre-signed transactions, and an emergency spending path to protect
+wallet for iOS and Android that applies [vault-style spending controls](/topics/vaults). It uses timelocks, pre-signed transactions, and an emergency spending path to protect
 funds in situations of theft or coercion.
 
 This grant will support BitcoinerLAB and RewindBitcoin. For BitcoinerLAB, work

--- a/data/projects/bdk.mdx
+++ b/data/projects/bdk.mdx
@@ -19,8 +19,9 @@ it so they don't have to rewrite this low-level Bitcoin logic for every new
 wallet project.
 
 The library uses output descriptors and miniscript to express spending
-conditions. Complex setups like multisig or time-locked vaults work without
-writing custom Bitcoin scripts. Developers choose their own blockchain backend
+conditions. Complex setups like multisig or time-locked [vaults](/topics/vaults)
+work without writing custom Bitcoin scripts. Developers choose their own
+blockchain backend
 (a local full node, Electrum, Esplora, or compact block filters), their own
 database, and their own signing setup. Through [`bdk-ffi`](https://github.com/bitcoindevkit/bdk-ffi), the same Rust core
 is available in Swift, Kotlin, and Python, running on iOS, Android, and desktop.

--- a/data/topics/op-ctv.mdx
+++ b/data/topics/op-ctv.mdx
@@ -7,7 +7,7 @@ aliases: ['CHECKTEMPLATEVERIFY', 'CTV', 'BIP 119']
 
 OP_CTV (CheckTemplateVerify) is a proposed opcode described in BIP 119. It lets an output commit to a hash of one specific future transaction. The coins can only be spent by a transaction that matches that hash.
 
-This is a minimal form of [covenant](/topics/covenant). Useful applications include congestion-controlled payment batching, vaults, non-interactive payment channels, and shared UTXO constructions such as payment pools.
+This is a minimal form of [covenant](/topics/covenant). Useful applications include congestion-controlled payment batching, [vaults](/topics/vaults), non-interactive payment channels, and shared UTXO constructions such as payment pools.
 
 Further reading: the [utxos.org](https://utxos.org/) landing page, the reference implementation in [bitcoin-inquisition](https://github.com/bitcoin-inquisition/bitcoin), and the BIP itself.
 

--- a/data/topics/vaults.mdx
+++ b/data/topics/vaults.mdx
@@ -9,11 +9,11 @@ Vaults are Bitcoin custody constructions that separate a withdrawal into stages.
 
 The goal is simple: turn key compromise from an instant loss into a security incident with response time. Different vault designs offer different delays, recovery paths, and assumptions about how many keys, devices, or pre-signed transactions must stay safe.
 
-Some vaults can be built today with timelocks, pre-signed transactions, and careful key management. Proposed covenants could make them simpler and more flexible. [OP_CTV](/topics/op-ctv) can express predefined vault trees, and BIP 345 proposes `OP_VAULT` and `OP_VAULT_RECOVER` as opcodes tailored to this use case.
+Some vaults can be built today with timelocks, pre-signed transactions, and careful key management. Proposed [covenants](/topics/covenant) could make them simpler and more flexible. [OP_CTV](/topics/op-ctv) can express predefined vault trees, and BIP 345 proposes `OP_VAULT` and `OP_VAULT_RECOVER` as opcodes tailored to this use case.
 
 Vaults matter for self-custody, inheritance planning, institutional storage, and coercion resistance. They also introduce tradeoffs in setup complexity, recovery procedures, and how tightly future spending paths are constrained.
 
 ## References
 
 - [Bitcoin Optech: Vaults](https://bitcoinops.org/en/topics/vaults/)
-- [BIP 345: `OP_VAULT`](https://en.bitcoin.it/wiki/BIP_0345)
+- [BIP 345: `OP_VAULT`](https://github.com/bitcoin/bips/blob/master/bip-0345.mediawiki)

--- a/data/topics/vaults.mdx
+++ b/data/topics/vaults.mdx
@@ -1,0 +1,19 @@
+---
+title: 'Vaults'
+summary: 'Bitcoin custody constructions that delay withdrawals and preserve a recovery path if a key is stolen or a spend is coerced.'
+category: 'Bitcoin'
+aliases: ['vault', 'bitcoin vault', 'OP_VAULT', 'BIP 345']
+---
+
+Vaults are Bitcoin custody constructions that separate a withdrawal into stages. A first transaction starts the withdrawal and enforces a delay. During that delay, the owner can trigger a recovery path and move the coins to safety if a key was stolen or a spend was coerced.
+
+The goal is simple: turn key compromise from an instant loss into a security incident with response time. Different vault designs offer different delays, recovery paths, and assumptions about how many keys, devices, or pre-signed transactions must stay safe.
+
+Some vaults can be built today with timelocks, pre-signed transactions, and careful key management. Proposed covenants could make them simpler and more flexible. [OP_CTV](/topics/op-ctv) can express predefined vault trees, and BIP 345 proposes `OP_VAULT` and `OP_VAULT_RECOVER` as opcodes tailored to this use case.
+
+Vaults matter for self-custody, inheritance planning, institutional storage, and coercion resistance. They also introduce tradeoffs in setup complexity, recovery procedures, and how tightly future spending paths are constrained.
+
+## References
+
+- [Bitcoin Optech: Vaults](https://bitcoinops.org/en/topics/vaults/)
+- [BIP 345: `OP_VAULT`](https://en.bitcoin.it/wiki/BIP_0345)


### PR DESCRIPTION
Adds a new `Vaults` topic page and links existing vault references to the new internal topic page.

- adds `data/topics/vaults.mdx` with a concise overview of staged withdrawals, recovery paths, and the tradeoffs behind vault designs
- links the new topic from the `OP_CTV` topic page, the BDK project page, the RewindBitcoin grant writeup, and the LNHANCE grant post

Closes https://github.com/OpenSats/content/issues/124

---

Build preview:
- [/topics/vaults](https://os-website-git-content-add-vaults-topic-page-124-opensats.vercel.app/topics/vaults)
