### PR TITLE
Add package relay topic page

### DIFF
--- a/data/blog/bitcoin-infrastructure-this-decade.mdx
+++ b/data/blog/bitcoin-infrastructure-this-decade.mdx
@@ -17,7 +17,7 @@ It's important that the tech we build supports Bitcoin's core values: self-sover
 Given these goals, what does a Bitcoin infrastructure look like a decade from now?
 
 - **Mining:** Transaction selection and block construction are more distributed, returning true value to the mempool as a necessary gossip protocol for the network.
-- **Mempool:** Improvements to the mempool (clusters, package relay, ephemeral anchors) help Bitcoin scale through more robust and miner-compatible open infrastructure, providing every Bitcoin node with reasonable access to competitive information and rate-setting in the global fee market.
+- **Mempool:** Improvements to the mempool (clusters, [package relay](/topics/package-relay), ephemeral anchors) help Bitcoin scale through more robust and miner-compatible open infrastructure, providing every Bitcoin node with reasonable access to competitive information and rate-setting in the global fee market.
 - **Layer 2:** A robust and interoperable set of options for "second layer" transaction ledgers, which offer bitcoiners the opportunity to stack and transact at different scales and timeline tradeoffs.
 - **Self-custody:** Accessible and understandable self-custodial tools and education, particularly opportunities for increasing the availability of self-custodianship of bitcoin in layer-2s.
 - **Privacy:** Ongoing research into new protocols that improve Bitcoin privacy at the base layer, such as increasing the surface area for multi-party input transactions (Splicing, Payjoin) and network protocols, which increase anonymity and reduce traceability across the public ledger.

--- a/data/topics/mempool.mdx
+++ b/data/topics/mempool.mdx
@@ -7,7 +7,7 @@ aliases: ['memory pool', 'transaction pool', 'tx pool']
 
 Every Bitcoin full node validates transactions it hears on the network and keeps accepted, non-conflicting ones in its **mempool** until they confirm in a block or expire under local policy. There is no global mempool: each peer maintains its own view based on what it saw, in which order, and which feerate rules it applies. Wallets ask their node (or a service like [mempool.space](https://mempool.space)) for a snapshot of that view when they estimate fees or when they show "pending" activity to a user.
 
-Miners and mining pools pull work from their own mempool (or from a pool template builder) when they assemble candidate blocks. [Stratum V2](/topics/stratum-v2) discussions often assume miners can see enough of the fee market to pick transactions with less blind trust in the pool operator. Policy changes such as package relay and feerate-based eviction adjust how those candidates enter and leave the set without changing consensus rules for confirmed blocks.
+Miners and mining pools pull work from their own mempool (or from a pool template builder) when they assemble candidate blocks. [Stratum V2](/topics/stratum-v2) discussions often assume miners can see enough of the fee market to pick transactions with less blind trust in the pool operator. Policy changes such as [package relay](/topics/package-relay) and feerate-based eviction adjust how those candidates enter and leave the set without changing consensus rules for confirmed blocks.
 
 The mempool is where soft congestion shows up first: when demand for block space spikes, the same mempool data is what drives rising feerates for the next confirmations.
 

--- a/data/topics/package-relay.mdx
+++ b/data/topics/package-relay.mdx
@@ -1,0 +1,19 @@
+---
+title: 'Package relay'
+summary: 'A proposed relay policy that lets Bitcoin nodes evaluate related transactions together instead of one by one.'
+category: 'Bitcoin'
+aliases: ['BIP 331', 'Ancestor Package Relay', 'transaction package relay']
+---
+
+Package relay is a proposed Bitcoin relay feature that lets nodes accept or reject a group of related transactions as one package. Instead of looking at each transaction in isolation, the node evaluates the combined feerate and relationships across the whole set.
+
+This matters because some useful fee-bumping patterns depend on a low-fee parent and a higher-fee child. Without package relay, a node may reject the parent before it ever considers the child, which breaks CPFP in cases where the parent fee is too low for current mempool conditions.
+
+That limitation matters most for time-sensitive protocols. Lightning channels, [vaults](/topics/vaults), and other contract systems may need to attach fees after the fact in order to confirm before a timeout. Package relay aims to make those fee-bumping strategies more reliable without weakening denial-of-service protections on the peer-to-peer network.
+
+BIP 331 specifies ancestor package relay for Bitcoin's peer services layer. As of mid-2026, the proposal remains under active design and implementation review.
+
+## References
+
+- [Bitcoin Optech: Package relay](https://bitcoinops.org/en/topics/package-relay/)
+- [BIP 331: Ancestor Package Relay](https://github.com/bitcoin/bips/blob/master/bip-0331.mediawiki)

--- a/data/topics/package-relay.mdx
+++ b/data/topics/package-relay.mdx
@@ -7,7 +7,7 @@ aliases: ['BIP 331', 'Ancestor Package Relay', 'transaction package relay']
 
 Package relay is a proposed Bitcoin relay feature that lets nodes accept or reject a group of related transactions as one package. Instead of looking at each transaction in isolation, the node evaluates the combined feerate and relationships across the whole set.
 
-This matters because some useful fee-bumping patterns depend on a low-fee parent and a higher-fee child. Without package relay, a node may reject the parent before it ever considers the child, which breaks CPFP in cases where the parent fee is too low for current mempool conditions.
+This matters because some useful fee-bumping patterns depend on a low-fee parent and a higher-fee child. Without package relay, a node may reject the parent before it ever considers the child, which breaks Child Pays for Parent (CPFP) in cases where the parent fee is too low for current [mempool](/topics/mempool) conditions.
 
 That limitation matters most for time-sensitive protocols. Lightning channels, [vaults](/topics/vaults), and other contract systems may need to attach fees after the fact in order to confirm before a timeout. Package relay aims to make those fee-bumping strategies more reliable without weakening denial-of-service protections on the peer-to-peer network.
 


### PR DESCRIPTION
Adds a new `Package relay` topic page and links existing references to the new internal topic page.

- adds `data/topics/package-relay.mdx` with a concise overview of package-level relay, CPFP reliability, and why the proposal matters for time-sensitive contract systems
- links the new topic from the `Mempool` topic page and the `Bitcoin infrastructure this decade` essay

Closes https://github.com/OpenSats/content/issues/127

---

Build preview:
- [/topics/package-relay](https://os-website-git-content-add-package-relay-topic-27f61a-opensats.vercel.app/topics/package-relay)
