### PR TITLE
Add back to projects link on project pages

### DIFF
--- a/components/BackToProjects.tsx
+++ b/components/BackToProjects.tsx
@@ -6,7 +6,7 @@ const BackToProjects = () => {
       <Link
         href="/projects"
         aria-label="Back to projects"
-        className="text-primary"
+        className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
       >
         &larr; Back to projects
       </Link>

--- a/pages/projects/[...slug].tsx
+++ b/pages/projects/[...slug].tsx
@@ -7,6 +7,7 @@ import type { Blog } from 'contentlayer/generated'
 import { PageActionLink } from '@/components/PageAction'
 import { getRelatedBlogPostsForProject } from '@/utils/relatedPosts'
 import PostList from '@/components/PostList'
+import BackToProjects from '@/components/BackToProjects'
 import { getFundDonationUrl, getFundLabel } from '@/utils/funds'
 import { getHeartbeatUrl } from '@/utils/heartbeat'
 import { faHeartPulse } from '@fortawesome/free-solid-svg-icons'
@@ -129,6 +130,14 @@ export default function ProjectPage({
           <PostList posts={furtherReading} rightAlignDate useProjectLayout />
         </section>
       )}
+      <footer className="pt-8 text-base font-medium leading-6">
+        <div className="items-start space-y-2 xl:grid xl:grid-cols-3 xl:gap-x-8 xl:space-y-0">
+          <div></div>
+          <div className="xl:col-span-2">
+            <BackToProjects />
+          </div>
+        </div>
+      </footer>
     </>
   )
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -101,6 +101,10 @@ module.exports = {
               color: theme('colors.gray.900'),
               borderLeftColor: theme('colors.gray.200'),
             },
+            // MDX wraps multi-line <cite> content in a paragraph, which would
+            // otherwise receive the auto-generated quotation marks
+            'blockquote cite p::before': { content: 'none' },
+            'blockquote cite p::after': { content: 'none' },
           },
         },
         dark: {


### PR DESCRIPTION
Project pages had no way to navigate back to the projects overview. This wires up the existing `BackToProjects` component, which was sitting unused in the codebase, as a footer link on project pages. It mirrors the "Back to the blog" link on blog posts and picks up the fund theme color via the `text-primary-500` classes. Also fixes blockquote attributions getting wrapped in auto-generated quotation marks.

- Render `BackToProjects` at the bottom of `pages/projects/[...slug].tsx`
- Update its styling so it follows the theme color and hover pattern used elsewhere
- Disable Tailwind Typography's auto quotes for paragraphs inside `<cite>`, which MDX produces for multi-line cite blocks

---

Build preview:
- [/projects/amber](https://os-website-git-project-page-back-button-opensats.vercel.app/projects/amber)
