### PR TITLE
Update VLS showcase page

### DIFF
--- a/data/projects/vls.mdx
+++ b/data/projects/vls.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Validating Lightning Signer'
 dateAdded: '2023-12-12'
-summary: 'A Lightning signing stack that takes keys off the node and refuses to sign anything that violates the Lightning protocol or the operator's own policies.'
+summary: 'A Lightning signing stack that keeps keys off the node and enforces operator policies.'
 nym: 'devrandom and contributors'
 website: 'https://vls.tech/'
 coverImage: '/static/images/projects/vls.png'

--- a/data/projects/vls.mdx
+++ b/data/projects/vls.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Validating Lightning Signer'
 dateAdded: '2023-12-12'
-summary: 'A hardware-friendly Lightning signing stack that keeps private keys off the Lightning node itself.'
+summary: 'A Lightning signing stack that takes keys off the node and refuses to sign anything that violates the Lightning protocol or the operator's own policies.'
 nym: 'devrandom and contributors'
 website: 'https://vls.tech/'
 coverImage: '/static/images/projects/vls.png'
@@ -16,8 +16,9 @@ node into two parts: an operational node that connects to peers and
 routes payments, and a separate signer that holds the private keys and
 validates every state change before signing it. If the node is compromised,
 the attacker gets network access but no keys; the signer refuses to sign
-malicious state updates because it enforces the rules of the Lightning
-protocol itself.
+malicious state updates because it independently enforces both the Lightning 
+protocol's rules and the operator's own policies (approved destinations, 
+velocity limits, spend caps, etc).
 
 VLS works with [Core Lightning](https://github.com/ElementsProject/lightning)
 and [LDK](https://lightningdevkit.org/), runs on desktop, server, and
@@ -26,7 +27,7 @@ to separate the signer onto its own machine.
 
 ## Why fund it?
 
-Holding Lightning keys on an online node is the largest single attack surface
+Holding Lightning keys on an online node is [the largest single attack surface](https://vls.tech/posts/lightning-security-spectrum/)
 in the current Lightning stack. VLS gives custodians, enterprises, and serious
 self-hosters a way to separate the keys from the node the same way Bitcoin
 signing devices did for on-chain funds. The design has been adopted inside
@@ -37,7 +38,7 @@ the node runs in Blockstream's cloud.
 OpenSats first funded VLS in the
 [December 2023 wave of Bitcoin grants](/blog/bitcoin-grants-december-2023#validating-lightning-signer)
 and renewed support in
-[July 2024](/blog/bitcoin-grants-july-2024#validating-lightning-signer).
+[July 2024](/blog/bitcoin-grants-july-2024#validating-lightning-signer). [Spiral](https://spiral.xyz/), 
 [Blockstream](https://blockstream.com/) and the
 [Human Rights Foundation](https://hrf.org/) also back the project. For a
 detailed look at progress, see the
@@ -48,8 +49,8 @@ impact report.
 
 The team is pushing toward an official 1.0 mainnet-ready release.
 [Version 0.14](https://gitlab.com/lightning-signer/validating-lightning-signer/-/releases/v0.14.0)
-shipped in late 2025 with a reworked release process and cleaner dependency
-graph. Ongoing work covers splicing, dual funding, key-reuse policy
-errors, running the signer on secure enclaves, and filling out the
+shipped in late 2025 with BOLT12 signing support, expanded HTLC monitoring, 
+and a cleaner dependency setup. Ongoing work covers splicing, dual funding, 
+improved recovery flows, running the signer on secure enclaves, and filling out the
 integration docs. LND support is the most requested next integration target,
 but it depends on changes upstream in LND before VLS can be wired in.


### PR DESCRIPTION
Updates the `VLS` project page to better explain the signer's security model and to refresh the funding and roadmap sections.

- Rewrites the summary and opening copy to emphasize policy enforcement alongside key isolation
- Adds the Lightning Security Spectrum post and Spiral as a funder
- Refreshes the `v0.14` update details with `BOLT12`, HTLC monitoring, and recovery-flow context

---

Build preview:
- [/projects/vls](https://os-website-git-fork-jackronaldi-vls-showcase-opensats.vercel.app/projects/vls)
