### PR TITLE
Add covenants topic page

### DIFF
--- a/data/blog/advancements-in-developer-libraries.mdx
+++ b/data/blog/advancements-in-developer-libraries.mdx
@@ -243,7 +243,7 @@ check transaction costs accurately.
 Rustaceanrob also added
 [`Transaction Version 3`](https://github.com/rust-bitcoin/rust-bitcoin/commit/9e6b8faf847662cf741bc166a690d63a9328c7e3)
 ([`BIP 431`](https://github.com/bitcoin/bips/blob/master/bip-0431.mediawiki))
-support to Rust‑Bitcoin, preparing the library for covenant‑style spending rules
+support to Rust‑Bitcoin, preparing the library for [covenant-style spending rules](/topics/covenants)
 while preserving full compatibility with existing transactions. Together with
 his other policy fixes, this keeps Rust‑Bitcoin aligned with Bitcoin Core and
 lets developers build applications that stay reliable as the protocol evolves.

--- a/data/blog/bitcoin-grants-september-2024-7th-wave.mdx
+++ b/data/blog/bitcoin-grants-september-2024-7th-wave.mdx
@@ -98,7 +98,7 @@ directly. By providing libraries for wallet operations, DLC communication, data
 storage, and integration of oracles, `dlcdevkit` enables seamless application
 development. Future work includes launching a platform-agnostic DLC marketplace,
 implementing WASM and mobile bindings for broader accessibility, and integrating
-covenant support to improve the efficiency of DLCs. These enhancements aim to
+[covenant](/topics/covenants) support to improve the efficiency of DLCs. These enhancements aim to
 foster a more cohesive and interoperable DLC ecosystem, driving broader adoption
 and enabling developers to build innovative Bitcoin applications with minimal
 friction.

--- a/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
@@ -114,7 +114,7 @@ License: MIT
 [HTLC]: /topics/htlc
 [CoinJoin]: /topics/coinjoin
 [PSBT]: /topics/psbt
-[covenant]: /topics/covenant
+[covenant]: /topics/covenants
 [rawBit-io/rawbit]: https://github.com/rawBit-io/rawbit
 
 ### Specter DIY

--- a/data/topics/covenants.mdx
+++ b/data/topics/covenants.mdx
@@ -1,0 +1,17 @@
+---
+title: 'Covenants'
+summary: 'A family of Bitcoin proposals that constrain how coins may be spent in future transactions.'
+category: 'Bitcoin'
+aliases: ['covenant', 'covenant support', 'covenant proposals']
+---
+
+In Bitcoin, a covenant is a spending rule that restricts what a transaction may do with coins after they are unlocked. Instead of only checking who may spend an output, a covenant also constrains where that output may be sent or what shape the spending transaction must follow.
+
+The term describes a family of proposals, not one single upgrade. Different covenant designs trade off expressiveness, reviewability, and implementation complexity. One narrow example is [OP_CTV](/topics/op-ctv), which commits coins to one precomputed future transaction template.
+
+People care about covenants because they could enable stronger vault designs, congestion-controlled batching, payment pools, and other constructions that need tighter control over future spending paths. Skeptics focus on the cost of added complexity and on whether any given proposal is the right tool for Bitcoin's long-term design.
+
+## References
+
+- [Bitcoin Optech: Covenants](https://bitcoinops.org/en/topics/covenants/)
+- [Bitcoin Wiki: Covenants support](https://en.bitcoin.it/wiki/Covenants_support)

--- a/data/topics/op-ctv.mdx
+++ b/data/topics/op-ctv.mdx
@@ -7,7 +7,7 @@ aliases: ['CHECKTEMPLATEVERIFY', 'CTV', 'BIP 119']
 
 OP_CTV (CheckTemplateVerify) is a proposed opcode described in BIP 119. It lets an output commit to a hash of one specific future transaction. The coins can only be spent by a transaction that matches that hash.
 
-This is a minimal form of [covenant](/topics/covenant). Useful applications include congestion-controlled payment batching, vaults, non-interactive payment channels, and shared UTXO constructions such as payment pools.
+This is a minimal form of [covenant](/topics/covenants). Useful applications include congestion-controlled payment batching, vaults, non-interactive payment channels, and shared UTXO constructions such as payment pools.
 
 Further reading: the [utxos.org](https://utxos.org/) landing page, the reference implementation in [bitcoin-inquisition](https://github.com/bitcoin-inquisition/bitcoin), and the BIP itself.
 


### PR DESCRIPTION
Adds a new `Covenants` topic page and links a few existing covenant references to the new internal topic page.

- adds `data/topics/covenants.mdx` with a concise overview of covenant proposals and a pointer to `OP_CTV` as one narrow example
- links the new topic from the rawBit grant post, the `dlcdevkit` grant post, the Rust-Bitcoin report, and the existing `OP_CTV` topic page

Closes https://github.com/OpenSats/content/issues/129

---

Build preview:
- [/topics/covenants](https://os-website-git-content-add-covenants-topic-page-129-opensats.vercel.app/topics/covenants)
