### PR TITLE
Make Nostr project pages use the purple theme

### DIFF
--- a/components/social-icons/index.tsx
+++ b/components/social-icons/index.tsx
@@ -43,7 +43,7 @@ const SocialIcon = ({ kind, href, size = 8 }) => {
     >
       <span className="sr-only">{kind}</span>
       <SocialSvg
-        className={`fill-current text-gray-700 hover:text-orange-500 dark:text-gray-200 dark:hover:text-orange-400 h-${size} w-${size}`}
+        className={`fill-current text-gray-700 hover:text-primary-600 dark:text-gray-200 dark:hover:text-primary-400 h-${size} w-${size}`}
       />
     </a>
   )

--- a/pages/projects/[...slug].tsx
+++ b/pages/projects/[...slug].tsx
@@ -33,6 +33,7 @@ export const getStaticProps = async ({ params }) => {
     props: {
       project,
       relatedPosts: allCoreContent(relatedPosts),
+      pageTheme: project?.fund === 'nostr' ? 'nostr' : 'default',
     },
   }
 }


### PR DESCRIPTION
This makes Nostr-funded project pages use the existing `nostr` theme so their accents render purple instead of orange.

- sets `pageTheme` from each project's `fund`
- switches project social icon hover colors to theme-aware `primary` classes

Closes OpenSats/content#253

---

Build preview:
- [/projects/coracle](https://os-website-6u58rjc7n-opensats.vercel.app/projects/coracle)
