### PR TITLE
Add FAQ entry on grant amount disclosure

### DIFF
--- a/data/pages/faq.mdx
+++ b/data/pages/faq.mdx
@@ -10,6 +10,7 @@ Frequently asked questions:
 - [What are you doing at OpenSats?](#what-are-you-doing-at-opensats)
 - [Why the name OpenSats?](#why-the-name-opensats)
 - [How are funds distributed?](#how-are-funds-distributed)
+- [Do you disclose grant amounts publicly?](#do-you-disclose-grant-amounts-publicly)
 - [How much of my donation goes towards open-source contributors?](#how-much-of-my-donation-goes-towards-open-source-contributors)
 - [How can I donate to OpenSats?](#how-can-i-donate-to-opensats)
 - [Do you distribute grants in bitcoin or fiat?](#do-you-distribute-grants-in-bitcoin-or-fiat)
@@ -56,6 +57,17 @@ impact projects in the Bitcoin space.
 
 You can find a list of past and active grantees, as well as links to our reports
 at our [transparency](/transparency) section.
+
+## Do you disclose grant amounts publicly?
+
+We do not usually disclose individual grant amounts publicly.
+
+We support grantees in [more than 40 countries](/map), and some grantees ask
+us not to disclose detailed amounts because doing so could endanger them or
+their families. We take the privacy and security of our grantees seriously.
+
+Please refer to our [transparency](/transparency) page for detailed financial
+reports.
 
 ## How much of my donation goes towards open-source contributors?
 


### PR DESCRIPTION
This adds a FAQ entry explaining why OpenSats does not usually disclose individual grant amounts publicly and points readers to the relevant financial reporting.

- adds the new question to the FAQ index and page body
- links to `/map` for geographic context and `/transparency` for financial reports

Closes https://github.com/OpenSats/content/issues/255

---

Build preview:
- [/faq#do-you-disclose-grant-amounts-publicly](https://os-website-lkccnegsa-opensats.vercel.app/faq#do-you-disclose-grant-amounts-publicly)
