### PR TITLE
Expand SDK topic project examples

### DIFF
--- a/data/topics/sdk.mdx
+++ b/data/topics/sdk.mdx
@@ -13,12 +13,17 @@ An SDK is related to an API, but the two terms describe different layers. The AP
 
 Good SDKs make ecosystems easier to extend. When maintainers publish solid SDKs, more wallets, clients, services, and experiments can build on the same foundation without starting from zero.
 
-## OpenSats SDK project pages
+## OpenSats-funded SDK-style projects
 
-OpenSats currently has project pages for two SDK-style projects:
+OpenSats has funded many SDK-style projects, such as:
 
 - [BDK](/projects/bdk), a Rust toolkit for building Bitcoin wallets
 - [NDK](/projects/ndk), a TypeScript toolkit for building nostr applications
+- [Applesauce](/projects/applesauce), a modular TypeScript SDK for nostr web clients
+- [Payjoin Dev Kit](/projects/pdk), a Rust Payjoin library with bindings for multiple languages
+- [rust-bitcoin](/projects/rust-bitcoin), a low-level Rust Bitcoin library stack
+
+OpenSats has also supported work on LDK, a modular Lightning library written in Rust.
 
 ## References
 

--- a/data/topics/sdk.mdx
+++ b/data/topics/sdk.mdx
@@ -17,13 +17,12 @@ Good SDKs make ecosystems easier to extend. When maintainers publish solid SDKs,
 
 OpenSats has funded many SDK-style projects, such as:
 
-- [BDK](/projects/bdk), a Rust toolkit for building Bitcoin wallets
-- [NDK](/projects/ndk), a TypeScript toolkit for building nostr applications
+- [BDK](/projects/bdk) (Bitcoin Dev Kit), a Rust toolkit for building Bitcoin wallets
+- LDK (Lightning Dev Kit), a modular Lightning library written in Rust
+- [NDK](/projects/ndk) (Nostr Dev Kit), a TypeScript toolkit for building nostr applications
+- [PDK](/projects/pdk) (Payjoin Dev Kit), a Rust Payjoin library with bindings for multiple languages
 - [Applesauce](/projects/applesauce), a modular TypeScript SDK for nostr web clients
-- [Payjoin Dev Kit](/projects/pdk), a Rust Payjoin library with bindings for multiple languages
 - [rust-bitcoin](/projects/rust-bitcoin), a low-level Rust Bitcoin library stack
-
-OpenSats has also supported work on LDK, a modular Lightning library written in Rust.
 
 ## References
 

--- a/data/topics/sdk.mdx
+++ b/data/topics/sdk.mdx
@@ -18,7 +18,7 @@ Good SDKs make ecosystems easier to extend. When maintainers publish solid SDKs,
 OpenSats has funded many SDK-style projects, such as:
 
 - [BDK](/projects/bdk) (Bitcoin Dev Kit), a Rust toolkit for building Bitcoin wallets
-- LDK (Lightning Dev Kit), a modular Lightning library written in Rust
+- [LDK](/projects/ldk) (Lightning Dev Kit), a modular Lightning library written in Rust
 - [NDK](/projects/ndk) (Nostr Dev Kit), a TypeScript toolkit for building nostr applications
 - [PDK](/projects/pdk) (Payjoin Dev Kit), a Rust Payjoin library with bindings for multiple languages
 - [Applesauce](/projects/applesauce), a modular TypeScript SDK for nostr web clients


### PR DESCRIPTION
Follow-up to the merged `SDK` topic page. This revises the OpenSats examples section so it reflects the broader set of funded SDK-style projects.

- renames the section to `OpenSats-funded SDK-style projects`
- expands the examples to include `Applesauce`, `Payjoin Dev Kit`, and `rust-bitcoin`, plus a short note about LDK

Follow-up to https://github.com/OpenSats/content/issues/109#issuecomment-4660465305

---

Build preview:
- [/topics/sdk](https://os-website-git-content-update-sdk-topic-page-examples-opensats.vercel.app/topics/sdk)
