### PR TITLE
Fix homepage blog date readability and tidy up post list

### DIFF
--- a/components/Tag.tsx
+++ b/components/Tag.tsx
@@ -3,13 +3,17 @@ import { kebabCase } from 'pliny/utils/kebabCase'
 
 interface Props {
   text: string
+  className?: string
 }
 
-const Tag = ({ text }: Props) => {
+const Tag = ({ text, className }: Props) => {
   return (
     <Link
       href={`/tags/${kebabCase(text)}`}
-      className="mr-3 text-sm font-medium uppercase text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+      className={
+        className ??
+        'mr-3 text-sm font-medium uppercase text-primary-500 hover:text-primary-600 dark:hover:text-primary-400'
+      }
     >
       {text.split(' ').join('-')}
     </Link>

--- a/data/blog/0xB10C-receives-lts-grant.mdx
+++ b/data/blog/0xB10C-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For 0xB10C'
 date: '2024-02-06'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS', 'core']
+tags: ['grants', 'bitcoin', 'LTS', 'core']
 draft: false
 authors: ['cfunk', 'arvin']
 images: ['/static/images/blog/23-0xB10C.jpg']

--- a/data/blog/10th-wave-of-nostr-grants.mdx
+++ b/data/blog/10th-wave-of-nostr-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Tenth Wave of Nostr Grants'
 date: '2025-03-27'
-tags: ['OpenSats', 'grants', 'nostr', 'wave']
+tags: ['grants', 'nostr', 'wave']
 draft: false
 authors: ['default', 'arvin', 'julian']
 images: ['/static/images/blog/73-tenth-wave-of-nostr-grants.jpg']

--- a/data/blog/2023-year-in-review.mdx
+++ b/data/blog/2023-year-in-review.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OpenSats' 2023 Year in Review"
 date: '2023-12-31'
-tags: ['OpenSats', 'grants', 'donations', 'bitcoin', 'nostr', 'review']
+tags: ['grants', 'donations', 'bitcoin', 'nostr', 'review']
 draft: false
 authors: ['dergigi', 'eiaine']
 images: ['/static/images/blog/20-eoy.jpg']

--- a/data/blog/2024-year-in-review.mdx
+++ b/data/blog/2024-year-in-review.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OpenSats' 2024 Year in Review"
 date: '2024-12-30'
-tags: ['OpenSats', 'grants', 'donations', 'bitcoin', 'nostr', 'review']
+tags: ['grants', 'donations', 'bitcoin', 'nostr', 'review']
 draft: false
 authors: ['dergigi', 'default']
 images: ['/static/images/blog/66-opensats-2024-year-in-review.jpg']

--- a/data/blog/2025-year-in-review.mdx
+++ b/data/blog/2025-year-in-review.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OpenSats' 2025 Year in Review"
 date: '2026-01-28'
-tags: ['OpenSats', 'grants', 'donations', 'bitcoin', 'nostr', 'review']
+tags: ['grants', 'donations', 'bitcoin', 'nostr', 'review']
 draft: false
 authors: ['dergigi', 'default']
 images: ['/static/images/blog/98-2025-year-in-review.jpg']

--- a/data/blog/3rd-wave-of-education-grants.mdx
+++ b/data/blog/3rd-wave-of-education-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Third Wave of Education Grants'
 date: '2024-11-18'
-tags: ['OpenSats', 'grants', 'bitcoin', 'education', 'wave']
+tags: ['grants', 'bitcoin', 'education', 'wave']
 draft: false
 authors: ['dread', 'arvin', 'julian', 'bayer']
 images: ['/static/images/blog/61-third-wave-education-grants.jpg']

--- a/data/blog/7th-wave-of-nostr-grants.mdx
+++ b/data/blog/7th-wave-of-nostr-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Seventh Wave of Nostr Grants'
 date: '2024-09-19'
-tags: ['OpenSats', 'grants', 'nostr', 'wave']
+tags: ['grants', 'nostr', 'wave']
 draft: false
 authors: ['arvin', 'dergigi']
 images: ['/static/images/blog/54-nostr-7th-wave.jpg']

--- a/data/blog/8th-wave-nostr-grants.mdx
+++ b/data/blog/8th-wave-nostr-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Eighth Wave of Nostr Grants'
 date: '2024-11-04'
-tags: ['OpenSats', 'grants', 'nostr', 'wave']
+tags: ['grants', 'nostr', 'wave']
 draft: false
 authors: ['arvin', 'ecurrencyhodler', 'julian']
 images: ['/static/images/blog/60-eighth-wave-nostr-grants.jpg']

--- a/data/blog/8th-wave-of-bitcoin-grants.mdx
+++ b/data/blog/8th-wave-of-bitcoin-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Eighth Wave of Bitcoin Grants'
 date: '2024-10-25'
-tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
+tags: ['grants', 'bitcoin', 'wave']
 draft: false
 authors: ['arvin', 'dergigi']
 images: ['/static/images/blog/59-bitcoin-8th-wave.jpg']

--- a/data/blog/9th-wave-of-nostr-grants.mdx
+++ b/data/blog/9th-wave-of-nostr-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Ninth Wave of Nostr Grants'
 date: '2024-12-16'
-tags: ['OpenSats', 'grants', 'nostr', 'wave']
+tags: ['grants', 'nostr', 'wave']
 draft: false
 authors: ['arvin', 'bayer', 'btcschellingpt']
 images: ['/static/images/blog/65-ninth-wave-of-nostr-grants.jpg']

--- a/data/blog/additional-ops-budget-from-hrf.mdx
+++ b/data/blog/additional-ops-budget-from-hrf.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Additional Operational Budget from HRF'
 date: '2025-02-18'
-tags: ['OpenSats', 'funding', 'donations', 'operations']
+tags: ['funding', 'donations', 'operations']
 draft: false
 authors: ['arvin', 'default']
 images: ['/static/images/blog/69-additional-ops-budget-from-hrf.jpg']

--- a/data/blog/advancements-in-bitcoin-and-lightning-wallets.mdx
+++ b/data/blog/advancements-in-bitcoin-and-lightning-wallets.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Advancements in Bitcoin and Lightning Wallets'
 date: '2025-10-27'
-tags: ['OpenSats', 'bitcoin', 'lightning', 'impact']
+tags: ['bitcoin', 'lightning', 'impact']
 authors: ['default', 'arvin', 'dergigi']
 images:
   ['/static/images/blog/86-advancements-in-bitcoin-and-lightning-wallets.jpg']

--- a/data/blog/advancements-in-developer-libraries.mdx
+++ b/data/blog/advancements-in-developer-libraries.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Advancements in Developer Libraries'
 date: '2025-08-04'
-tags: ['OpenSats', 'bitcoin', 'impact', 'libraries']
+tags: ['bitcoin', 'impact', 'libraries']
 authors: ['default', 'arvin']
 images: ['/static/images/blog/82-advancements-in-developer-libraries.jpg']
 draft: false

--- a/data/blog/advancements-in-developer-training.mdx
+++ b/data/blog/advancements-in-developer-training.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Advancements in Developer Training'
 date: '2025-06-21'
-tags: ['OpenSats', 'bitcoin', 'impact', 'education']
+tags: ['bitcoin', 'impact', 'education']
 authors: ['dread', 'arvin', 'default']
 images: ['/static/images/blog/79-advancements-in-developer-training.jpg']
 draft: false

--- a/data/blog/advancements-in-ecash.mdx
+++ b/data/blog/advancements-in-ecash.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Advancements in Ecash'
 date: '2025-09-26'
-tags: ['OpenSats', 'bitcoin', 'impact', 'ecash']
+tags: ['bitcoin', 'impact', 'ecash']
 authors: ['default', 'arvin', 'dergigi']
 images: ['/static/images/blog/84-advancements-in-ecash.jpg']
 draft: false

--- a/data/blog/advancements-in-lightning-infrastructure.mdx
+++ b/data/blog/advancements-in-lightning-infrastructure.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Advancements in Lightning Infrastructure'
 date: '2025-04-17'
-tags: ['OpenSats', 'bitcoin', 'impact', 'lightning']
+tags: ['bitcoin', 'impact', 'lightning']
 authors: ['default', 'arvin', 'julian']
 images: ['/static/images/blog/74-advancements-in-lightning-infrastructure.jpg']
 draft: false

--- a/data/blog/advancements-in-nostr-clients.mdx
+++ b/data/blog/advancements-in-nostr-clients.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Advancements in Nostr Clients'
 date: '2025-12-01'
-tags: ['OpenSats', 'nostr', 'impact', 'clients']
+tags: ['nostr', 'impact', 'clients']
 authors: ['default', 'arvin', 'dergigi']
 images: ['/static/images/blog/88-advancements-in-nostr-clients.jpg']
 draft: false

--- a/data/blog/advancements-in-nostr-relays.mdx
+++ b/data/blog/advancements-in-nostr-relays.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Advancements in Nostr Relays'
 date: '2026-03-26'
-tags: ['OpenSats', 'nostr', 'impact', 'relays']
+tags: ['nostr', 'impact', 'relays']
 authors: ['default', 'arvin', 'tuma']
 images: ['/static/images/blog/103-advancements-in-nostr-relays.jpg']
 draft: false

--- a/data/blog/alex-gleason-receives-lts-grant.mdx
+++ b/data/blog/alex-gleason-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Alex Gleason'
 date: '2024-08-29'
-tags: ['OpenSats', 'grants', 'nostr', 'LTS']
+tags: ['grants', 'nostr', 'LTS']
 draft: false
 authors: ['arvin', 'dergigi']
 images: ['/static/images/blog/51-alex-gleason-receives-lts-grant.jpg']

--- a/data/blog/andrew-toth-receives-lts-grant.mdx
+++ b/data/blog/andrew-toth-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Long-Term Support For Andrew Toth"
 date: '2025-12-03'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS', 'core']
+tags: ['grants', 'bitcoin', 'LTS', 'core']
 authors: ['default', 'arvin']
 images: ['/static/images/blog/89-andrew-toth-lts.jpg']
 draft: false

--- a/data/blog/announcing-lts-grant-program-to-support-bitcoin-core-contributors.mdx
+++ b/data/blog/announcing-lts-grant-program-to-support-bitcoin-core-contributors.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support Program for Bitcoin Core Developers'
 date: '2023-07-07'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS', 'core']
+tags: ['grants', 'bitcoin', 'LTS', 'core']
 draft: false
 authors: ['dergigi']
 images: ['/static/images/blog/02-lts.jpg']

--- a/data/blog/announcing-nostr-design.mdx
+++ b/data/blog/announcing-nostr-design.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Take Nostr Mainstream with Help from Nostr Design'
 date: '2023-09-09'
-tags: ['OpenSats', 'nostr', 'design']
+tags: ['nostr', 'design']
 draft: false
 authors: ['default']
 images: ['/static/images/blog/08-nostr-design.jpg']

--- a/data/blog/announcing-the-opensats-education-initiative.mdx
+++ b/data/blog/announcing-the-opensats-education-initiative.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Announcing the OpenSats Education Initiative'
 date: '2024-07-05'
-tags: ['OpenSats', 'grants', 'bitcoin', 'education', 'wave']
+tags: ['grants', 'bitcoin', 'education', 'wave']
 draft: false
 authors: ['dread']
 images: ['/static/images/blog/38-education.jpg']

--- a/data/blog/bitcoin-and-nostr-grants-august-2023.mdx
+++ b/data/blog/bitcoin-and-nostr-grants-august-2023.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Grants for BDK, LNbits, Nostr, and More!'
 date: '2023-08-17'
-tags: ['OpenSats', 'grants', 'bitcoin', 'nostr', 'wave']
+tags: ['grants', 'bitcoin', 'nostr', 'wave']
 draft: false
 authors: ['odell']
 images: ['/static/images/blog/06-august.jpg']

--- a/data/blog/bitcoin-grants-december-2023.mdx
+++ b/data/blog/bitcoin-grants-december-2023.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Third Wave of Bitcoin Grants'
 date: '2023-12-18'
-tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
+tags: ['grants', 'bitcoin', 'wave']
 draft: false
 authors: ['dergigi', 'odell']
 images: ['/static/images/blog/17-bitcoin-dec.jpg']

--- a/data/blog/bitcoin-grants-feb-2024.mdx
+++ b/data/blog/bitcoin-grants-feb-2024.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Fourth Wave of Bitcoin Grants'
 date: '2024-02-25'
-tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
+tags: ['grants', 'bitcoin', 'wave']
 draft: false
 authors: ['robos', 'dergigi']
 images: ['/static/images/blog/24-bitcoin-feb.jpg']

--- a/data/blog/bitcoin-grants-july-2023.mdx
+++ b/data/blog/bitcoin-grants-july-2023.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'First Wave of Bitcoin Grants'
 date: '2023-07-14'
-tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
+tags: ['grants', 'bitcoin', 'wave']
 draft: false
 authors: ['dergigi']
 images: ['/static/images/blog/04-bitcoin.jpg']

--- a/data/blog/bitcoin-grants-july-2024-6th-wave.mdx
+++ b/data/blog/bitcoin-grants-july-2024-6th-wave.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Sixth Wave of Bitcoin Grants'
 date: '2024-07-22'
-tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
+tags: ['grants', 'bitcoin', 'wave']
 draft: false
 authors: ['arvin', 'btcschellingpt']
 images: ['/static/images/blog/41-bitcoin-6th-wave.jpg']

--- a/data/blog/bitcoin-grants-july-2024.mdx
+++ b/data/blog/bitcoin-grants-july-2024.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Fifth Wave of Bitcoin Grants'
 date: '2024-07-02'
-tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
+tags: ['grants', 'bitcoin', 'wave']
 draft: false
 authors: ['btcschellingpt', 'arvin']
 images: ['/static/images/blog/36-bitcoin-jul.jpg']

--- a/data/blog/bitcoin-grants-september-2024-7th-wave.mdx
+++ b/data/blog/bitcoin-grants-september-2024-7th-wave.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Seventh Wave of Bitcoin Grants'
 date: '2024-09-24'
-tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
+tags: ['grants', 'bitcoin', 'wave']
 draft: false
 authors: ['arvin', 'dergigi', 'bayer']
 images: ['/static/images/blog/55-seventh-wave-bitcoin-grants.jpg']

--- a/data/blog/bitcoin-infrastructure-this-decade.mdx
+++ b/data/blog/bitcoin-infrastructure-this-decade.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Looking Ahead: Bitcoin Infrastructure This Decade'
 date: '2023-09-20'
-tags: ['OpenSats', 'bitcoin', 'infrastructure', 'research']
+tags: ['bitcoin', 'infrastructure', 'research']
 draft: false
 authors: ['niftynei']
 images: ['/static/images/blog/09-nifty-infra.jpg']

--- a/data/blog/brad-stachurski-receives-lts.mdx
+++ b/data/blog/brad-stachurski-receives-lts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Long-Term Support For Brad Stachurski"
 date: '2025-12-31'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS']
+tags: ['grants', 'bitcoin', 'LTS']
 authors: ['default', 'arvin']
 images: ['/static/images/blog/96-brad-stachurski-receives-lts.jpg']
 draft: false

--- a/data/blog/bruno-garcia-receives-lts-grant.mdx
+++ b/data/blog/bruno-garcia-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Bruno Garcia'
 date: '2024-03-19'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS', 'core']
+tags: ['grants', 'bitcoin', 'LTS', 'core']
 draft: false
 authors: ['cfunk']
 images: ['/static/images/blog/26-bruno-lts.jpg']

--- a/data/blog/call-for-applications-spring-2026.mdx
+++ b/data/blog/call-for-applications-spring-2026.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Call for Applications"
 date: '2026-04-29'
-tags: ['OpenSats', 'bitcoin', 'applications']
+tags: ['bitcoin', 'applications']
 authors: ['default', 'arvin', 'tuma', 'btcschellingpt']
 images: ['/static/images/blog/107-call-for-applications-spring-2026.jpg']
 draft: false

--- a/data/blog/caring-for-bitcoin-core.mdx
+++ b/data/blog/caring-for-bitcoin-core.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Caring For Core'
 date: '2024-08-14'
-tags: ['OpenSats', 'grants', 'bitcoin', 'core', 'wave']
+tags: ['grants', 'bitcoin', 'core', 'wave']
 draft: false
 authors: ['arvin', 'dergigi', 'jamesob']
 images: ['/static/images/blog/48-caring-for-bitcoin-core.jpg']

--- a/data/blog/cashu-calle-receives-lts-grant.mdx
+++ b/data/blog/cashu-calle-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Calle'
 date: '2024-06-21'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS']
+tags: ['grants', 'bitcoin', 'LTS']
 draft: false
 authors: ['arvin', 'bayer']
 images: ['/static/images/blog/34-calle.jpg']

--- a/data/blog/daniele-receives-lts-grant.mdx
+++ b/data/blog/daniele-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Daniele'
 date: '2024-08-27'
-tags: ['OpenSats', 'grants', 'nostr', 'LTS']
+tags: ['grants', 'nostr', 'LTS']
 draft: false
 authors: ['arvin', 'dergigi']
 images: ['/static/images/blog/49-daniele-lts.jpg']

--- a/data/blog/developer-spotlight-codytseng-jumblesocial.mdx
+++ b/data/blog/developer-spotlight-codytseng-jumblesocial.mdx
@@ -5,7 +5,7 @@ tags: ['nostr', 'spotlight', 'clients']
 authors: ['ville']
 images: ['/static/images/spotlight/cody-tseng/featured.jpg', '/static/images/spotlight/cody-tseng/hero.jpg']
 draft: false
-summary: "Cody Tseng is an OpenSats grantee behind Jumble, a Nostr client for the open social web"
+summary: "Cody Tseng is the OpenSats grantee behind Jumble, a Nostr client for the open social web."
 pullQuotes:
   - "Like many people, I dislike being controlled and want to truly own certain things."
   - "The design of Nostr is extremely simple. You can describe its core principles in just a few sentences."

--- a/data/blog/developer-spotlight-codytseng-jumblesocial.mdx
+++ b/data/blog/developer-spotlight-codytseng-jumblesocial.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Cody Tseng Is Building a Social App That Follows Your Heart, Not an Algorithm"
 date: '2026-06-02'
-tags: ['OpenSats', 'nostr', 'spotlight', 'clients']
+tags: ['nostr', 'spotlight', 'clients']
 authors: ['ville']
 images: ['/static/images/spotlight/cody-tseng/featured.jpg', '/static/images/spotlight/cody-tseng/hero.jpg']
 draft: false

--- a/data/blog/developer-spotlight-kurt-unger.mdx
+++ b/data/blog/developer-spotlight-kurt-unger.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Made in Africa: Kurt and the Open-Source Bitcoin Miner That Anyone Can Make"
 date: '2026-05-22'
-tags: ['OpenSats', 'bitcoin', 'hardware', 'spotlight']
+tags: ['bitcoin', 'hardware', 'spotlight']
 authors: ['ville']
 images: ['/static/images/spotlight/kurt-unger/featured.jpg', '/static/images/spotlight/kurt-unger/hero.jpg']
 draft: false

--- a/data/blog/developing-advancements-in-onchain-privacy.mdx
+++ b/data/blog/developing-advancements-in-onchain-privacy.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Advancements in On-Chain Privacy'
 date: '2025-02-28'
-tags: ['OpenSats', 'bitcoin', 'impact', 'privacy']
+tags: ['bitcoin', 'impact', 'privacy']
 authors: ['default', 'arvin', 'julian']
 images:
   ['/static/images/blog/70-developing-advancements-in-onchain-privacy.jpg']

--- a/data/blog/donation-commitment-from-build-asset-management.mdx
+++ b/data/blog/donation-commitment-from-build-asset-management.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'OpenSats Receives Donation Commitment from Build Asset Management'
 date: '2024-08-08'
-tags: ['OpenSats', 'funding', 'donations', 'bitcoin']
+tags: ['funding', 'donations', 'bitcoin']
 draft: false
 authors: ['odell', 'arvin', 'dergigi']
 images: ['/static/images/blog/44-build-asset-management.jpg']

--- a/data/blog/doubling-down-on-nostr.mdx
+++ b/data/blog/doubling-down-on-nostr.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Doubling Down on Nostr '
 date: '2024-11-20'
-tags: ['OpenSats', 'grants', 'nostr', 'wave']
+tags: ['grants', 'nostr', 'wave']
 draft: false
 authors: ['dergigi', 'odell']
 images: ['/static/images/blog/63-doubling-down-on-nostr.jpg']

--- a/data/blog/dusty-daemon-receives-lts-grant.mdx
+++ b/data/blog/dusty-daemon-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Dusty Daemon'
 date: '2024-10-02'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS']
+tags: ['grants', 'bitcoin', 'LTS']
 draft: false
 authors: ['btcschellingpt', 'arvin', 'dergigi']
 images: ['/static/images/blog/57-dusty-daemon-lts-grant.jpg']

--- a/data/blog/eleventh-wave-of-bitcoin-grants.mdx
+++ b/data/blog/eleventh-wave-of-bitcoin-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Eleventh Wave of Bitcoin Grants'
 date: '2025-05-14'
-tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
+tags: ['grants', 'bitcoin', 'wave']
 draft: false
 authors: ['default', 'arvin']
 images: ['/static/images/blog/eleventh-wave-of-bitcoin-grants.jpg']

--- a/data/blog/eleventh-wave-of-nostr-grants.mdx
+++ b/data/blog/eleventh-wave-of-nostr-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Eleventh Wave of Nostr Grants'
 date: '2025-04-16'
-tags: ['OpenSats', 'grants', 'nostr', 'wave']
+tags: ['grants', 'nostr', 'wave']
 authors: ['default', 'arvin', 'julian']
 images: ['/static/images/blog/76-eleventh-wave-of-nostr-grants.jpg']
 draft: false

--- a/data/blog/fiatjaf-receives-lts-grant.mdx
+++ b/data/blog/fiatjaf-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For fiatjaf'
 date: '2024-07-23'
-tags: ['OpenSats', 'grants', 'nostr', 'LTS']
+tags: ['grants', 'nostr', 'LTS']
 draft: false
 authors: ['dergigi', 'arvin']
 images: ['/static/images/blog/42-fiatjaf.jpg']

--- a/data/blog/fifteenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/fifteenth-wave-of-bitcoin-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Fifteenth Wave of Bitcoin Grants"
 date: '2025-12-27'
-tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
+tags: ['grants', 'bitcoin', 'wave']
 authors: ['default', 'arvin', 'dergigi']
 images: ['/static/images/blog/92-fifteenth-wave-of-bitcoin-grants.jpg']
 draft: false

--- a/data/blog/fifteenth-wave-of-nostr-grants.mdx
+++ b/data/blog/fifteenth-wave-of-nostr-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Fifteenth Wave of Nostr Grants"
 date: '2026-02-17'
-tags: ['OpenSats', 'grants', 'nostr', 'wave']
+tags: ['grants', 'nostr', 'wave']
 authors: ['default', 'arvin']
 images: ['/static/images/blog/100-fifteenth-wave-of-nostr-grants.jpg']
 draft: false

--- a/data/blog/five-grants-to-strengthen-bitcoin-development.mdx
+++ b/data/blog/five-grants-to-strengthen-bitcoin-development.mdx
@@ -1,7 +1,7 @@
 ---
 title: "5 Grants to Strengthen Bitcoin Development"
 date: '2026-03-11'
-tags: ['OpenSats', 'grants', 'bitcoin', 'wave', 'core']
+tags: ['grants', 'bitcoin', 'wave', 'core']
 authors: ['jamesob', 'arvin']
 images: ['/static/images/blog/101-five-grants-to-strengthen-bitcoin-development.jpg']
 draft: false

--- a/data/blog/fourteenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/fourteenth-wave-of-bitcoin-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Fourteenth Wave of Bitcoin Grants'
 date: '2025-10-03'
-tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
+tags: ['grants', 'bitcoin', 'wave']
 authors: ['default', 'arvin']
 images: ['/static/images/blog/85-fourteenth-wave-of-bitcoin-grants.jpg']
 draft: false

--- a/data/blog/fourteenth-wave-of-nostr-grants.mdx
+++ b/data/blog/fourteenth-wave-of-nostr-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Fourteenth Wave of Nostr Grants"
 date: '2025-12-21'
-tags: ['OpenSats', 'grants', 'nostr', 'wave']
+tags: ['grants', 'nostr', 'wave']
 authors: ['default', 'arvin', 'dergigi']
 images: ['/static/images/blog/94-fourteenth-wave-of-nostr-grants.jpg']
 draft: false

--- a/data/blog/fourth-wave-of-education-grants.mdx
+++ b/data/blog/fourth-wave-of-education-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Fourth Wave of Education Grants'
 date: '2025-04-07'
-tags: ['OpenSats', 'grants', 'bitcoin', 'education', 'wave']
+tags: ['grants', 'bitcoin', 'education', 'wave']
 authors: ['dread', 'arvin', 'julian']
 images: ['/static/images/blog/75-fourth-wave-of-education-grants.jpg']
 draft: false

--- a/data/blog/furszy-receives-lts-grant-for-bitcoin-core.mdx
+++ b/data/blog/furszy-receives-lts-grant-for-bitcoin-core.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Furszy'
 date: '2023-10-27'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS', 'core']
+tags: ['grants', 'bitcoin', 'LTS', 'core']
 draft: false
 authors: ['dergigi']
 images: ['/static/images/blog/15-furszy.jpg']

--- a/data/blog/gleb-naumenko-receives-lts-grant.mdx
+++ b/data/blog/gleb-naumenko-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Gleb Naumenko'
 date: '2023-10-18'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS', 'core']
+tags: ['grants', 'bitcoin', 'LTS', 'core']
 draft: false
 authors: ['dergigi', 'jamesob']
 images: ['/static/images/blog/12-gleb.jpg']

--- a/data/blog/greenart7c3-receives-lts-grant.mdx
+++ b/data/blog/greenart7c3-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Greenart7c3'
 date: '2024-10-15'
-tags: ['OpenSats', 'grants', 'nostr', 'LTS']
+tags: ['grants', 'nostr', 'LTS']
 draft: false
 authors: ['arvin', 'dergigi']
 images: ['/static/images/blog/58-greenart7c3-lts.jpg']

--- a/data/blog/hodlbod-receives-lts-grant.mdx
+++ b/data/blog/hodlbod-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Hodlbod'
 date: '2024-07-18'
-tags: ['OpenSats', 'grants', 'nostr', 'LTS']
+tags: ['grants', 'nostr', 'LTS']
 draft: false
 authors: ['arvin', 'bayer']
 images: ['/static/images/blog/40-hodlbod.jpg']

--- a/data/blog/hzrd149-receives-lts-grant.mdx
+++ b/data/blog/hzrd149-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For hzrd149'
 date: '2024-04-15'
-tags: ['OpenSats', 'grants', 'nostr', 'LTS']
+tags: ['grants', 'nostr', 'LTS']
 draft: false
 authors: ['arvin', 'dergigi']
 images: ['/static/images/blog/29-hzrd149-lts.jpg']

--- a/data/blog/jason-donenfeld-lts-grant.mdx
+++ b/data/blog/jason-donenfeld-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Jason Donenfeld'
 date: '2024-09-12'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS']
+tags: ['grants', 'bitcoin', 'LTS']
 draft: false
 authors: ['arvin', 'dergigi', 'jamesob']
 images: ['/static/images/blog/46-jason-donenfeld.jpg']

--- a/data/blog/jb55-receives-lts-grant.mdx
+++ b/data/blog/jb55-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For William Casarin'
 date: '2024-06-22'
-tags: ['OpenSats', 'grants', 'nostr', 'LTS']
+tags: ['grants', 'nostr', 'LTS']
 draft: false
 authors: ['arvin', 'dergigi']
 images: ['/static/images/blog/35-jb55.jpg']

--- a/data/blog/jon-atack-receives-lts-grant.mdx
+++ b/data/blog/jon-atack-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Jon Atack'
 date: '2024-09-26'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS', 'core']
+tags: ['grants', 'bitcoin', 'LTS', 'core']
 draft: false
 authors: ['arvin', 'dergigi']
 images: ['/static/images/blog/53-jon-atack-lts.jpg']

--- a/data/blog/josi-baker-receives-opensats-lts-grant.mdx
+++ b/data/blog/josi-baker-receives-opensats-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Josie Baker'
 date: '2023-08-16'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS', 'core']
+tags: ['grants', 'bitcoin', 'LTS', 'core']
 draft: false
 authors: ['jamesob']
 images: ['/static/images/blog/05-josi.jpg']

--- a/data/blog/kieran-receives-lts-grant.mdx
+++ b/data/blog/kieran-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Kieran Harkin'
 date: '2024-08-06'
-tags: ['OpenSats', 'grants', 'nostr', 'LTS']
+tags: ['grants', 'nostr', 'LTS']
 draft: false
 authors: ['arvin', 'dergigi']
 images: ['/static/images/blog/43-kieran.jpg']

--- a/data/blog/let-a-thousand-flowers-bloom.mdx
+++ b/data/blog/let-a-thousand-flowers-bloom.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Let a Thousand Flowers Bloom'
 date: '2025-03-15'
-tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
+tags: ['grants', 'bitcoin', 'wave']
 draft: false
 authors: ['default', 'dergigi']
 images: ['/static/images/blog/72-let-a-thousand-flowers-bloom.jpg']

--- a/data/blog/m1sterc001guy-receives-lts-grant.mdx
+++ b/data/blog/m1sterc001guy-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For m1sterc001guy '
 date: '2024-11-13'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS']
+tags: ['grants', 'bitcoin', 'LTS']
 draft: false
 authors: ['arvin', 'btcschellingpt', 'ecurrencyhodler']
 images: ['/static/images/blog/62-m1sterc001guy-lts.jpg']

--- a/data/blog/matt-morehouse-lightning-security-lts-grant.mdx
+++ b/data/blog/matt-morehouse-lightning-security-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Matt Morehouse'
 date: '2023-10-23'
-tags: ['OpenSats', 'grants', 'bitcoin', 'lightning', 'LTS']
+tags: ['grants', 'bitcoin', 'lightning', 'LTS']
 draft: false
 authors: ['dergigi']
 images: ['/static/images/blog/14-matt-morehouse.jpg']

--- a/data/blog/mike-dilger-receives-lts-grant.mdx
+++ b/data/blog/mike-dilger-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Mike Dilger'
 date: '2024-09-11'
-tags: ['OpenSats', 'grants', 'nostr', 'LTS']
+tags: ['grants', 'nostr', 'LTS']
 draft: false
 authors: ['arvin', 'dergigi']
 images: ['/static/images/blog/52-mike-dilger-lts.jpg']

--- a/data/blog/more-for-core.mdx
+++ b/data/blog/more-for-core.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Additional Grants for Bitcoin Core Contributors'
 date: '2025-01-20'
-tags: ['OpenSats', 'grants', 'bitcoin', 'core', 'wave']
+tags: ['grants', 'bitcoin', 'core', 'wave']
 draft: false
 authors: ['jamesob', 'arvin']
 images: ['/static/images/blog/67-more-for-core.jpg']

--- a/data/blog/niel-liesmons-joins-the-opensats-design-initiative.mdx
+++ b/data/blog/niel-liesmons-joins-the-opensats-design-initiative.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Niel Liesmons Joins OpenSats Design'
 date: '2023-10-20'
-tags: ['OpenSats', 'nostr', 'design']
+tags: ['nostr', 'design']
 draft: false
 authors: ['dergigi', 'karnage']
 images: ['/static/images/blog/13-nostr-design.jpg']

--- a/data/blog/ninth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/ninth-wave-of-bitcoin-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Ninth Wave of Bitcoin Grants'
 date: '2025-01-29'
-tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
+tags: ['grants', 'bitcoin', 'wave']
 draft: false
 authors: ['arvin', 'default']
 images: ['/static/images/blog/68-ninth-wave-of-bitcoin-grants.jpg']

--- a/data/blog/nostr-grants-august-2024.mdx
+++ b/data/blog/nostr-grants-august-2024.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Sixth Wave of Nostr Grants'
 date: '2024-08-07'
-tags: ['OpenSats', 'grants', 'nostr', 'wave']
+tags: ['grants', 'nostr', 'wave']
 draft: false
 authors: ['arvin', 'dergigi']
 images: ['/static/images/blog/45-nostr-grants-august-2024.jpg']

--- a/data/blog/nostr-grants-december-2023.mdx
+++ b/data/blog/nostr-grants-december-2023.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Fourth Wave of Nostr Grants'
 date: '2023-12-21'
-tags: ['OpenSats', 'grants', 'nostr', 'wave']
+tags: ['grants', 'nostr', 'wave']
 draft: false
 authors: ['nvk', 'dergigi']
 images: ['/static/images/blog/18-nostr-dec.jpg']

--- a/data/blog/nostr-grants-july-2023.mdx
+++ b/data/blog/nostr-grants-july-2023.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'First Wave of Nostr Grants'
 date: '2023-07-08'
-tags: ['OpenSats', 'grants', 'nostr', 'wave']
+tags: ['grants', 'nostr', 'wave']
 draft: false
 authors: ['dergigi']
 images: ['/static/images/blog/03-nostr.jpg']

--- a/data/blog/nostr-grants-july-2024.mdx
+++ b/data/blog/nostr-grants-july-2024.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Fifth Wave of Nostr Grants'
 date: '2024-07-15'
-tags: ['OpenSats', 'grants', 'nostr', 'wave']
+tags: ['grants', 'nostr', 'wave']
 draft: false
 authors: ['arvin', 'jason']
 images: ['/static/images/blog/39-nostr-jul.jpg']

--- a/data/blog/nostr-grants-october-2023.mdx
+++ b/data/blog/nostr-grants-october-2023.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Third Wave of Nostr Grants'
 date: '2023-10-18'
-tags: ['OpenSats', 'grants', 'nostr', 'wave']
+tags: ['grants', 'nostr', 'wave']
 draft: false
 authors: ['dergigi', 'odell']
 images: ['/static/images/blog/11-nostr-oct.jpg']

--- a/data/blog/nostr-lts-long-term-support-for-nostr-developers.mdx
+++ b/data/blog/nostr-lts-long-term-support-for-nostr-developers.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-term Support for Nostr Developers'
 date: '2024-03-11'
-tags: ['OpenSats', 'grants', 'LTS', 'nostr']
+tags: ['grants', 'LTS', 'nostr']
 draft: false
 authors: ['odell', 'nvk']
 images: ['/static/images/blog/25-nostr-lts.jpg']

--- a/data/blog/open-hardware-for-open-money.mdx
+++ b/data/blog/open-hardware-for-open-money.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Open Hardware for Open Money"
 date: '2026-04-21'
-tags: ['OpenSats', 'bitcoin', 'impact', 'hardware']
+tags: ['bitcoin', 'impact', 'hardware']
 authors: ['arvin', 'tuma', 'default']
 images: ['/static/images/blog/106-open-hardware-for-open-money.jpg']
 draft: false

--- a/data/blog/opensats-receives-additional-funding-of-dollar10m-from-startsmall.mdx
+++ b/data/blog/opensats-receives-additional-funding-of-dollar10m-from-startsmall.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Additional Funding from #startsmall'
 date: '2023-05-04'
-tags: ['OpenSats', 'funding', 'donations', 'startsmall', 'bitcoin', 'nostr']
+tags: ['funding', 'donations', 'startsmall', 'bitcoin', 'nostr']
 draft: false
 images: ['/static/images/blog/32-startsmall.jpg']
 summary: 'OpenSats receives $10 million from #startsmall for bitcoin, nostr, and related FOSS development.'

--- a/data/blog/opensats-receives-additional-funding-of-dollar21m-from-startsmall.mdx
+++ b/data/blog/opensats-receives-additional-funding-of-dollar21m-from-startsmall.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Additional Funding from #startsmall'
 date: '2024-05-04'
-tags: ['OpenSats', 'funding', 'donations', 'startsmall', 'bitcoin', 'nostr']
+tags: ['funding', 'donations', 'startsmall', 'bitcoin', 'nostr']
 images: ['/static/images/blog/32-startsmall.jpg']
 draft: false
 summary: 'OpenSats receives $21 million from #startsmall for bitcoin, nostr, and related FOSS development.'

--- a/data/blog/opensats-receives-dollar250k-donation-from-tether.mdx
+++ b/data/blog/opensats-receives-dollar250k-donation-from-tether.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OpenSats Receives $250,000 Donation From Tether"
 date: '2025-10-16'
-tags: ['OpenSats', 'funding', 'donations']
+tags: ['funding', 'donations']
 authors: ['odell', 'dergigi']
 images: ['/static/images/blog/90-opensats-receives-donation-from-tether.jpg']
 draft: false

--- a/data/blog/opensats-receives-dollar400k-donation-from-starkware-starknet.mdx
+++ b/data/blog/opensats-receives-dollar400k-donation-from-starkware-starknet.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OpenSats Receives $400,000 Donation From StarkWare and Starknet Foundation"
 date: '2025-11-24'
-tags: ['OpenSats', 'funding', 'donations']
+tags: ['funding', 'donations']
 authors: ['odell', 'dergigi']
 images: ['/static/images/blog/95-opensats-receives-donation-from-starkware-starknet-foundation.jpg']
 draft: false

--- a/data/blog/opensats-receives-donation-commitment-from-steak-n-shake.mdx
+++ b/data/blog/opensats-receives-donation-commitment-from-steak-n-shake.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OpenSats Receives Donation Commitment from Steak 'n Shake"
 date: '2025-10-31'
-tags: ['OpenSats', 'funding', 'donations']
+tags: ['funding', 'donations']
 authors: ['odell', 'dergigi']
 images: ['/static/images/blog/91-opensats-receives-commitment-from-steak-n-shake.jpg']
 draft: false

--- a/data/blog/opensats-receives-donation-from-bitwise-etf.mdx
+++ b/data/blog/opensats-receives-donation-from-bitwise-etf.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OpenSats Receives Donation from Bitwise Bitcoin ETF"
 date: '2026-03-10'
-tags: ['OpenSats', 'funding', 'donations', 'bitcoin']
+tags: ['funding', 'donations', 'bitcoin']
 authors: ['odell', 'dergigi']
 images: ['/static/images/blog/102-opensats-receives-donation-from-bitwise-bitcoin-etf.jpg']
 draft: false

--- a/data/blog/opensats-receives-funding-from-the-human-rights-foundation.mdx
+++ b/data/blog/opensats-receives-funding-from-the-human-rights-foundation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OpenSats Receives Funding from the Human Rights Foundation"
 date: '2026-01-20'
-tags: ['OpenSats', 'funding', 'donations', 'operations']
+tags: ['funding', 'donations', 'operations']
 authors: ['default', 'dergigi', 'arvin', 'lucas', 'robos']
 images: ['/static/images/blog/97-opensats-receives-funding-from-the-human-rights-foundation.jpg']
 draft: false

--- a/data/blog/opensats-receives-one-million-from-reynolds-foundation.mdx
+++ b/data/blog/opensats-receives-one-million-from-reynolds-foundation.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'OpenSats Receives $1,000,000 Donation From The Reynolds Foundation'
 date: '2024-04-22'
-tags: ['OpenSats', 'funding', 'bitcoin', 'donations']
+tags: ['funding', 'bitcoin', 'donations']
 authors: ['dergigi', 'default']
 images: ['/static/images/blog/30-reynolds.jpg']
 draft: false

--- a/data/blog/opensats-receives-two-million-donation-from-the-reynolds-foundation.mdx
+++ b/data/blog/opensats-receives-two-million-donation-from-the-reynolds-foundation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OpenSats Receives $2,000,000 Donation From The Reynolds Foundation"
 date: '2025-05-22'
-tags: ['OpenSats', 'funding', 'donations']
+tags: ['funding', 'donations']
 authors: ['default', 'dergigi']
 images: ['/static/images/blog/93-opensats-receives-additional-donation-from-the-reynolds-foundation.jpg']
 draft: false

--- a/data/blog/pablofz7-receives-lts-grant.mdx
+++ b/data/blog/pablofz7-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For PabloF7z'
 date: '2024-04-09'
-tags: ['OpenSats', 'grants', 'nostr', 'LTS']
+tags: ['grants', 'nostr', 'LTS']
 draft: false
 authors: ['arvin', 'dergigi']
 images: ['/static/images/blog/27-pablo-lts.jpg']

--- a/data/blog/recurring-donations-from-bitwise-bitcoin-etf-bitb.mdx
+++ b/data/blog/recurring-donations-from-bitwise-bitcoin-etf-bitb.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'OpenSats to Receive Recurring Donations from Bitwise Bitcoin ETF Profits'
 date: '2024-01-10'
-tags: ['OpenSats', 'funding', 'donations', 'bitcoin']
+tags: ['funding', 'donations', 'bitcoin']
 draft: false
 authors: ['dergigi', 'odell']
 images: ['/static/images/blog/21-bitb.jpg']

--- a/data/blog/rene-pickhardt-receives-lts-grant.mdx
+++ b/data/blog/rene-pickhardt-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For René Pickhardt'
 date: '2024-01-24'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS']
+tags: ['grants', 'bitcoin', 'LTS']
 draft: false
 authors: ['cfunk']
 images: ['/static/images/blog/22-rene.jpg']

--- a/data/blog/renewing-our-commitment-to-bitcoin.mdx
+++ b/data/blog/renewing-our-commitment-to-bitcoin.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Renewing Our Commitment to Bitcoin'
 date: '2024-12-08'
-tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
+tags: ['grants', 'bitcoin', 'wave']
 draft: false
 authors: ['default', 'dergigi', 'arvin', 'btcschellingpt', 'julian']
 images: ['/static/images/blog/64-renewing-our-commitment-to-bitcoin.jpg']

--- a/data/blog/second-wave-of-education-grants.mdx
+++ b/data/blog/second-wave-of-education-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Second Wave of Education Grants'
 date: '2024-09-27'
-tags: ['OpenSats', 'grants', 'bitcoin', 'education', 'wave']
+tags: ['grants', 'bitcoin', 'education', 'wave']
 draft: false
 authors: ['arvin', 'dergigi', 'dread']
 images: ['/static/images/blog/56-second-wave-of-education-grants.jpg']

--- a/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Seventeenth Wave of Bitcoin Grants"
 date: '2026-03-31'
-tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
+tags: ['grants', 'bitcoin', 'wave']
 authors: ['default', 'arvin', 'tuma']
 images: ['/static/images/blog/104-seventeenth-wave-of-bitcoin-grants.jpg']
 draft: false

--- a/data/blog/seventeenth-wave-of-nostr-grants.mdx
+++ b/data/blog/seventeenth-wave-of-nostr-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Seventeenth Wave of Nostr Grants"
 date: '2026-05-20'
-tags: ['OpenSats', 'grants', 'nostr', 'wave']
+tags: ['grants', 'nostr', 'wave']
 authors: ['arvin', 'tuma', 'default']
 images: ['/static/images/blog/108-seventeenth-wave-of-nostr-grants.jpg']
 draft: false

--- a/data/blog/shashwat-vangani-receives-lts-grant.mdx
+++ b/data/blog/shashwat-vangani-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Shashwat Vangani'
 date: '2024-05-02'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS']
+tags: ['grants', 'bitcoin', 'LTS']
 draft: false
 authors: ['btcschellingpt']
 images: ['/static/images/blog/31-shashwat-lts.jpg']

--- a/data/blog/sixteenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/sixteenth-wave-of-bitcoin-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sixteenth Wave of Bitcoin Grants"
 date: '2026-02-04'
-tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
+tags: ['grants', 'bitcoin', 'wave']
 authors: ['default', 'arvin']
 images: ['/static/images/blog/99-sixteenth-wave-of-bitcoin-grants.jpg']
 draft: false

--- a/data/blog/sixteenth-wave-of-nostr-grants.mdx
+++ b/data/blog/sixteenth-wave-of-nostr-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sixteenth Wave of Nostr Grants"
 date: '2026-04-08'
-tags: ['OpenSats', 'grants', 'nostr', 'wave']
+tags: ['grants', 'nostr', 'wave']
 authors: ['default', 'arvin', 'tuma']
 images: ['/static/images/blog/105-sixteenth-wave-of-nostr-grants.jpg']
 draft: false

--- a/data/blog/sjors-provoost-receives-opensats-lts-grant.mdx
+++ b/data/blog/sjors-provoost-receives-opensats-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Sjors Provoost'
 date: '2023-09-08'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS', 'core']
+tags: ['grants', 'bitcoin', 'LTS', 'core']
 draft: false
 authors: ['dergigi']
 images: ['/static/images/blog/07-sjors.jpg']

--- a/data/blog/snowcait-receives-lts-grant.mdx
+++ b/data/blog/snowcait-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For SnowCait'
 date: '2025-06-06'
-tags: ['OpenSats', 'grants', 'nostr', 'LTS']
+tags: ['grants', 'nostr', 'LTS']
 draft: false
 authors: ['default', 'arvin']
 images: ['/static/images/blog/78-long-term-support-for-snowcait.jpg']

--- a/data/blog/stuart-bowman-receives-lts-grant.mdx
+++ b/data/blog/stuart-bowman-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Stuart Bowman'
 date: '2024-04-12'
-tags: ['OpenSats', 'grants', 'nostr', 'LTS']
+tags: ['grants', 'nostr', 'LTS']
 draft: false
 authors: ['arvin', 'dergigi']
 images: ['/static/images/blog/28-stuart-lts.jpg']

--- a/data/blog/tenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/tenth-wave-of-bitcoin-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Tenth Wave of Bitcoin Grants'
 date: '2025-03-14'
-tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
+tags: ['grants', 'bitcoin', 'wave']
 draft: false
 authors: ['default', 'arvin', 'julian']
 images: ['/static/images/blog/71-tenth-wave-of-bitcoin-grants.jpg']

--- a/data/blog/the-libraries-behind-open-communication.mdx
+++ b/data/blog/the-libraries-behind-open-communication.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Libraries Behind Open Communication"
 date: '2026-06-01'
-tags: ['OpenSats', 'nostr', 'impact', 'libraries']
+tags: ['nostr', 'impact', 'libraries']
 authors: ['arvin', 'tuma', 'default']
 images: ['/static/images/blog/109-the-libraries-behind-open-communication.jpg']
 draft: false

--- a/data/blog/thirteenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/thirteenth-wave-of-bitcoin-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Thirteenth Wave of Bitcoin Grants'
 date: '2025-08-11'
-tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
+tags: ['grants', 'bitcoin', 'wave']
 authors: ['default', 'arvin']
 images: ['/static/images/blog/83-thirteenth-wave-of-bitcoin-grants.jpg']
 draft: false

--- a/data/blog/thirteenth-wave-of-nostr-grants.mdx
+++ b/data/blog/thirteenth-wave-of-nostr-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Thirteenth Wave of Nostr Grants'
 date: '2025-11-05'
-tags: ['OpenSats', 'grants', 'nostr', 'wave']
+tags: ['grants', 'nostr', 'wave']
 authors: ['default', 'arvin', 'dergigi']
 images: ['/static/images/blog/87-thirteenth-wave-of-nostr-grants.jpg']
 draft: false

--- a/data/blog/tobin-harding-receives-lts-grant-for-rust-bitcoin.mdx
+++ b/data/blog/tobin-harding-receives-lts-grant-for-rust-bitcoin.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Tobin Harding'
 date: '2023-12-26'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS']
+tags: ['grants', 'bitcoin', 'LTS']
 draft: false
 authors: ['cfunk']
 images: ['/static/images/blog/19-tobin.jpg']

--- a/data/blog/tor-receives-support-grant.mdx
+++ b/data/blog/tor-receives-support-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Strengthening Network Privacy with Tor'
 date: '2024-08-28'
-tags: ['OpenSats', 'grants', 'bitcoin']
+tags: ['grants', 'bitcoin']
 draft: false
 authors: ['arvin', 'dergigi']
 images: ['/static/images/blog/50-support-for-tor.jpg']

--- a/data/blog/twelfth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/twelfth-wave-of-bitcoin-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Twelfth Wave of Bitcoin Grants'
 date: '2025-07-08'
-tags: ['OpenSats', 'grants', 'bitcoin', 'wave']
+tags: ['grants', 'bitcoin', 'wave']
 authors: ['arvin', 'dergigi', 'default']
 images: ['/static/images/blog/81-twelfth-wave-of-bitcoin-grants.jpg']
 draft: false

--- a/data/blog/twelfth-wave-of-nostr-grants.mdx
+++ b/data/blog/twelfth-wave-of-nostr-grants.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Twelfth Wave of Nostr Grants'
 date: '2025-07-01'
-tags: ['OpenSats', 'grants', 'nostr', 'wave']
+tags: ['grants', 'nostr', 'wave']
 authors: ['arvin', 'default']
 images: ['/static/images/blog/80-twelfth-wave-of-nostr-grants.jpg']
 draft: false

--- a/data/blog/vasil-dimov-receives-lts-grant.mdx
+++ b/data/blog/vasil-dimov-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Vasil Dimov'
 date: '2023-10-16'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS', 'core']
+tags: ['grants', 'bitcoin', 'LTS', 'core']
 draft: false
 authors: ['dergigi']
 images: ['/static/images/blog/10-vasil.jpg']

--- a/data/blog/vitor-pamplona-receives-lts-grant.mdx
+++ b/data/blog/vitor-pamplona-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Vitor Pamplona'
 date: '2024-08-19'
-tags: ['OpenSats', 'grants', 'nostr', 'LTS']
+tags: ['grants', 'nostr', 'LTS']
 draft: false
 authors: ['arvin', 'dergigi']
 images: ['/static/images/blog/47-vitor-pamplona.jpg']

--- a/data/blog/will-clark-receives-lts-grant-for-bitcoin-core.mdx
+++ b/data/blog/will-clark-receives-lts-grant-for-bitcoin-core.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Will Clark'
 date: '2023-11-20'
-tags: ['OpenSats', 'grants', 'bitcoin', 'LTS', 'core']
+tags: ['grants', 'bitcoin', 'LTS', 'core']
 draft: false
 authors: ['dergigi']
 images: ['/static/images/blog/16-will-clark.jpg']

--- a/data/blog/yuki-receives-lts-grant.mdx
+++ b/data/blog/yuki-receives-lts-grant.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Long-Term Support For Yuki Kishimoto'
 date: '2024-07-04'
-tags: ['OpenSats', 'grants', 'nostr', 'LTS']
+tags: ['grants', 'nostr', 'LTS']
 draft: false
 authors: ['bayer', 'arvin']
 images: ['/static/images/blog/37-yuki.jpg']

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -237,7 +237,7 @@ export default function Home({
                           {summary}
                         </div>
                       </div>
-                      <div className="text-base font-medium leading-6">
+                      <div className="text-right text-base font-medium leading-6">
                         <Link
                           href={`/blog/${slug}`}
                           className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -225,16 +225,20 @@ export default function Home({
                       </div>
                       <div className="flex items-baseline text-base font-medium leading-6">
                         <div className="hidden flex-wrap items-baseline xl:flex">
-                          {tags.map((tag) => (
-                            <Tag key={tag} text={tag} />
-                          ))}
                           <span className="sr-only">Published on</span>
                           <time
                             dateTime={date}
-                            className="text-sm font-medium text-gray-500 dark:text-gray-400"
+                            className="mr-3 text-sm font-medium text-gray-500 dark:text-gray-400"
                           >
                             {formatDate(date, siteMetadata.locale)}
                           </time>
+                          {tags.map((tag) => (
+                            <Tag
+                              key={tag}
+                              text={tag}
+                              className="mr-3 text-sm font-medium uppercase text-gray-500 hover:text-primary-500 dark:text-gray-400 dark:hover:text-primary-400"
+                            />
+                          ))}
                         </div>
                         <Link
                           href={`/blog/${slug}`}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -261,16 +261,6 @@ export default function Home({
           <NewsletterSignup />
         </div>
       )}
-      <p className="pt-4 text-lg leading-7 text-gray-500 dark:text-gray-400">
-        You can also find us on{' '}
-        <CustomLink
-          href="https://njump.to/npub10pensatlcfwktnvjjw2dtem38n6rvw8g6fv73h84cuacxn4c28eqyfn34f"
-          className="underline"
-        >
-          nostr
-        </CustomLink>
-        .
-      </p>
       {posts.length > MAX_DISPLAY && (
         <div className="flex justify-end pb-8 text-base font-medium leading-6">
           <Link

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -199,9 +199,8 @@ export default function Home({
               <li key={slug} className="py-12">
                 <article>
                   <div className="space-x-4 space-y-4 xl:grid xl:grid-cols-3 xl:items-start xl:space-y-0">
-                    <div className="relative">
-                      <h1 className="sr-only">Published on</h1>
-                      <Link href={`/blog/${slug}`}>
+                    <div>
+                      <Link href={`/blog/${slug}`} className="block">
                         <Image
                           src={images[0]}
                           alt="blog post"
@@ -209,15 +208,22 @@ export default function Home({
                           height={300}
                         />
                       </Link>
-                      <h2 className="absolute left-5 top-3 text-base font-semibold text-white xl:left-2.5 xl:top-1">
-                        <time dateTime={date}>
-                          {formatDate(date, siteMetadata.locale)}
-                        </time>
-                      </h2>
                     </div>
                     <div className="space-y-2 xl:col-span-2">
                       <div className="space-y-4">
                         <div>
+                          <div className="flex flex-wrap items-baseline">
+                            <span className="sr-only">Published on</span>
+                            <time
+                              dateTime={date}
+                              className="mr-3 text-sm font-medium text-gray-500 dark:text-gray-400"
+                            >
+                              {formatDate(date, siteMetadata.locale)}
+                            </time>
+                            {tags.map((tag) => (
+                              <Tag key={tag} text={tag} />
+                            ))}
+                          </div>
                           <h2 className="text-2xl font-bold leading-8 tracking-tight max-[375px]:text-xl">
                             <Link
                               href={`/blog/${slug}`}
@@ -226,11 +232,6 @@ export default function Home({
                               {title}
                             </Link>
                           </h2>
-                          <div className="flex flex-wrap">
-                            {tags.map((tag) => (
-                              <Tag key={tag} text={tag} />
-                            ))}
-                          </div>
                         </div>
                         <div className="prose max-w-none text-gray-500 dark:text-gray-400">
                           {summary}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -198,7 +198,7 @@ export default function Home({
             return (
               <li key={slug} className="py-12">
                 <article>
-                  <div className="space-x-4 space-y-4 xl:grid xl:grid-cols-3 xl:items-start xl:space-y-0">
+                  <div className="space-y-4 xl:grid xl:grid-cols-3 xl:items-start xl:gap-x-4 xl:space-y-0">
                     <div>
                       <Link href={`/blog/${slug}`} className="block">
                         <Image

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -211,36 +211,34 @@ export default function Home({
                     </div>
                     <div className="space-y-2 xl:col-span-2">
                       <div className="space-y-4">
-                        <div>
-                          <div className="hidden flex-wrap items-baseline xl:flex">
-                            <span className="sr-only">Published on</span>
-                            <time
-                              dateTime={date}
-                              className="mr-3 text-sm font-medium text-gray-500 dark:text-gray-400"
-                            >
-                              {formatDate(date, siteMetadata.locale)}
-                            </time>
-                            {tags.map((tag) => (
-                              <Tag key={tag} text={tag} />
-                            ))}
-                          </div>
-                          <h2 className="text-2xl font-bold leading-8 tracking-tight max-[375px]:text-xl">
-                            <Link
-                              href={`/blog/${slug}`}
-                              className="text-gray-900 dark:text-gray-100"
-                            >
-                              {title}
-                            </Link>
-                          </h2>
-                        </div>
+                        <h2 className="text-2xl font-bold leading-8 tracking-tight max-[375px]:text-xl">
+                          <Link
+                            href={`/blog/${slug}`}
+                            className="text-gray-900 dark:text-gray-100"
+                          >
+                            {title}
+                          </Link>
+                        </h2>
                         <div className="prose max-w-none text-gray-500 dark:text-gray-400">
                           {summary}
                         </div>
                       </div>
-                      <div className="text-right text-base font-medium leading-6">
+                      <div className="flex items-baseline text-base font-medium leading-6">
+                        <div className="hidden flex-wrap items-baseline xl:flex">
+                          <span className="sr-only">Published on</span>
+                          <time
+                            dateTime={date}
+                            className="mr-3 text-sm font-medium text-gray-500 dark:text-gray-400"
+                          >
+                            {formatDate(date, siteMetadata.locale)}
+                          </time>
+                          {tags.map((tag) => (
+                            <Tag key={tag} text={tag} />
+                          ))}
+                        </div>
                         <Link
                           href={`/blog/${slug}`}
-                          className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+                          className="ml-auto text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
                           aria-label={`Read "${title}"`}
                         >
                           Read more &rarr;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -237,7 +237,7 @@ export default function Home({
                           {summary}
                         </div>
                       </div>
-                      <div className="hidden text-base font-medium leading-6 md:block">
+                      <div className="text-base font-medium leading-6">
                         <Link
                           href={`/blog/${slug}`}
                           className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -212,7 +212,7 @@ export default function Home({
                     <div className="space-y-2 xl:col-span-2">
                       <div className="space-y-4">
                         <div>
-                          <div className="flex flex-wrap items-baseline">
+                          <div className="hidden flex-wrap items-baseline xl:flex">
                             <span className="sr-only">Published on</span>
                             <time
                               dateTime={date}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -225,16 +225,16 @@ export default function Home({
                       </div>
                       <div className="flex items-baseline text-base font-medium leading-6">
                         <div className="hidden flex-wrap items-baseline xl:flex">
-                          <span className="sr-only">Published on</span>
-                          <time
-                            dateTime={date}
-                            className="mr-3 text-sm font-medium text-gray-500 dark:text-gray-400"
-                          >
-                            {formatDate(date, siteMetadata.locale)}
-                          </time>
                           {tags.map((tag) => (
                             <Tag key={tag} text={tag} />
                           ))}
+                          <span className="sr-only">Published on</span>
+                          <time
+                            dateTime={date}
+                            className="text-sm font-medium text-gray-500 dark:text-gray-400"
+                          >
+                            {formatDate(date, siteMetadata.locale)}
+                          </time>
                         </div>
                         <Link
                           href={`/blog/${slug}`}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -228,10 +228,16 @@ export default function Home({
                           <span className="sr-only">Published on</span>
                           <time
                             dateTime={date}
-                            className="mr-3 text-sm font-medium text-gray-500 dark:text-gray-400"
+                            className="text-sm font-medium text-gray-500 dark:text-gray-400"
                           >
                             {formatDate(date, siteMetadata.locale)}
                           </time>
+                          <span
+                            aria-hidden
+                            className="mx-3 text-sm font-medium text-gray-500 dark:text-gray-400"
+                          >
+                            &middot;
+                          </span>
                           {tags.map((tag) => (
                             <Tag
                               key={tag}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -182,7 +182,7 @@ export default function Home({
           </div>
         </div>
       </div>
-      <div className="divide-y divide-gray-200 dark:divide-gray-700">
+      <div>
         <div className="space-y-2 pb-2 pt-8 md:space-y-5 xl:pt-12">
           <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 max-[375px]:text-2xl sm:text-3xl sm:leading-10 md:text-5xl md:leading-14 lg:text-6xl">
             Stay Updated
@@ -191,7 +191,7 @@ export default function Home({
             Read the latest news from OpenSats:
           </p>
         </div>
-        <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+        <ul>
           {!posts.length && 'No posts found.'}
           {posts.slice(0, MAX_DISPLAY).map((post) => {
             const { slug, date, title, summary, tags, images } = post


### PR DESCRIPTION
This reworks the homepage `Stay Updated` blog list to fix the unreadable white date that was overlaid on the top-left of light cover images (OpenSats/content#120). The date and tags now live in a clean footer row beneath each post, and the redundant `OpenSats` tag is dropped from every blog post since every post is already an OpenSats post.

- moves the date and tags into a footer line (`date · muted tags`) with a right-aligned `Read more` link, shown only in the desktop grid layout
- removes the `OpenSats` tag from all blog posts and drops the separators from the `Stay Updated` list
- fixes mobile alignment, shows `Read more` on mobile, corrects the Cody Tseng spotlight summary, and removes the "find us on nostr" line

Build preview:
- [/](https://os-website-git-fix-header-date-overlay-readability-opensats.vercel.app/)
