### PR TITLE
Split project grant announcements from further reading

### DIFF
--- a/data/blog/2023-year-in-review.mdx
+++ b/data/blog/2023-year-in-review.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OpenSats' 2023 Year in Review"
 date: '2023-12-31'
-tags: ['grants', 'donations', 'bitcoin', 'nostr', 'review']
+tags: ['donations', 'bitcoin', 'nostr', 'review']
 draft: false
 authors: ['dergigi', 'eiaine']
 images: ['/static/images/blog/20-eoy.jpg']

--- a/data/blog/2024-year-in-review.mdx
+++ b/data/blog/2024-year-in-review.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OpenSats' 2024 Year in Review"
 date: '2024-12-30'
-tags: ['grants', 'donations', 'bitcoin', 'nostr', 'review']
+tags: ['donations', 'bitcoin', 'nostr', 'review']
 draft: false
 authors: ['dergigi', 'default']
 images: ['/static/images/blog/66-opensats-2024-year-in-review.jpg']

--- a/data/blog/2025-year-in-review.mdx
+++ b/data/blog/2025-year-in-review.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OpenSats' 2025 Year in Review"
 date: '2026-01-28'
-tags: ['grants', 'donations', 'bitcoin', 'nostr', 'review']
+tags: ['donations', 'bitcoin', 'nostr', 'review']
 draft: false
 authors: ['dergigi', 'default']
 images: ['/static/images/blog/98-2025-year-in-review.jpg']

--- a/pages/projects/[...slug].tsx
+++ b/pages/projects/[...slug].tsx
@@ -41,6 +41,13 @@ export default function ProjectPage({
   project,
   relatedPosts,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
+  const grantAnnouncements = relatedPosts.filter((post) =>
+    (post.tags || []).some((tag) => tag.toLowerCase() === 'grants')
+  )
+  const furtherReading = relatedPosts.filter(
+    (post) => !(post.tags || []).some((tag) => tag.toLowerCase() === 'grants')
+  )
+
   return (
     <>
       <MDXLayoutRenderer
@@ -89,9 +96,27 @@ export default function ProjectPage({
           )}
         </aside>
       </div>
-      {relatedPosts.length > 0 && (
+      {grantAnnouncements.length > 0 && (
         <section
           id="announcements"
+          className="mt-12 divide-y divide-gray-200 dark:divide-gray-700"
+        >
+          <div className="items-start space-y-2 xl:grid xl:grid-cols-3 xl:gap-x-8 xl:space-y-0">
+            <div></div>
+            <h2 className="pb-8 text-3xl font-bold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl sm:leading-10 md:text-5xl md:leading-14 xl:col-span-2">
+              Grant Announcements
+            </h2>
+          </div>
+          <PostList
+            posts={grantAnnouncements}
+            rightAlignDate
+            useProjectLayout
+          />
+        </section>
+      )}
+      {furtherReading.length > 0 && (
+        <section
+          id="further-reading"
           className="mt-12 divide-y divide-gray-200 dark:divide-gray-700"
         >
           <div className="items-start space-y-2 xl:grid xl:grid-cols-3 xl:gap-x-8 xl:space-y-0">
@@ -100,7 +125,7 @@ export default function ProjectPage({
               Further Reading
             </h2>
           </div>
-          <PostList posts={relatedPosts} rightAlignDate useProjectLayout />
+          <PostList posts={furtherReading} rightAlignDate useProjectLayout />
         </section>
       )}
     </>


### PR DESCRIPTION
This splits project-page related posts into `Grant Announcements` for `grants` posts and `Further Reading` for everything else.

- keeps the existing related-post matching logic
- drops the `grants` tag from the year-in-review posts so they stay in `Further Reading`
- only renders a section when it has entries

Closes OpenSats/content#252

---

Build preview:
- [/projects/coracle](https://os-website-f7wpua2sl-opensats.vercel.app/projects/coracle)
