### PR TITLE
Add Mainnet topic page

### DIFF
--- a/data/topics/mainnet.mdx
+++ b/data/topics/mainnet.mdx
@@ -14,5 +14,5 @@ That is why wallet software, node software, and protocol changes are treated mor
 ## References
 
 - [Bitcoin Stack Exchange: What is the difference between the testnet and the mainnet?](https://bitcoin.stackexchange.com/questions/75800/what-is-the-difference-between-the-testnet-and-the-mainnet)
-- [Bitcoin Treasuries glossary: Mainnet](https://bitcointreasuries.net/glossary/mainnet)
-- [Lightspark glossary: Mainnet](https://www.lightspark.com/glossary/mainnet)
+- [Bitcoin Optech: Testnet](https://bitcoinops.org/en/topics/testnet/)
+- [Bitcoin Optech: Signet](https://bitcoinops.org/en/topics/signet/)

--- a/data/topics/mainnet.mdx
+++ b/data/topics/mainnet.mdx
@@ -1,0 +1,18 @@
+---
+title: 'Mainnet'
+summary: 'Bitcoin’s live production network, where transactions move real bitcoin under real economic incentives.'
+category: 'Bitcoin'
+aliases: ['Bitcoin mainnet', 'main chain', 'main network']
+---
+
+Mainnet is Bitcoin’s live production network. It is the chain people usually mean when they say `Bitcoin`, and the coins on it carry real value. Every on-chain payment, fee market decision, and confirmation target that matters economically happens on mainnet.
+
+Developers usually test new software on [Testnet](/topics/testnet) or [Signet](/topics/signet) before shipping to mainnet. Those networks use separate coins and tolerate more breakage. A mistake on mainnet can lock funds, leak privacy, or create irreversible losses for users.
+
+That is why wallet software, node software, and protocol changes are treated more conservatively on mainnet. Real users, real counterparties, and real fees force software to behave under adversarial conditions instead of lab assumptions.
+
+## References
+
+- [Bitcoin Stack Exchange: What is the difference between the testnet and the mainnet?](https://bitcoin.stackexchange.com/questions/75800/what-is-the-difference-between-the-testnet-and-the-mainnet)
+- [Bitcoin Treasuries glossary: Mainnet](https://bitcointreasuries.net/glossary/mainnet)
+- [Lightspark glossary: Mainnet](https://www.lightspark.com/glossary/mainnet)


### PR DESCRIPTION
Adds a `mainnet` topic page to the topics section. The page explains that mainnet is Bitcoin's live production network, why real economic incentives change the operating environment, and why new software is usually tested on `testnet` or `signet` first.

- Adds `data/topics/mainnet.mdx` covering mainnet as Bitcoin's live chain and the risks of shipping directly to it
- Positions `mainnet` in relation to the existing `testnet` and `signet` topic pages
- References Bitcoin Stack Exchange plus Bitcoin Optech's `testnet` and `signet` topic pages for background context

Closes OpenSats/content#250

---

Build preview:
- [/topics/mainnet](https://os-website-git-content-add-mainnet-topic-page-250-opensats.vercel.app/topics/mainnet)
