### PR TITLE
Add testnet topic page

### DIFF
--- a/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
@@ -110,7 +110,7 @@ License: MIT
 [rawBit]: https://rawbit.io/
 [SegWit]: /topics/segwit
 [Taproot]: /topics/taproot
-[testnet]: https://bitcoinops.org/en/topics/testnet/
+[testnet]: /topics/testnet
 [HTLC]: /topics/htlc
 [CoinJoin]: /topics/coinjoin
 [PSBT]: /topics/psbt

--- a/data/blog/twelfth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/twelfth-wave-of-bitcoin-grants.mdx
@@ -109,7 +109,7 @@ matches Bitcoin Core on regtest. It delivers modular libraries for crypto, base
 protocol, wallet, blockchain, transport, and RPC use.
 
 Support from this grant will fund
-[testnet4](https://bitcoinops.org/en/topics/testnet/) syncing and completion of
+[testnet4](/topics/testnet) syncing and completion of
 the wire protocol. Development will focus on peer-to-peer messaging, protocol
 alignment with Bitcoin Core, and expanded network testing. The project will also
 refine core modules, increase cross-platform stability, and move closer to a

--- a/data/projects/bdk.mdx
+++ b/data/projects/bdk.mdx
@@ -66,7 +66,7 @@ September 2024.
 ## What's next?
 
 Recent releases have added Tor connectivity, a compact block filter light
-client ([Kyoto](https://github.com/rustaceanrob/kyoto)), Testnet4 support, and
+client ([Kyoto](https://github.com/rustaceanrob/kyoto)), [Testnet4](/topics/testnet) support, and
 a dedicated [Silent Payments](https://github.com/bitcoindevkit/bdk-sp) experimental crate
 (BIP352). An experimental
 [`bdk-tx`](https://github.com/bitcoindevkit/bdk-tx) project is decoupling

--- a/data/topics/testnet.mdx
+++ b/data/topics/testnet.mdx
@@ -1,0 +1,19 @@
+---
+title: 'Testnet'
+summary: 'Bitcoin’s public test network, where developers can broadcast valueless coins and exercise software against shared network conditions.'
+category: 'Bitcoin'
+aliases: ['testnet3', 'testnet4', 'Bitcoin testnet']
+---
+
+Testnet is Bitcoin’s public testing network. It uses separate coins with no intended monetary value, so developers can test wallets, nodes, transaction flows, and protocol changes without risking mainnet funds.
+
+Because testnet is public, anyone can join it, mine blocks, and broadcast transactions. That makes it useful for interoperability testing between independent teams and for demos that need a shared network instead of a local sandbox.
+
+The tradeoff is reliability. Testnet has historically suffered from spam, unstable block production, and resets between generations. That is one reason many teams now use [Signet](/topics/signet) for coordinated multi-party testing when they need a more predictable environment.
+
+As of mid-2026, the active public network is Testnet4. Earlier generations were reset after long periods of instability or abuse.
+
+## References
+
+- [Bitcoin Wiki: Testnet](https://en.bitcoin.it/wiki/Testnet)
+- [Bitcoin Optech: Testnet](https://bitcoinops.org/en/topics/testnet/)

--- a/data/topics/testnet.mdx
+++ b/data/topics/testnet.mdx
@@ -11,9 +11,10 @@ Because testnet is public, anyone can join it, mine blocks, and broadcast transa
 
 The tradeoff is reliability. Testnet has historically suffered from spam, unstable block production, and resets between generations. That is one reason many teams now use [Signet](/topics/signet) for coordinated multi-party testing when they need a more predictable environment.
 
-As of mid-2026, the active public network is Testnet4. Earlier generations were reset after long periods of instability or abuse.
+As of mid-2026, the active public network is Testnet4, as defined by BIP 94. Earlier generations were reset after long periods of instability or abuse.
 
 ## References
 
 - [Bitcoin Wiki: Testnet](https://en.bitcoin.it/wiki/Testnet)
 - [Bitcoin Optech: Testnet](https://bitcoinops.org/en/topics/testnet/)
+- [BIP 94: Testnet 4](https://github.com/bitcoin/bips/blob/master/bip-0094.mediawiki)


### PR DESCRIPTION
Adds a new `Testnet` topic page and links existing testnet references to the new internal topic page.

- adds `data/topics/testnet.mdx` with a concise overview of the public Bitcoin test network, its tradeoffs, and why teams often compare it with `Signet`
- links the new topic from the rawBit grant post, the Swift Bitcoin grant post, and the BDK project page

Closes https://github.com/OpenSats/content/issues/128

---

Build preview:
- [/topics/testnet](https://os-website-git-content-add-testnet-topic-page-128-opensats.vercel.app/topics/testnet)
