### PR TITLE
Add op-csfs topic page

### DIFF
--- a/data/blog/fifteenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/fifteenth-wave-of-bitcoin-grants.mdx
@@ -256,7 +256,7 @@ Licenses: CC0-1.0, CC BY 4.0, MIT
 [hArk]: https://delvingbitcoin.org/t/evolving-the-ark-protocol-using-ctv-and-csfs/1602#p-4785-hark-hash-lock-ark-10
 [vaults]: https://bitcoinops.org/en/topics/vaults/
 [CTV]: /topics/op-ctv
-[CSFS]: https://bitcoinops.org/en/topics/op_checksigfromstack/
+[CSFS]: /topics/op-csfs
 [LDK]: https://github.com/lightningdevkit
 [Ark-like protocols]: /topics/ark
 [bark]: https://docs.rs/bark-wallet/latest/bark/

--- a/data/topics/op-csfs.mdx
+++ b/data/topics/op-csfs.mdx
@@ -1,0 +1,17 @@
+---
+title: 'OP_CSFS'
+summary: 'A proposed opcode that checks a signature against an arbitrary message supplied by script, instead of only the spending transaction.'
+category: 'Bitcoin'
+aliases: ['OP_CHECKSIGFROMSTACK', 'CSFS', 'CHECKSIGFROMSTACK']
+---
+
+OP_CSFS, short for `OP_CHECKSIGFROMSTACK`, is a proposed opcode that verifies a signature against a message and public key placed on the script stack. Bitcoin's existing signature opcodes derive the signed message from the transaction being spent. OP_CSFS would make it possible to verify signatures over other precommitted data instead.
+
+That extra flexibility matters for more expressive contract designs. Protocol designers often discuss OP_CSFS alongside [OP_CTV](/topics/op-ctv), because the two together can help encode staged spending rules, delegated recovery flows, and other covenant-like constructions such as [vaults](/topics/vaults).
+
+OP_CSFS already exists on Elements-based sidechains, where it is used as an experimental opcode. On Bitcoin, it remains a proposal rather than a deployed consensus rule.
+
+## References
+
+- [Bitcoin Optech: `OP_CHECKSIGFROMSTACK`](https://bitcoinops.org/en/topics/op_checksigfromstack/)
+- [Elements: Additional opcodes](https://elementsproject.org/features/opcodes)

--- a/data/topics/op-csfs.mdx
+++ b/data/topics/op-csfs.mdx
@@ -7,7 +7,7 @@ aliases: ['OP_CHECKSIGFROMSTACK', 'CSFS', 'CHECKSIGFROMSTACK']
 
 OP_CSFS, short for `OP_CHECKSIGFROMSTACK`, is a proposed opcode that verifies a signature against a message and public key placed on the script stack. Bitcoin's existing signature opcodes derive the signed message from the transaction being spent. OP_CSFS would make it possible to verify signatures over other precommitted data instead.
 
-That extra flexibility matters for more expressive contract designs. Protocol designers often discuss OP_CSFS alongside [OP_CTV](/topics/op-ctv), because the two together can help encode staged spending rules, delegated recovery flows, and other covenant-like constructions such as [vaults](/topics/vaults).
+That extra flexibility matters for more expressive contract designs. Protocol designers often discuss OP_CSFS alongside [OP_CTV](/topics/op-ctv), because the two together can help encode staged spending rules, delegated recovery flows, and other [covenant](/topics/covenant)-like constructions such as [vaults](/topics/vaults).
 
 OP_CSFS already exists on Elements-based sidechains, where it is used as an experimental opcode. On Bitcoin, it remains a proposal rather than a deployed consensus rule.
 


### PR DESCRIPTION
Adds a new `OP_CSFS` topic page and links the existing CSFS reference to the new internal topic page.

- adds `data/topics/op-csfs.mdx` with a concise overview of `OP_CHECKSIGFROMSTACK`, how it differs from Bitcoin's current signature opcodes, and why it is discussed alongside `OP_CTV`
- links the new topic from the LNHANCE grant post where `CSFS` already appears in the discussion of vaults, Ark-like protocols, and Eltoo designs

Closes https://github.com/OpenSats/content/issues/125

---

Build preview:
- [/topics/op-csfs](https://os-website-git-content-add-op-csfs-topic-page-125-opensats.vercel.app/topics/op-csfs)
