### PR TITLE
Add CPFP topic page

### DIFF
--- a/data/topics/cpfp.mdx
+++ b/data/topics/cpfp.mdx
@@ -1,0 +1,16 @@
+---
+title: 'CPFP'
+summary: 'A Bitcoin fee-bumping technique where a high-fee child transaction helps confirm a low-fee parent.'
+category: 'Bitcoin'
+aliases: ['Child Pays for Parent', 'child-pays-for-parent']
+---
+
+CPFP, short for Child Pays for Parent, is a Bitcoin fee-bumping technique. A user spends an output from an unconfirmed low-fee transaction in a new child transaction with a higher feerate. Miners that evaluate the pair together can profit by confirming both transactions, so the expensive child helps pull the parent into a block.
+
+Wallets use CPFP when the original fee is too low for current [mempool](/topics/mempool) conditions and the spender of an output from that transaction can create the child. That can help either the sender or the receiver accelerate confirmation, depending on who controls a spendable output.
+
+CPFP depends on relay and mining policy rather than consensus alone. Nodes and miners need to accept the low-fee parent and consider the package's combined economics. Proposed improvements such as [package relay](/topics/package-relay) aim to make CPFP more reliable when fee pressure is high.
+
+## References
+
+- [Bitcoin Optech: Child pays for parent (CPFP)](https://bitcoinops.org/en/topics/cpfp/)


### PR DESCRIPTION
Adds a CPFP topic page to the topics section. The page explains how a high-fee child transaction can help confirm a low-fee parent transaction and why the technique depends on node and miner policy during fee pressure.

- Adds `data/topics/cpfp.mdx` covering how `CPFP` works, who can use it, and why it matters when mempool conditions change
- Cross-links the new page from the existing `mempool` and `package relay` topic pages
- References Bitcoin Optech for the canonical background explainer

Closes OpenSats/website#844

---

Build preview:
- [/topics/cpfp](https://os-website-git-content-add-cpfp-topic-page-844-opensats.vercel.app/topics/cpfp)
