### PR TITLE
Add total sats sent to general fund projects

### DIFF
--- a/data/pages/transparency.mdx
+++ b/data/pages/transparency.mdx
@@ -12,6 +12,10 @@ transparency, openness, as well as conversing and working in public.
 
 <LifetimeStats />
 
+<small>All numbers are approximate. The sats shown here and on individual
+project pages are past payouts, not balances. Grantees use the funds to do
+the work we support them for, which is to say: the money is spent.</small>
+
 By adhering to these principles, we aim to demonstrate our commitment to
 responsible bitcoin treasury management, good corporate citizenship, and the long-term
 sustainability of our organization.

--- a/data/pages/transparency.mdx
+++ b/data/pages/transparency.mdx
@@ -12,10 +12,6 @@ transparency, openness, as well as conversing and working in public.
 
 <LifetimeStats />
 
-<small>All numbers are approximate. The sats shown here and on individual
-project pages are past payouts, not balances. Grantees use the funds to do
-the work we support them for, which is to say: the money is spent.</small>
-
 By adhering to these principles, we aim to demonstrate our commitment to
 responsible bitcoin treasury management, good corporate citizenship, and the long-term
 sustainability of our organization.

--- a/data/projects/0xchat.mdx
+++ b/data/projects/0xchat.mdx
@@ -11,7 +11,7 @@ nostr: 'npub10td4yrp6cl9kmjp9x5yd7r8pm96a5j07lk5mtj2kw39qf8frpt8qm9x2wl'
 zapstore: 'https://zapstore.dev/apps/com.oxchat.nostr'
 tags: ['Nostr', 'Mobile', 'iOS', 'Android', 'Desktop']
 fund: nostr
-totalSatsSent: 457899253
+totalSatsSent: 457899204
 announcementLink: '/blog/nostr-grants-october-2023#0xchat'
 ---
 

--- a/data/projects/0xchat.mdx
+++ b/data/projects/0xchat.mdx
@@ -11,7 +11,7 @@ nostr: 'npub10td4yrp6cl9kmjp9x5yd7r8pm96a5j07lk5mtj2kw39qf8frpt8qm9x2wl'
 zapstore: 'https://zapstore.dev/apps/com.oxchat.nostr'
 tags: ['Nostr', 'Mobile', 'iOS', 'Android', 'Desktop']
 fund: nostr
-totalSatsSent: 457899187
+totalSatsSent: 457899253
 announcementLink: '/blog/nostr-grants-october-2023#0xchat'
 ---
 

--- a/data/projects/amber.mdx
+++ b/data/projects/amber.mdx
@@ -10,7 +10,7 @@ nostr: 'npub1w4uswmv6lu9yel005l3qgheysmr7tk9uvwluddznju3nuxalevvs2d0jr5'
 zapstore: 'https://zapstore.dev/apps/com.greenart7c3.nostrsigner'
 tags: ['Nostr', 'Signing', 'Mobile', 'Android']
 fund: nostr
-totalSatsSent: 88358977
+totalSatsSent: 88359103
 announcementLink: '/blog/greenart7c3-receives-lts-grant'
 ---
 

--- a/data/projects/amber.mdx
+++ b/data/projects/amber.mdx
@@ -10,7 +10,7 @@ nostr: 'npub1w4uswmv6lu9yel005l3qgheysmr7tk9uvwluddznju3nuxalevvs2d0jr5'
 zapstore: 'https://zapstore.dev/apps/com.greenart7c3.nostrsigner'
 tags: ['Nostr', 'Signing', 'Mobile', 'Android']
 fund: nostr
-totalSatsSent: 88359103
+totalSatsSent: 88358968
 announcementLink: '/blog/greenart7c3-receives-lts-grant'
 ---
 

--- a/data/projects/amethyst.mdx
+++ b/data/projects/amethyst.mdx
@@ -12,7 +12,7 @@ zapstore: 'https://zapstore.dev/apps/com.vitorpamplona.amethyst'
 tags: ['Nostr', 'Mobile', 'Android', 'Desktop']
 showcase: true
 fund: nostr
-totalSatsSent: 318869081
+totalSatsSent: 318868973
 announcementLink: '/blog/nostr-grants-july-2023#amethyst'
 ---
 

--- a/data/projects/amethyst.mdx
+++ b/data/projects/amethyst.mdx
@@ -12,7 +12,7 @@ zapstore: 'https://zapstore.dev/apps/com.vitorpamplona.amethyst'
 tags: ['Nostr', 'Mobile', 'Android', 'Desktop']
 showcase: true
 fund: nostr
-totalSatsSent: 318868973
+totalSatsSent: 318869029
 announcementLink: '/blog/nostr-grants-july-2023#amethyst'
 ---
 

--- a/data/projects/applesauce.mdx
+++ b/data/projects/applesauce.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/applesauce.png'
 git: 'https://github.com/hzrd149/applesauce'
 tags: ['Nostr', 'TypeScript', 'Library', 'SDK']
 fund: nostr
-totalSatsSent: 291347487
+totalSatsSent: 291347524
 announcementLink: '/blog/hzrd149-receives-lts-grant'
 ---
 

--- a/data/projects/applesauce.mdx
+++ b/data/projects/applesauce.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/applesauce.png'
 git: 'https://github.com/hzrd149/applesauce'
 tags: ['Nostr', 'TypeScript', 'Library', 'SDK']
 fund: nostr
-totalSatsSent: 291347524
+totalSatsSent: 291347550
 announcementLink: '/blog/hzrd149-receives-lts-grant'
 ---
 

--- a/data/projects/asmap.mdx
+++ b/data/projects/asmap.mdx
@@ -9,6 +9,7 @@ darkCoverImage: '/static/images/projects/asmap-dark.png'
 git: 'https://github.com/asmap/kartograf'
 tags: ['Bitcoin', 'Security', 'Networking']
 fund: general
+totalSatsSent: 128871648
 announcementLink: '/blog/bitcoin-grants-september-2024-7th-wave#asmap'
 ---
 

--- a/data/projects/asmap.mdx
+++ b/data/projects/asmap.mdx
@@ -9,7 +9,7 @@ darkCoverImage: '/static/images/projects/asmap-dark.png'
 git: 'https://github.com/asmap/kartograf'
 tags: ['Bitcoin', 'Security', 'Networking']
 fund: general
-totalSatsSent: 128871571
+totalSatsSent: 128871586
 announcementLink: '/blog/bitcoin-grants-september-2024-7th-wave#asmap'
 ---
 

--- a/data/projects/asmap.mdx
+++ b/data/projects/asmap.mdx
@@ -9,7 +9,7 @@ darkCoverImage: '/static/images/projects/asmap-dark.png'
 git: 'https://github.com/asmap/kartograf'
 tags: ['Bitcoin', 'Security', 'Networking']
 fund: general
-totalSatsSent: 128871648
+totalSatsSent: 128871571
 announcementLink: '/blog/bitcoin-grants-september-2024-7th-wave#asmap'
 ---
 

--- a/data/projects/bdk.mdx
+++ b/data/projects/bdk.mdx
@@ -34,7 +34,9 @@ environments via WebAssembly.
 > building secure, modern bitcoin apps and services. [...] If there is a bitcoin
 > project you want to see in the world, BDK will help you build it.
 >
-> <cite>—[Steve Myers](/blog/advancements-in-developer-libraries#bitcoin-dev-kit)</cite>
+> <cite>
+>   —[Steve Myers](/blog/advancements-in-developer-libraries#bitcoin-dev-kit)
+> </cite>
 
 BDK reached its 1.0 release in December 2024 after a full redesign that
 stabilized the API under semantic versioning, and has since shipped 2.0 and
@@ -81,4 +83,3 @@ progress, see the
 [Advancements in Developer Libraries](/blog/advancements-in-developer-libraries#bitcoin-dev-kit)
 impact report. Or keep an eye out for updates on the
 [BDK blog](https://bitcoindevkit.org/blog/).
-

--- a/data/projects/bdk.mdx
+++ b/data/projects/bdk.mdx
@@ -10,6 +10,7 @@ twitter: 'bitcoindevkit'
 tags: ['Bitcoin', 'Library']
 showcase: true
 fund: general
+totalSatsSent: 1266201077
 announcementLink: '/blog/bitcoin-and-nostr-grants-august-2023#bdk'
 ---
 

--- a/data/projects/bdk.mdx
+++ b/data/projects/bdk.mdx
@@ -10,7 +10,7 @@ twitter: 'bitcoindevkit'
 tags: ['Bitcoin', 'Library']
 showcase: true
 fund: general
-totalSatsSent: 1266201077
+totalSatsSent: 1266200941
 announcementLink: '/blog/bitcoin-and-nostr-grants-august-2023#bdk'
 ---
 

--- a/data/projects/bdk.mdx
+++ b/data/projects/bdk.mdx
@@ -10,7 +10,7 @@ twitter: 'bitcoindevkit'
 tags: ['Bitcoin', 'Library']
 showcase: true
 fund: general
-totalSatsSent: 1266200941
+totalSatsSent: 1266201245
 announcementLink: '/blog/bitcoin-and-nostr-grants-august-2023#bdk'
 ---
 

--- a/data/projects/bitaxe.mdx
+++ b/data/projects/bitaxe.mdx
@@ -21,7 +21,9 @@ The [organization page][org] is the entry point, where each device has its own d
 
 > My best estimates put the number of Bitaxe units sold to date at over 100,000. Self-sovereign, private miners have solo mined at least six blocks.
 >
-> <cite>[skot](/blog/open-hardware-for-open-money#bitaxe), Bitaxe project lead</cite>
+> <cite>
+>   [skot](/blog/open-hardware-for-open-money#bitaxe), Bitaxe project lead
+> </cite>
 
 ## Why fund it?
 

--- a/data/projects/bitaxe.mdx
+++ b/data/projects/bitaxe.mdx
@@ -11,7 +11,7 @@ containCoverImage: true
 git: 'https://github.com/bitaxeorg'
 tags: ['Bitcoin', 'Mining', 'Hardware']
 fund: general
-totalSatsSent: 257477406
+totalSatsSent: 257477291
 announcementLink: '/blog/bitcoin-grants-feb-2024#the-bitaxe'
 ---
 

--- a/data/projects/bitaxe.mdx
+++ b/data/projects/bitaxe.mdx
@@ -11,7 +11,7 @@ containCoverImage: true
 git: 'https://github.com/bitaxeorg'
 tags: ['Bitcoin', 'Mining', 'Hardware']
 fund: general
-totalSatsSent: 257477291
+totalSatsSent: 257477456
 announcementLink: '/blog/bitcoin-grants-feb-2024#the-bitaxe'
 ---
 

--- a/data/projects/bitaxe.mdx
+++ b/data/projects/bitaxe.mdx
@@ -11,6 +11,7 @@ containCoverImage: true
 git: 'https://github.com/bitaxeorg'
 tags: ['Bitcoin', 'Mining', 'Hardware']
 fund: general
+totalSatsSent: 257477406
 announcementLink: '/blog/bitcoin-grants-feb-2024#the-bitaxe'
 ---
 

--- a/data/projects/bitcoin-core.mdx
+++ b/data/projects/bitcoin-core.mdx
@@ -10,6 +10,7 @@ twitter: 'bitcoincoreorg'
 tags: ['Bitcoin']
 showcase: true
 fund: general
+totalSatsSent: 4129267505
 announcementLink: '/blog/announcing-lts-grant-program-to-support-bitcoin-core-contributors'
 ---
 

--- a/data/projects/bitcoin-core.mdx
+++ b/data/projects/bitcoin-core.mdx
@@ -10,7 +10,7 @@ twitter: 'bitcoincoreorg'
 tags: ['Bitcoin']
 showcase: true
 fund: general
-totalSatsSent: 4129267817
+totalSatsSent: 3938619594
 announcementLink: '/blog/announcing-lts-grant-program-to-support-bitcoin-core-contributors'
 ---
 

--- a/data/projects/bitcoin-core.mdx
+++ b/data/projects/bitcoin-core.mdx
@@ -10,7 +10,7 @@ twitter: 'bitcoincoreorg'
 tags: ['Bitcoin']
 showcase: true
 fund: general
-totalSatsSent: 4129267505
+totalSatsSent: 4129267817
 announcementLink: '/blog/announcing-lts-grant-program-to-support-bitcoin-core-contributors'
 ---
 

--- a/data/projects/bitcoindesign.mdx
+++ b/data/projects/bitcoindesign.mdx
@@ -13,6 +13,7 @@ twitter: 'bitcoin_design'
 personalTwitter: 'GBKS'
 tags: ['Bitcoin', 'Design', 'UX']
 fund: general
+totalSatsSent: 190648124
 announcementLink: '/blog/bitcoin-grants-december-2023#bitcoin-core-app'
 ---
 

--- a/data/projects/bitcoinfuzz.mdx
+++ b/data/projects/bitcoinfuzz.mdx
@@ -8,6 +8,7 @@ coverImage: '/static/images/projects/bitcoinfuzz.png'
 git: 'https://github.com/bitcoinfuzz/bitcoinfuzz'
 tags: ['Bitcoin', 'Core']
 fund: general
+totalSatsSent: 335221067
 announcementLink: '/blog/bruno-garcia-receives-lts-grant'
 ---
 

--- a/data/projects/bitcoinfuzz.mdx
+++ b/data/projects/bitcoinfuzz.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/bitcoinfuzz.png'
 git: 'https://github.com/bitcoinfuzz/bitcoinfuzz'
 tags: ['Bitcoin', 'Core']
 fund: general
-totalSatsSent: 335221067
+totalSatsSent: 335221141
 announcementLink: '/blog/bruno-garcia-receives-lts-grant'
 ---
 

--- a/data/projects/bitcoinfuzz.mdx
+++ b/data/projects/bitcoinfuzz.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/bitcoinfuzz.png'
 git: 'https://github.com/bitcoinfuzz/bitcoinfuzz'
 tags: ['Bitcoin', 'Core']
 fund: general
-totalSatsSent: 335221141
+totalSatsSent: 335220951
 announcementLink: '/blog/bruno-garcia-receives-lts-grant'
 ---
 

--- a/data/projects/bitcoinresearchkit.mdx
+++ b/data/projects/bitcoinresearchkit.mdx
@@ -8,6 +8,7 @@ coverImage: '/static/images/projects/bitcoinresearchkit.svg'
 git: 'https://github.com/bitcoinresearchkit/brk'
 tags: ['Bitcoin', 'Research', 'Infrastructure']
 fund: general
+totalSatsSent: 84296002
 announcementLink: '/blog/twelfth-wave-of-bitcoin-grants#bitcoin-research-kit'
 ---
 

--- a/data/projects/bitcoinresearchkit.mdx
+++ b/data/projects/bitcoinresearchkit.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/bitcoinresearchkit.svg'
 git: 'https://github.com/bitcoinresearchkit/brk'
 tags: ['Bitcoin', 'Research', 'Infrastructure']
 fund: general
-totalSatsSent: 84296002
+totalSatsSent: 84295928
 announcementLink: '/blog/twelfth-wave-of-bitcoin-grants#bitcoin-research-kit'
 ---
 

--- a/data/projects/bitcoinresearchkit.mdx
+++ b/data/projects/bitcoinresearchkit.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/bitcoinresearchkit.svg'
 git: 'https://github.com/bitcoinresearchkit/brk'
 tags: ['Bitcoin', 'Research', 'Infrastructure']
 fund: general
-totalSatsSent: 84295928
+totalSatsSent: 84296023
 announcementLink: '/blog/twelfth-wave-of-bitcoin-grants#bitcoin-research-kit'
 ---
 

--- a/data/projects/bitshala.mdx
+++ b/data/projects/bitshala.mdx
@@ -9,6 +9,7 @@ invertDarkImage: true
 git: 'https://github.com/Bitshala'
 tags: ['Bitcoin', 'Education']
 fund: general
+totalSatsSent: 448454699
 announcementLink: '/blog/let-a-thousand-flowers-bloom#bitshala'
 ---
 

--- a/data/projects/bitshala.mdx
+++ b/data/projects/bitshala.mdx
@@ -9,7 +9,7 @@ invertDarkImage: true
 git: 'https://github.com/Bitshala'
 tags: ['Bitcoin', 'Education']
 fund: general
-totalSatsSent: 448454699
+totalSatsSent: 448454766
 announcementLink: '/blog/let-a-thousand-flowers-bloom#bitshala'
 ---
 

--- a/data/projects/bitshala.mdx
+++ b/data/projects/bitshala.mdx
@@ -9,7 +9,7 @@ invertDarkImage: true
 git: 'https://github.com/Bitshala'
 tags: ['Bitcoin', 'Education']
 fund: general
-totalSatsSent: 448454766
+totalSatsSent: 448454702
 announcementLink: '/blog/let-a-thousand-flowers-bloom#bitshala'
 ---
 

--- a/data/projects/blitz-wallet.mdx
+++ b/data/projects/blitz-wallet.mdx
@@ -11,7 +11,7 @@ nostr: 'npub14l69mauhjyu9j8pgmhj04vjqauzq43ch9yp9g2yx9j9tc4n8xh8s5l9dz2'
 zapstore: 'https://zapstore.dev/apps/com.blitzwallet'
 tags: ['Bitcoin', 'Lightning', 'Wallet']
 fund: general
-totalSatsSent: 153818232
+totalSatsSent: 153818259
 announcementLink: '/blog/bitcoin-grants-july-2024-6th-wave#blitz-wallet'
 ---
 

--- a/data/projects/blitz-wallet.mdx
+++ b/data/projects/blitz-wallet.mdx
@@ -11,7 +11,7 @@ nostr: 'npub14l69mauhjyu9j8pgmhj04vjqauzq43ch9yp9g2yx9j9tc4n8xh8s5l9dz2'
 zapstore: 'https://zapstore.dev/apps/com.blitzwallet'
 tags: ['Bitcoin', 'Lightning', 'Wallet']
 fund: general
-totalSatsSent: 153818259
+totalSatsSent: 153818413
 announcementLink: '/blog/bitcoin-grants-july-2024-6th-wave#blitz-wallet'
 ---
 

--- a/data/projects/blitz-wallet.mdx
+++ b/data/projects/blitz-wallet.mdx
@@ -11,6 +11,7 @@ nostr: 'npub14l69mauhjyu9j8pgmhj04vjqauzq43ch9yp9g2yx9j9tc4n8xh8s5l9dz2'
 zapstore: 'https://zapstore.dev/apps/com.blitzwallet'
 tags: ['Bitcoin', 'Lightning', 'Wallet']
 fund: general
+totalSatsSent: 153818232
 announcementLink: '/blog/bitcoin-grants-july-2024-6th-wave#blitz-wallet'
 ---
 

--- a/data/projects/blixt.mdx
+++ b/data/projects/blixt.mdx
@@ -12,6 +12,7 @@ nostr: 'npub1v4v57fu60zvc9d2uq23cey4fnwvxlzga9q2vta2n6xalu03rs57s0mxwu8'
 zapstore: 'https://zapstore.dev/apps/com.blixtwallet'
 tags: ['Bitcoin', 'Lightning', 'Wallet']
 fund: general
+totalSatsSent: 352235577
 announcementLink: '/blog/bitcoin-grants-july-2023#blixt-wallet'
 ---
 

--- a/data/projects/blixt.mdx
+++ b/data/projects/blixt.mdx
@@ -12,7 +12,7 @@ nostr: 'npub1v4v57fu60zvc9d2uq23cey4fnwvxlzga9q2vta2n6xalu03rs57s0mxwu8'
 zapstore: 'https://zapstore.dev/apps/com.blixtwallet'
 tags: ['Bitcoin', 'Lightning', 'Wallet']
 fund: general
-totalSatsSent: 352235577
+totalSatsSent: 352235622
 announcementLink: '/blog/bitcoin-grants-july-2023#blixt-wallet'
 ---
 

--- a/data/projects/blixt.mdx
+++ b/data/projects/blixt.mdx
@@ -12,7 +12,7 @@ nostr: 'npub1v4v57fu60zvc9d2uq23cey4fnwvxlzga9q2vta2n6xalu03rs57s0mxwu8'
 zapstore: 'https://zapstore.dev/apps/com.blixtwallet'
 tags: ['Bitcoin', 'Lightning', 'Wallet']
 fund: general
-totalSatsSent: 352235622
+totalSatsSent: 352235630
 announcementLink: '/blog/bitcoin-grants-july-2023#blixt-wallet'
 ---
 

--- a/data/projects/btcpayserver.mdx
+++ b/data/projects/btcpayserver.mdx
@@ -12,7 +12,7 @@ personalTwitter: 'NicolasDorier'
 tags: ['Bitcoin', 'Lightning', 'Wallet', 'Node', 'Commerce', 'Infrastructure']
 showcase: true
 fund: general
-totalSatsSent: 1813908868
+totalSatsSent: 1813908807
 announcementLink: '/blog/bitcoin-grants-july-2023#btcpay-server'
 ---
 

--- a/data/projects/btcpayserver.mdx
+++ b/data/projects/btcpayserver.mdx
@@ -12,6 +12,7 @@ personalTwitter: 'NicolasDorier'
 tags: ['Bitcoin', 'Lightning', 'Wallet', 'Node', 'Commerce', 'Infrastructure']
 showcase: true
 fund: general
+totalSatsSent: 1813908868
 announcementLink: '/blog/bitcoin-grants-july-2023#btcpay-server'
 ---
 

--- a/data/projects/btcpayserver.mdx
+++ b/data/projects/btcpayserver.mdx
@@ -12,7 +12,7 @@ personalTwitter: 'NicolasDorier'
 tags: ['Bitcoin', 'Lightning', 'Wallet', 'Node', 'Commerce', 'Infrastructure']
 showcase: true
 fund: general
-totalSatsSent: 1813908807
+totalSatsSent: 1813908843
 announcementLink: '/blog/bitcoin-grants-july-2023#btcpay-server'
 ---
 

--- a/data/projects/cashu.mdx
+++ b/data/projects/cashu.mdx
@@ -12,7 +12,7 @@ nostr: 'npub17fzkepv3q2szsvdefmws9znhhpzx9kvhgl2p3jqk9tm5z6sjalvsg49yxv'
 tags: ['Bitcoin', 'Lightning', 'ecash']
 showcase: true
 fund: general
-totalSatsSent: 719944596
+totalSatsSent: 719944625
 announcementLink: '/blog/bitcoin-grants-july-2023#cashu'
 ---
 

--- a/data/projects/cashu.mdx
+++ b/data/projects/cashu.mdx
@@ -12,7 +12,7 @@ nostr: 'npub17fzkepv3q2szsvdefmws9znhhpzx9kvhgl2p3jqk9tm5z6sjalvsg49yxv'
 tags: ['Bitcoin', 'Lightning', 'ecash']
 showcase: true
 fund: general
-totalSatsSent: 719944625
+totalSatsSent: 719944691
 announcementLink: '/blog/bitcoin-grants-july-2023#cashu'
 ---
 

--- a/data/projects/cashu.mdx
+++ b/data/projects/cashu.mdx
@@ -12,6 +12,7 @@ nostr: 'npub17fzkepv3q2szsvdefmws9znhhpzx9kvhgl2p3jqk9tm5z6sjalvsg49yxv'
 tags: ['Bitcoin', 'Lightning', 'ecash']
 showcase: true
 fund: general
+totalSatsSent: 719944596
 announcementLink: '/blog/bitcoin-grants-july-2023#cashu'
 ---
 

--- a/data/projects/cdk.mdx
+++ b/data/projects/cdk.mdx
@@ -10,6 +10,7 @@ git: 'https://github.com/cashubtc/cdk'
 nostr: 'npub1qjgcmlpkeyl8mdkvp4s0xls4ytcux6my606tgfx9xttut907h0zs76lgjw'
 tags: ['Bitcoin', 'Lightning', 'ecash', 'Library']
 fund: general
+totalSatsSent: 120998934
 announcementLink: '/blog/thirteenth-wave-of-bitcoin-grants#cdk--sats-app'
 ---
 

--- a/data/projects/cdk.mdx
+++ b/data/projects/cdk.mdx
@@ -10,7 +10,7 @@ git: 'https://github.com/cashubtc/cdk'
 nostr: 'npub1qjgcmlpkeyl8mdkvp4s0xls4ytcux6my606tgfx9xttut907h0zs76lgjw'
 tags: ['Bitcoin', 'Lightning', 'ecash', 'Library']
 fund: general
-totalSatsSent: 120998934
+totalSatsSent: 120998840
 announcementLink: '/blog/thirteenth-wave-of-bitcoin-grants#cdk--sats-app'
 ---
 

--- a/data/projects/cdk.mdx
+++ b/data/projects/cdk.mdx
@@ -10,7 +10,7 @@ git: 'https://github.com/cashubtc/cdk'
 nostr: 'npub1qjgcmlpkeyl8mdkvp4s0xls4ytcux6my606tgfx9xttut907h0zs76lgjw'
 tags: ['Bitcoin', 'Lightning', 'ecash', 'Library']
 fund: general
-totalSatsSent: 120998840
+totalSatsSent: 120998948
 announcementLink: '/blog/thirteenth-wave-of-bitcoin-grants#cdk--sats-app'
 ---
 

--- a/data/projects/citrine.mdx
+++ b/data/projects/citrine.mdx
@@ -10,7 +10,7 @@ nostr: 'npub1w4uswmv6lu9yel005l3qgheysmr7tk9uvwluddznju3nuxalevvs2d0jr5'
 zapstore: 'https://zapstore.dev/apps/com.greenart7c3.citrine'
 tags: ['Nostr', 'Relay', 'Mobile', 'Android']
 fund: nostr
-totalSatsSent: 4902842
+totalSatsSent: 4902849
 announcementLink: '/blog/greenart7c3-receives-lts-grant'
 ---
 

--- a/data/projects/citrine.mdx
+++ b/data/projects/citrine.mdx
@@ -10,7 +10,7 @@ nostr: 'npub1w4uswmv6lu9yel005l3qgheysmr7tk9uvwluddznju3nuxalevvs2d0jr5'
 zapstore: 'https://zapstore.dev/apps/com.greenart7c3.citrine'
 tags: ['Nostr', 'Relay', 'Mobile', 'Android']
 fund: nostr
-totalSatsSent: 4902849
+totalSatsSent: 4902796
 announcementLink: '/blog/greenart7c3-receives-lts-grant'
 ---
 

--- a/data/projects/contextvm.mdx
+++ b/data/projects/contextvm.mdx
@@ -12,7 +12,7 @@ git: 'https://github.com/ContextVM'
 tags: ['Nostr', 'MCP', 'Protocol', 'SDK']
 showcase: true
 fund: nostr
-totalSatsSent: 52691591
+totalSatsSent: 52691630
 announcementLink: '/blog/fifteenth-wave-of-nostr-grants#contextvm'
 ---
 

--- a/data/projects/contextvm.mdx
+++ b/data/projects/contextvm.mdx
@@ -12,7 +12,7 @@ git: 'https://github.com/ContextVM'
 tags: ['Nostr', 'MCP', 'Protocol', 'SDK']
 showcase: true
 fund: nostr
-totalSatsSent: 52691615
+totalSatsSent: 52691591
 announcementLink: '/blog/fifteenth-wave-of-nostr-grants#contextvm'
 ---
 

--- a/data/projects/coracle.mdx
+++ b/data/projects/coracle.mdx
@@ -12,7 +12,7 @@ zapstore: 'https://zapstore.dev/apps/social.coracle.app'
 tags: ['Nostr']
 showcase: true
 fund: nostr
-totalSatsSent: 693072159
+totalSatsSent: 693072327
 announcementLink: '/blog/nostr-grants-july-2023#coracle'
 ---
 

--- a/data/projects/coracle.mdx
+++ b/data/projects/coracle.mdx
@@ -12,7 +12,7 @@ zapstore: 'https://zapstore.dev/apps/social.coracle.app'
 tags: ['Nostr']
 showcase: true
 fund: nostr
-totalSatsSent: 693072294
+totalSatsSent: 693072159
 announcementLink: '/blog/nostr-grants-july-2023#coracle'
 ---
 

--- a/data/projects/cove.mdx
+++ b/data/projects/cove.mdx
@@ -11,7 +11,7 @@ twitter: 'covewallet'
 tags: ['Bitcoin', 'Wallet']
 showcase: true
 fund: general
-totalSatsSent: 347103775
+totalSatsSent: 347103822
 announcementLink: '/blog/bitcoin-grants-july-2024#cove'
 ---
 

--- a/data/projects/cove.mdx
+++ b/data/projects/cove.mdx
@@ -11,7 +11,7 @@ twitter: 'covewallet'
 tags: ['Bitcoin', 'Wallet']
 showcase: true
 fund: general
-totalSatsSent: 347103745
+totalSatsSent: 347103775
 announcementLink: '/blog/bitcoin-grants-july-2024#cove'
 ---
 

--- a/data/projects/cove.mdx
+++ b/data/projects/cove.mdx
@@ -11,6 +11,7 @@ twitter: 'covewallet'
 tags: ['Bitcoin', 'Wallet']
 showcase: true
 fund: general
+totalSatsSent: 347103745
 announcementLink: '/blog/bitcoin-grants-july-2024#cove'
 ---
 

--- a/data/projects/damus.mdx
+++ b/data/projects/damus.mdx
@@ -11,7 +11,7 @@ nostr: 'npub1xtscya34g58tk0z605fvr788k263gsu6cy9x0mhnm87echrgufzsevkk5s'
 tags: ['Nostr', 'Mobile', 'iOS']
 showcase: true
 fund: nostr
-totalSatsSent: 846761964
+totalSatsSent: 846761961
 announcementLink: '/blog/nostr-grants-july-2023#damus'
 ---
 

--- a/data/projects/damus.mdx
+++ b/data/projects/damus.mdx
@@ -11,7 +11,7 @@ nostr: 'npub1xtscya34g58tk0z605fvr788k263gsu6cy9x0mhnm87echrgufzsevkk5s'
 tags: ['Nostr', 'Mobile', 'iOS']
 showcase: true
 fund: nostr
-totalSatsSent: 846761961
+totalSatsSent: 846761996
 announcementLink: '/blog/nostr-grants-july-2023#damus'
 ---
 

--- a/data/projects/dana-wallet.mdx
+++ b/data/projects/dana-wallet.mdx
@@ -12,7 +12,7 @@ nostr: 'npub17vjlv6u4dg2ypyy5je9zc3lpeyfrnfrpmzgwt8v4rc289p2m79cqepwz5q'
 zapstore: 'https://zapstore.dev/apps/dev.silentpayments.danawallet'
 tags: ['Bitcoin', 'Privacy', 'Wallet', 'Mobile']
 fund: general
-totalSatsSent: 26345807
+totalSatsSent: 26345735
 announcementLink: '/blog/fifteenth-wave-of-bitcoin-grants#dana-wallet'
 ---
 

--- a/data/projects/dana-wallet.mdx
+++ b/data/projects/dana-wallet.mdx
@@ -12,7 +12,7 @@ nostr: 'npub17vjlv6u4dg2ypyy5je9zc3lpeyfrnfrpmzgwt8v4rc289p2m79cqepwz5q'
 zapstore: 'https://zapstore.dev/apps/dev.silentpayments.danawallet'
 tags: ['Bitcoin', 'Privacy', 'Wallet', 'Mobile']
 fund: general
-totalSatsSent: 26345735
+totalSatsSent: 26345719
 announcementLink: '/blog/fifteenth-wave-of-bitcoin-grants#dana-wallet'
 ---
 

--- a/data/projects/dana-wallet.mdx
+++ b/data/projects/dana-wallet.mdx
@@ -12,6 +12,7 @@ nostr: 'npub17vjlv6u4dg2ypyy5je9zc3lpeyfrnfrpmzgwt8v4rc289p2m79cqepwz5q'
 zapstore: 'https://zapstore.dev/apps/dev.silentpayments.danawallet'
 tags: ['Bitcoin', 'Privacy', 'Wallet', 'Mobile']
 fund: general
+totalSatsSent: 26345807
 announcementLink: '/blog/fifteenth-wave-of-bitcoin-grants#dana-wallet'
 ---
 

--- a/data/projects/floresta.mdx
+++ b/data/projects/floresta.mdx
@@ -8,6 +8,7 @@ coverImage: '/static/images/projects/floresta.png'
 git: 'https://github.com/getfloresta/Floresta'
 tags: ['Bitcoin', 'Core']
 fund: general
+totalSatsSent: 80718027
 announcementLink: '/blog/bitcoin-grants-september-2024-7th-wave#floresta'
 ---
 

--- a/data/projects/floresta.mdx
+++ b/data/projects/floresta.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/floresta.png'
 git: 'https://github.com/getfloresta/Floresta'
 tags: ['Bitcoin', 'Core']
 fund: general
-totalSatsSent: 80718027
+totalSatsSent: 80718285
 announcementLink: '/blog/bitcoin-grants-september-2024-7th-wave#floresta'
 ---
 

--- a/data/projects/floresta.mdx
+++ b/data/projects/floresta.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/floresta.png'
 git: 'https://github.com/getfloresta/Floresta'
 tags: ['Bitcoin', 'Core']
 fund: general
-totalSatsSent: 80718285
+totalSatsSent: 80717987
 announcementLink: '/blog/bitcoin-grants-september-2024-7th-wave#floresta'
 ---
 

--- a/data/projects/frostr.mdx
+++ b/data/projects/frostr.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/frostr.png'
 git: 'https://github.com/FROSTR-ORG'
 tags: ['Nostr', 'Signing']
 fund: nostr
-totalSatsSent: 140328406
+totalSatsSent: 140328386
 announcementLink: '/blog/twelfth-wave-of-nostr-grants#frostr'
 ---
 

--- a/data/projects/frostr.mdx
+++ b/data/projects/frostr.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/frostr.png'
 git: 'https://github.com/FROSTR-ORG'
 tags: ['Nostr', 'Signing']
 fund: nostr
-totalSatsSent: 140328386
+totalSatsSent: 140328396
 announcementLink: '/blog/twelfth-wave-of-nostr-grants#frostr'
 ---
 

--- a/data/projects/grapheneos.mdx
+++ b/data/projects/grapheneos.mdx
@@ -11,7 +11,7 @@ git: 'https://github.com/GrapheneOS'
 twitter: 'GrapheneOS'
 nostr: 'npub1235tem4hfn34edqh8hxfja9amty73998f0eagnuu4zm423s9e8ksdg0ht5'
 fund: general
-totalSatsSent: 2837508371
+totalSatsSent: 4308096606
 announcementLink: '/blog/2023-year-in-review#grantees'
 tags: ['Privacy', 'OS', 'Mobile']
 bonusUSD: 1000000

--- a/data/projects/grapheneos.mdx
+++ b/data/projects/grapheneos.mdx
@@ -11,7 +11,7 @@ git: 'https://github.com/GrapheneOS'
 twitter: 'GrapheneOS'
 nostr: 'npub1235tem4hfn34edqh8hxfja9amty73998f0eagnuu4zm423s9e8ksdg0ht5'
 fund: general
-totalSatsSent: 4308096606
+totalSatsSent: 2837508371
 announcementLink: '/blog/2023-year-in-review#grantees'
 tags: ['Privacy', 'OS', 'Mobile']
 bonusUSD: 1000000

--- a/data/projects/grapheneos.mdx
+++ b/data/projects/grapheneos.mdx
@@ -11,6 +11,7 @@ git: 'https://github.com/GrapheneOS'
 twitter: 'GrapheneOS'
 nostr: 'npub1235tem4hfn34edqh8hxfja9amty73998f0eagnuu4zm423s9e8ksdg0ht5'
 fund: general
+totalSatsSent: 2837500000
 announcementLink: '/blog/2023-year-in-review#grantees'
 tags: ['Privacy', 'OS', 'Mobile']
 bonusUSD: 1000000

--- a/data/projects/grapheneos.mdx
+++ b/data/projects/grapheneos.mdx
@@ -11,7 +11,7 @@ git: 'https://github.com/GrapheneOS'
 twitter: 'GrapheneOS'
 nostr: 'npub1235tem4hfn34edqh8hxfja9amty73998f0eagnuu4zm423s9e8ksdg0ht5'
 fund: general
-totalSatsSent: 2837500000
+totalSatsSent: 2837508371
 announcementLink: '/blog/2023-year-in-review#grantees'
 tags: ['Privacy', 'OS', 'Mobile']
 bonusUSD: 1000000

--- a/data/projects/jumble.mdx
+++ b/data/projects/jumble.mdx
@@ -11,7 +11,7 @@ git: 'https://github.com/CodyTseng/jumble'
 tags: ['Nostr', 'Web', 'PWA']
 showcase: true
 fund: nostr
-totalSatsSent: 63318770
+totalSatsSent: 63318635
 announcementLink: '/blog/twelfth-wave-of-nostr-grants#jumble'
 ---
 

--- a/data/projects/jumble.mdx
+++ b/data/projects/jumble.mdx
@@ -11,7 +11,7 @@ git: 'https://github.com/CodyTseng/jumble'
 tags: ['Nostr', 'Web', 'PWA']
 showcase: true
 fund: nostr
-totalSatsSent: 63318702
+totalSatsSent: 63318770
 announcementLink: '/blog/twelfth-wave-of-nostr-grants#jumble'
 ---
 

--- a/data/projects/krux.mdx
+++ b/data/projects/krux.mdx
@@ -8,6 +8,7 @@ coverImage: '/static/images/projects/krux-logo.png'
 git: 'https://github.com/selfcustody/krux'
 tags: ['Bitcoin', 'Wallet', 'Signing']
 fund: general
+totalSatsSent: 163769111
 announcementLink: '/blog/bitcoin-grants-december-2023#krux'
 ---
 

--- a/data/projects/krux.mdx
+++ b/data/projects/krux.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/krux-logo.png'
 git: 'https://github.com/selfcustody/krux'
 tags: ['Bitcoin', 'Wallet', 'Signing']
 fund: general
-totalSatsSent: 163768949
+totalSatsSent: 163768976
 announcementLink: '/blog/bitcoin-grants-december-2023#krux'
 ---
 

--- a/data/projects/krux.mdx
+++ b/data/projects/krux.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/krux-logo.png'
 git: 'https://github.com/selfcustody/krux'
 tags: ['Bitcoin', 'Wallet', 'Signing']
 fund: general
-totalSatsSent: 163769111
+totalSatsSent: 163768949
 announcementLink: '/blog/bitcoin-grants-december-2023#krux'
 ---
 

--- a/data/projects/ldk.mdx
+++ b/data/projects/ldk.mdx
@@ -9,7 +9,7 @@ invertDarkImage: true
 git: 'https://github.com/lightningdevkit/rust-lightning'
 tags: ['Lightning', 'Rust', 'Library', 'SDK']
 fund: general
-totalSatsSent: 280286477
+totalSatsSent: 280286420
 announcementLink: '/blog/shashwat-vangani-receives-lts-grant'
 ---
 

--- a/data/projects/ldk.mdx
+++ b/data/projects/ldk.mdx
@@ -9,7 +9,7 @@ invertDarkImage: true
 git: 'https://github.com/lightningdevkit/rust-lightning'
 tags: ['Lightning', 'Rust', 'Library', 'SDK']
 fund: general
-totalSatsSent: 280286420
+totalSatsSent: 280286507
 announcementLink: '/blog/shashwat-vangani-receives-lts-grant'
 ---
 

--- a/data/projects/ldk.mdx
+++ b/data/projects/ldk.mdx
@@ -9,6 +9,7 @@ invertDarkImage: true
 git: 'https://github.com/lightningdevkit/rust-lightning'
 tags: ['Lightning', 'Rust', 'Library', 'SDK']
 fund: general
+totalSatsSent: 280286477
 announcementLink: '/blog/shashwat-vangani-receives-lts-grant'
 ---
 

--- a/data/projects/libbitcoin.mdx
+++ b/data/projects/libbitcoin.mdx
@@ -8,6 +8,7 @@ coverImage: '/static/images/projects/libbitcoin.svg'
 git: 'https://github.com/libbitcoin'
 tags: ['Bitcoin', 'Node', 'Library']
 fund: general
+totalSatsSent: 43910746
 announcementLink: '/blog/sixteenth-wave-of-bitcoin-grants#libbitcoin'
 ---
 

--- a/data/projects/libbitcoin.mdx
+++ b/data/projects/libbitcoin.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/libbitcoin.svg'
 git: 'https://github.com/libbitcoin'
 tags: ['Bitcoin', 'Node', 'Library']
 fund: general
-totalSatsSent: 43910746
+totalSatsSent: 43910833
 announcementLink: '/blog/sixteenth-wave-of-bitcoin-grants#libbitcoin'
 ---
 

--- a/data/projects/libbitcoin.mdx
+++ b/data/projects/libbitcoin.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/libbitcoin.svg'
 git: 'https://github.com/libbitcoin'
 tags: ['Bitcoin', 'Node', 'Library']
 fund: general
-totalSatsSent: 43910833
+totalSatsSent: 43910715
 announcementLink: '/blog/sixteenth-wave-of-bitcoin-grants#libbitcoin'
 ---
 

--- a/data/projects/lnbits.mdx
+++ b/data/projects/lnbits.mdx
@@ -9,7 +9,7 @@ git: 'https://github.com/lnbits/lnbits'
 twitter: 'lnbits'
 tags: ['Bitcoin', 'Lightning', 'Wallet', 'Infrastructure']
 fund: general
-totalSatsSent: 406588769
+totalSatsSent: 406588749
 announcementLink: '/blog/bitcoin-and-nostr-grants-august-2023#lnbits'
 ---
 

--- a/data/projects/lnbits.mdx
+++ b/data/projects/lnbits.mdx
@@ -9,6 +9,7 @@ git: 'https://github.com/lnbits/lnbits'
 twitter: 'lnbits'
 tags: ['Bitcoin', 'Lightning', 'Wallet', 'Infrastructure']
 fund: general
+totalSatsSent: 406588769
 announcementLink: '/blog/bitcoin-and-nostr-grants-august-2023#lnbits'
 ---
 

--- a/data/projects/lnbits.mdx
+++ b/data/projects/lnbits.mdx
@@ -9,7 +9,7 @@ git: 'https://github.com/lnbits/lnbits'
 twitter: 'lnbits'
 tags: ['Bitcoin', 'Lightning', 'Wallet', 'Infrastructure']
 fund: general
-totalSatsSent: 406588749
+totalSatsSent: 406588782
 announcementLink: '/blog/bitcoin-and-nostr-grants-august-2023#lnbits'
 ---
 

--- a/data/projects/minibits.mdx
+++ b/data/projects/minibits.mdx
@@ -9,6 +9,7 @@ git: 'https://github.com/minibits-cash/minibits_wallet'
 zapstore: 'https://zapstore.dev/apps/com.minibits_wallet'
 tags: ['Bitcoin', 'Lightning', 'ecash', 'Mobile']
 fund: general
+totalSatsSent: 81339576
 announcementLink: '/blog/bitcoin-grants-september-2024-7th-wave#minibits'
 ---
 

--- a/data/projects/minibits.mdx
+++ b/data/projects/minibits.mdx
@@ -9,7 +9,7 @@ git: 'https://github.com/minibits-cash/minibits_wallet'
 zapstore: 'https://zapstore.dev/apps/com.minibits_wallet'
 tags: ['Bitcoin', 'Lightning', 'ecash', 'Mobile']
 fund: general
-totalSatsSent: 81339623
+totalSatsSent: 81339512
 announcementLink: '/blog/bitcoin-grants-september-2024-7th-wave#minibits'
 ---
 

--- a/data/projects/minibits.mdx
+++ b/data/projects/minibits.mdx
@@ -9,7 +9,7 @@ git: 'https://github.com/minibits-cash/minibits_wallet'
 zapstore: 'https://zapstore.dev/apps/com.minibits_wallet'
 tags: ['Bitcoin', 'Lightning', 'ecash', 'Mobile']
 fund: general
-totalSatsSent: 81339576
+totalSatsSent: 81339623
 announcementLink: '/blog/bitcoin-grants-september-2024-7th-wave#minibits'
 ---
 

--- a/data/projects/mostro.mdx
+++ b/data/projects/mostro.mdx
@@ -12,7 +12,7 @@ twitter: 'MostroP2P'
 nostr: 'npub1m0str0d7z2ww8rdh20t2n9lx520xjwhaq24p68umqp06wwrwtsnqen40un'
 tags: ['Bitcoin', 'Lightning', 'Nostr']
 fund: nostr
-totalSatsSent: 255653629
+totalSatsSent: 255653806
 announcementLink: '/blog/nostr-grants-july-2024#mostro'
 ---
 

--- a/data/projects/mostro.mdx
+++ b/data/projects/mostro.mdx
@@ -12,7 +12,7 @@ twitter: 'MostroP2P'
 nostr: 'npub1m0str0d7z2ww8rdh20t2n9lx520xjwhaq24p68umqp06wwrwtsnqen40un'
 tags: ['Bitcoin', 'Lightning', 'Nostr']
 fund: nostr
-totalSatsSent: 255653839
+totalSatsSent: 255653629
 announcementLink: '/blog/nostr-grants-july-2024#mostro'
 ---
 

--- a/data/projects/ndk.mdx
+++ b/data/projects/ndk.mdx
@@ -9,7 +9,7 @@ git: 'https://github.com/nostr-dev-kit/ndk'
 nostr: 'npub1l2vyh47mk2p0qlsku7hg0vn29faehy9hy34ygaclpn66ukqp3afqutajft'
 tags: ['Nostr', 'TypeScript', 'Library', 'SDK']
 fund: nostr
-totalSatsSent: 895015539
+totalSatsSent: 895015530
 announcementLink: '/blog/nostr-grants-july-2023#ndk'
 ---
 

--- a/data/projects/ndk.mdx
+++ b/data/projects/ndk.mdx
@@ -9,7 +9,7 @@ git: 'https://github.com/nostr-dev-kit/ndk'
 nostr: 'npub1l2vyh47mk2p0qlsku7hg0vn29faehy9hy34ygaclpn66ukqp3afqutajft'
 tags: ['Nostr', 'TypeScript', 'Library', 'SDK']
 fund: nostr
-totalSatsSent: 895015530
+totalSatsSent: 895015483
 announcementLink: '/blog/nostr-grants-july-2023#ndk'
 ---
 

--- a/data/projects/ngit.mdx
+++ b/data/projects/ngit.mdx
@@ -9,7 +9,7 @@ git: 'https://github.com/DanConwayDev/ngit-cli'
 nostr: 'npub15qydau2hjma6ngxkl2cyar74wzyjshvl65za5k5rl69264ar2exs5cyejr'
 tags: ['Nostr', 'Git', 'Developer Tools']
 fund: nostr
-totalSatsSent: 643952790
+totalSatsSent: 643952782
 announcementLink: '/blog/nostr-grants-july-2023#code-collaboration-over-nostr'
 ---
 

--- a/data/projects/ngit.mdx
+++ b/data/projects/ngit.mdx
@@ -9,7 +9,7 @@ git: 'https://github.com/DanConwayDev/ngit-cli'
 nostr: 'npub15qydau2hjma6ngxkl2cyar74wzyjshvl65za5k5rl69264ar2exs5cyejr'
 tags: ['Nostr', 'Git', 'Developer Tools']
 fund: nostr
-totalSatsSent: 643952782
+totalSatsSent: 643952602
 announcementLink: '/blog/nostr-grants-july-2023#code-collaboration-over-nostr'
 ---
 

--- a/data/projects/opencash.mdx
+++ b/data/projects/opencash.mdx
@@ -8,7 +8,7 @@ donationLink: 'https://opencash.dev/'
 coverImage: '/static/images/projects/opencash.png'
 tags: ['Bitcoin', 'Lightning', 'ecash']
 fund: general
-totalSatsSent: 214714493
+totalSatsSent: 214714513
 announcementLink: '/blog/let-a-thousand-flowers-bloom#opencash'
 ---
 

--- a/data/projects/opencash.mdx
+++ b/data/projects/opencash.mdx
@@ -8,6 +8,7 @@ donationLink: 'https://opencash.dev/'
 coverImage: '/static/images/projects/opencash.png'
 tags: ['Bitcoin', 'Lightning', 'ecash']
 fund: general
+totalSatsSent: 214714519
 announcementLink: '/blog/let-a-thousand-flowers-bloom#opencash'
 ---
 

--- a/data/projects/opencash.mdx
+++ b/data/projects/opencash.mdx
@@ -8,7 +8,7 @@ donationLink: 'https://opencash.dev/'
 coverImage: '/static/images/projects/opencash.png'
 tags: ['Bitcoin', 'Lightning', 'ecash']
 fund: general
-totalSatsSent: 214714519
+totalSatsSent: 214714493
 announcementLink: '/blog/let-a-thousand-flowers-bloom#opencash'
 ---
 

--- a/data/projects/pdk.mdx
+++ b/data/projects/pdk.mdx
@@ -11,7 +11,7 @@ twitter: 'payjoindevkit'
 tags: ['Bitcoin', 'Privacy']
 showcase: true
 fund: general
-totalSatsSent: 541454925
+totalSatsSent: 541454858
 announcementLink: '/blog/bitcoin-grants-july-2023#payjoin-dev-kit'
 ---
 

--- a/data/projects/pdk.mdx
+++ b/data/projects/pdk.mdx
@@ -72,7 +72,7 @@ bundles the directory, OHTTP relay, and metrics into a single binary that
 [BOB Space](https://bobspaces.net/), Cake Wallet, Vinteum, Achow101, and
 others now run as public infrastructure.
 
-Alongside the dev kit, the Foundation runs a research track led by 
+Alongside the dev kit, the Foundation runs a research track led by
 [Armin Sabouri](https://github.com/arminsabouri) on wallet fingerprinting
 ([tx-indexer](https://github.com/payjoin/tx-indexer),
 [btsim](https://github.com/payjoin/btsim), and an automated

--- a/data/projects/pdk.mdx
+++ b/data/projects/pdk.mdx
@@ -11,7 +11,7 @@ twitter: 'payjoindevkit'
 tags: ['Bitcoin', 'Privacy']
 showcase: true
 fund: general
-totalSatsSent: 541454858
+totalSatsSent: 541454804
 announcementLink: '/blog/bitcoin-grants-july-2023#payjoin-dev-kit'
 ---
 

--- a/data/projects/pdk.mdx
+++ b/data/projects/pdk.mdx
@@ -11,6 +11,7 @@ twitter: 'payjoindevkit'
 tags: ['Bitcoin', 'Privacy']
 showcase: true
 fund: general
+totalSatsSent: 541454925
 announcementLink: '/blog/bitcoin-grants-july-2023#payjoin-dev-kit'
 ---
 

--- a/data/projects/routstr.mdx
+++ b/data/projects/routstr.mdx
@@ -11,6 +11,7 @@ git: 'https://github.com/Routstr'
 nostr: 'npub130mznv74rxs032peqym6g3wqavh472623mt3z5w73xq9r6qqdufs7ql29s'
 tags: ['Bitcoin', 'Nostr', 'Privacy', 'Protocol']
 fund: general
+totalSatsSent: 16935375
 ---
 
 Routstr is a decentralized AI inference protocol for private, pay-per-request access to language models. It combines [Nostr](/topics/nostr) for node discovery with [Cashu](/projects/cashu) ecash for Bitcoin micropayments, so users can connect to providers without opening accounts or handing over a credit card. The core system is OpenAI-compatible, which lets developers point existing SDKs and tools at a Routstr node instead of a centralized API.

--- a/data/projects/routstr.mdx
+++ b/data/projects/routstr.mdx
@@ -11,7 +11,7 @@ git: 'https://github.com/Routstr'
 nostr: 'npub130mznv74rxs032peqym6g3wqavh472623mt3z5w73xq9r6qqdufs7ql29s'
 tags: ['Bitcoin', 'Nostr', 'Privacy', 'Protocol']
 fund: general
-totalSatsSent: 16935359
+totalSatsSent: 16935286
 ---
 
 Routstr is a decentralized AI inference protocol for private, pay-per-request access to language models. It combines [Nostr](/topics/nostr) for node discovery with [Cashu](/projects/cashu) ecash for Bitcoin micropayments, so users can connect to providers without opening accounts or handing over a credit card. The core system is OpenAI-compatible, which lets developers point existing SDKs and tools at a Routstr node instead of a centralized API.

--- a/data/projects/routstr.mdx
+++ b/data/projects/routstr.mdx
@@ -11,7 +11,7 @@ git: 'https://github.com/Routstr'
 nostr: 'npub130mznv74rxs032peqym6g3wqavh472623mt3z5w73xq9r6qqdufs7ql29s'
 tags: ['Bitcoin', 'Nostr', 'Privacy', 'Protocol']
 fund: general
-totalSatsSent: 16935375
+totalSatsSent: 16935359
 ---
 
 Routstr is a decentralized AI inference protocol for private, pay-per-request access to language models. It combines [Nostr](/topics/nostr) for node discovery with [Cashu](/projects/cashu) ecash for Bitcoin micropayments, so users can connect to providers without opening accounts or handing over a credit card. The core system is OpenAI-compatible, which lets developers point existing SDKs and tools at a Routstr node instead of a centralized API.

--- a/data/projects/rust-bitcoin.mdx
+++ b/data/projects/rust-bitcoin.mdx
@@ -10,6 +10,7 @@ git: 'https://github.com/rust-bitcoin/rust-bitcoin'
 tags: ['Bitcoin', 'Library']
 showcase: true
 fund: general
+totalSatsSent: 688647468
 announcementLink: '/blog/ninth-wave-of-bitcoin-grants#rust-bitcoin'
 ---
 

--- a/data/projects/rust-bitcoin.mdx
+++ b/data/projects/rust-bitcoin.mdx
@@ -10,7 +10,7 @@ git: 'https://github.com/rust-bitcoin/rust-bitcoin'
 tags: ['Bitcoin', 'Library']
 showcase: true
 fund: general
-totalSatsSent: 688647468
+totalSatsSent: 688647527
 announcementLink: '/blog/ninth-wave-of-bitcoin-grants#rust-bitcoin'
 ---
 

--- a/data/projects/rust-bitcoin.mdx
+++ b/data/projects/rust-bitcoin.mdx
@@ -10,7 +10,7 @@ git: 'https://github.com/rust-bitcoin/rust-bitcoin'
 tags: ['Bitcoin', 'Library']
 showcase: true
 fund: general
-totalSatsSent: 688647527
+totalSatsSent: 688647578
 announcementLink: '/blog/ninth-wave-of-bitcoin-grants#rust-bitcoin'
 ---
 

--- a/data/projects/satoshinakamotoinstitute.mdx
+++ b/data/projects/satoshinakamotoinstitute.mdx
@@ -11,7 +11,7 @@ git: 'https://github.com/NakamotoInstitute/nakamotoinstitute.org'
 tags: ['Bitcoin', 'Education', 'Research']
 showcase: true
 fund: general
-totalSatsSent: 255837149
+totalSatsSent: 255836980
 announcementLink: '/blog/announcing-the-opensats-education-initiative#satoshi-nakamoto-institute'
 ---
 

--- a/data/projects/satoshinakamotoinstitute.mdx
+++ b/data/projects/satoshinakamotoinstitute.mdx
@@ -11,6 +11,7 @@ git: 'https://github.com/NakamotoInstitute/nakamotoinstitute.org'
 tags: ['Bitcoin', 'Education', 'Research']
 showcase: true
 fund: general
+totalSatsSent: 255837092
 announcementLink: '/blog/announcing-the-opensats-education-initiative#satoshi-nakamoto-institute'
 ---
 

--- a/data/projects/satoshinakamotoinstitute.mdx
+++ b/data/projects/satoshinakamotoinstitute.mdx
@@ -27,7 +27,7 @@ OpenSats supported SNI through the [OpenSats Education Initiative][education]. T
 
 ## What's next?
 
-The Satoshi Nakamoto Institute has long been the closest thing Bitcoin has to a historical library. But its underlying system was built like a website, and not an archive. This means content is loosely organized, and there is no standard way to bring in bulk material like early mailing lists, forum threads, IRC logs, and other primary-source collections at scale. 
+The Satoshi Nakamoto Institute has long been the closest thing Bitcoin has to a historical library. But its underlying system was built like a website, and not an archive. This means content is loosely organized, and there is no standard way to bring in bulk material like early mailing lists, forum threads, IRC logs, and other primary-source collections at scale.
 
 Archive v2 rebuilds that foundation using the same preservation standards that govern the Library of Congress and major research libraries worldwide, so that Bitcoin's intellectual history can be brought in and properly catalogued, described, and kept intact at scale.
 

--- a/data/projects/satoshinakamotoinstitute.mdx
+++ b/data/projects/satoshinakamotoinstitute.mdx
@@ -11,7 +11,7 @@ git: 'https://github.com/NakamotoInstitute/nakamotoinstitute.org'
 tags: ['Bitcoin', 'Education', 'Research']
 showcase: true
 fund: general
-totalSatsSent: 255837092
+totalSatsSent: 255837149
 announcementLink: '/blog/announcing-the-opensats-education-initiative#satoshi-nakamoto-institute'
 ---
 

--- a/data/projects/soapbox.mdx
+++ b/data/projects/soapbox.mdx
@@ -12,7 +12,7 @@ nostr: 'npub108pv4cg5ag52nq082kd5leu9ffrn2gdg6g4xdwatn73y36uzplmq9uyev6'
 zapstore: 'https://zapstore.dev/apps/pub.ditto.app'
 tags: ['Nostr']
 fund: nostr
-totalSatsSent: 942003938
+totalSatsSent: 942003983
 announcementLink: '/blog/nostr-grants-july-2023#soapbox'
 ---
 

--- a/data/projects/soapbox.mdx
+++ b/data/projects/soapbox.mdx
@@ -12,7 +12,7 @@ nostr: 'npub108pv4cg5ag52nq082kd5leu9ffrn2gdg6g4xdwatn73y36uzplmq9uyev6'
 zapstore: 'https://zapstore.dev/apps/pub.ditto.app'
 tags: ['Nostr']
 fund: nostr
-totalSatsSent: 942003983
+totalSatsSent: 942003907
 announcementLink: '/blog/nostr-grants-july-2023#soapbox'
 ---
 

--- a/data/projects/splicing.mdx
+++ b/data/projects/splicing.mdx
@@ -12,7 +12,7 @@ personalTwitter: 'dusty_daemon'
 nostr: 'npub1fuk7q4y0wzqw7vjrg7xeuuva79pg7ctg69a53zsxq6gepksufrrst9mzly'
 tags: ['Lightning', 'Protocol']
 fund: general
-totalSatsSent: 652602771
+totalSatsSent: 652602818
 announcementLink: '/blog/bitcoin-grants-july-2023#splicing'
 ---
 

--- a/data/projects/splicing.mdx
+++ b/data/projects/splicing.mdx
@@ -20,7 +20,9 @@ Splicing is a Lightning protocol improvement that lets users resize channels wit
 
 > The increased liquidity flows improve all aspects of Lightning including payment speed, payment fees, and payment reliability.
 >
-> <cite>— [Dusty Daemon](/blog/advancements-in-lightning-infrastructure#splicing)</cite>
+> <cite>
+>   — [Dusty Daemon](/blog/advancements-in-lightning-infrastructure#splicing)
+> </cite>
 
 Splicing gives users a cleaner way to add or remove liquidity, helping node operators manage capital more efficiently.
 

--- a/data/projects/splicing.mdx
+++ b/data/projects/splicing.mdx
@@ -12,6 +12,7 @@ personalTwitter: 'dusty_daemon'
 nostr: 'npub1fuk7q4y0wzqw7vjrg7xeuuva79pg7ctg69a53zsxq6gepksufrrst9mzly'
 tags: ['Lightning', 'Protocol']
 fund: general
+totalSatsSent: 652602746
 announcementLink: '/blog/bitcoin-grants-july-2023#splicing'
 ---
 

--- a/data/projects/splicing.mdx
+++ b/data/projects/splicing.mdx
@@ -12,7 +12,7 @@ personalTwitter: 'dusty_daemon'
 nostr: 'npub1fuk7q4y0wzqw7vjrg7xeuuva79pg7ctg69a53zsxq6gepksufrrst9mzly'
 tags: ['Lightning', 'Protocol']
 fund: general
-totalSatsSent: 652602746
+totalSatsSent: 652602771
 announcementLink: '/blog/bitcoin-grants-july-2023#splicing'
 ---
 

--- a/data/projects/stable-channels.mdx
+++ b/data/projects/stable-channels.mdx
@@ -9,7 +9,7 @@ git: 'https://github.com/toneloc/stable-channels'
 tags: ['Bitcoin', 'Lightning']
 showcase: true
 fund: general
-totalSatsSent: 157067157
+totalSatsSent: 157067165
 announcementLink: '/blog/tenth-wave-of-bitcoin-grants#stable-channels'
 ---
 

--- a/data/projects/stable-channels.mdx
+++ b/data/projects/stable-channels.mdx
@@ -9,6 +9,7 @@ git: 'https://github.com/toneloc/stable-channels'
 tags: ['Bitcoin', 'Lightning']
 showcase: true
 fund: general
+totalSatsSent: 157067044
 announcementLink: '/blog/tenth-wave-of-bitcoin-grants#stable-channels'
 ---
 

--- a/data/projects/stable-channels.mdx
+++ b/data/projects/stable-channels.mdx
@@ -9,7 +9,7 @@ git: 'https://github.com/toneloc/stable-channels'
 tags: ['Bitcoin', 'Lightning']
 showcase: true
 fund: general
-totalSatsSent: 157067044
+totalSatsSent: 157067157
 announcementLink: '/blog/tenth-wave-of-bitcoin-grants#stable-channels'
 ---
 

--- a/data/projects/stratumv2.mdx
+++ b/data/projects/stratumv2.mdx
@@ -12,7 +12,7 @@ personalTwitter: 'StratumV2'
 tags: ['Bitcoin', 'Privacy', 'Protocol', 'Mining']
 showcase: true
 fund: general
-totalSatsSent: 376965208
+totalSatsSent: 376964959
 announcementLink: '/blog/bitcoin-and-nostr-grants-august-2023#stratum-v2-testing--benchmarking-tool'
 ---
 

--- a/data/projects/stratumv2.mdx
+++ b/data/projects/stratumv2.mdx
@@ -12,7 +12,7 @@ personalTwitter: 'StratumV2'
 tags: ['Bitcoin', 'Privacy', 'Protocol', 'Mining']
 showcase: true
 fund: general
-totalSatsSent: 376964959
+totalSatsSent: 376965174
 announcementLink: '/blog/bitcoin-and-nostr-grants-august-2023#stratum-v2-testing--benchmarking-tool'
 ---
 

--- a/data/projects/stratumv2.mdx
+++ b/data/projects/stratumv2.mdx
@@ -12,6 +12,7 @@ personalTwitter: 'StratumV2'
 tags: ['Bitcoin', 'Privacy', 'Protocol', 'Mining']
 showcase: true
 fund: general
+totalSatsSent: 376965208
 announcementLink: '/blog/bitcoin-and-nostr-grants-august-2023#stratum-v2-testing--benchmarking-tool'
 ---
 

--- a/data/projects/summerofbitcoin.mdx
+++ b/data/projects/summerofbitcoin.mdx
@@ -11,7 +11,7 @@ twitter: 'summerofbitcoin'
 tags: ['Bitcoin', 'Education']
 showcase: true
 fund: general
-totalSatsSent: 222771278
+totalSatsSent: 222771266
 announcementLink: '/blog/announcing-the-opensats-education-initiative#summer-of-bitcoin'
 ---
 

--- a/data/projects/summerofbitcoin.mdx
+++ b/data/projects/summerofbitcoin.mdx
@@ -11,6 +11,7 @@ twitter: 'summerofbitcoin'
 tags: ['Bitcoin', 'Education']
 showcase: true
 fund: general
+totalSatsSent: 222771278
 announcementLink: '/blog/announcing-the-opensats-education-initiative#summer-of-bitcoin'
 ---
 

--- a/data/projects/summerofbitcoin.mdx
+++ b/data/projects/summerofbitcoin.mdx
@@ -11,7 +11,7 @@ twitter: 'summerofbitcoin'
 tags: ['Bitcoin', 'Education']
 showcase: true
 fund: general
-totalSatsSent: 222771266
+totalSatsSent: 222771243
 announcementLink: '/blog/announcing-the-opensats-education-initiative#summer-of-bitcoin'
 ---
 

--- a/data/projects/tor.mdx
+++ b/data/projects/tor.mdx
@@ -13,7 +13,7 @@ zapstore: 'https://zapstore.dev/apps/org.torproject.android'
 tags: ['Privacy', 'Protocol']
 showcase: true
 fund: general
-totalSatsSent: 180331224
+totalSatsSent: 180331261
 announcementLink: '/blog/tor-receives-support-grant'
 ---
 

--- a/data/projects/tor.mdx
+++ b/data/projects/tor.mdx
@@ -13,7 +13,7 @@ zapstore: 'https://zapstore.dev/apps/org.torproject.android'
 tags: ['Privacy', 'Protocol']
 showcase: true
 fund: general
-totalSatsSent: 180331261
+totalSatsSent: 180331274
 announcementLink: '/blog/tor-receives-support-grant'
 ---
 

--- a/data/projects/tor.mdx
+++ b/data/projects/tor.mdx
@@ -13,6 +13,7 @@ zapstore: 'https://zapstore.dev/apps/org.torproject.android'
 tags: ['Privacy', 'Protocol']
 showcase: true
 fund: general
+totalSatsSent: 180331224
 announcementLink: '/blog/tor-receives-support-grant'
 ---
 

--- a/data/projects/utreexod.mdx
+++ b/data/projects/utreexod.mdx
@@ -9,7 +9,7 @@ invertDarkImage: true
 git: 'https://github.com/utreexo/utreexod'
 tags: ['Bitcoin', 'Core']
 fund: general
-totalSatsSent: 549878641
+totalSatsSent: 549878532
 announcementLink: '/blog/bitcoin-grants-july-2024#utreexo'
 ---
 

--- a/data/projects/utreexod.mdx
+++ b/data/projects/utreexod.mdx
@@ -9,7 +9,7 @@ invertDarkImage: true
 git: 'https://github.com/utreexo/utreexod'
 tags: ['Bitcoin', 'Core']
 fund: general
-totalSatsSent: 549878590
+totalSatsSent: 549878641
 announcementLink: '/blog/bitcoin-grants-july-2024#utreexo'
 ---
 

--- a/data/projects/utreexod.mdx
+++ b/data/projects/utreexod.mdx
@@ -9,6 +9,7 @@ invertDarkImage: true
 git: 'https://github.com/utreexo/utreexod'
 tags: ['Bitcoin', 'Core']
 fund: general
+totalSatsSent: 549878590
 announcementLink: '/blog/bitcoin-grants-july-2024#utreexo'
 ---
 

--- a/data/projects/vls.mdx
+++ b/data/projects/vls.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/vls.png'
 git: 'https://gitlab.com/lightning-signer/validating-lightning-signer'
 tags: ['Bitcoin', 'Lightning']
 fund: general
-totalSatsSent: 543348832
+totalSatsSent: 543348759
 announcementLink: '/blog/bitcoin-grants-december-2023#validating-lightning-signer'
 ---
 

--- a/data/projects/vls.mdx
+++ b/data/projects/vls.mdx
@@ -17,8 +17,8 @@ node into two parts: an operational node that connects to peers and
 routes payments, and a separate signer that holds the private keys and
 validates every state change before signing it. If the node is compromised,
 the attacker gets network access but no keys; the signer refuses to sign
-malicious state updates because it independently enforces both the Lightning 
-protocol's rules and the operator's own policies (approved destinations, 
+malicious state updates because it independently enforces both the Lightning
+protocol's rules and the operator's own policies (approved destinations,
 velocity limits, spend caps, etc).
 
 VLS works with [Core Lightning](https://github.com/ElementsProject/lightning)
@@ -39,7 +39,7 @@ the node runs in Blockstream's cloud.
 OpenSats first funded VLS in the
 [December 2023 wave of Bitcoin grants](/blog/bitcoin-grants-december-2023#validating-lightning-signer)
 and renewed support in
-[July 2024](/blog/bitcoin-grants-july-2024#validating-lightning-signer). [Spiral](https://spiral.xyz/), 
+[July 2024](/blog/bitcoin-grants-july-2024#validating-lightning-signer). [Spiral](https://spiral.xyz/),
 [Blockstream](https://blockstream.com/) and the
 [Human Rights Foundation](https://hrf.org/) also back the project. For a
 detailed look at progress, see the
@@ -50,8 +50,8 @@ impact report.
 
 The team is pushing toward an official 1.0 mainnet-ready release.
 [Version 0.14](https://gitlab.com/lightning-signer/validating-lightning-signer/-/releases/v0.14.0)
-shipped in late 2025 with BOLT12 signing support, expanded HTLC monitoring, 
-and a cleaner dependency setup. Ongoing work covers splicing, dual funding, 
+shipped in late 2025 with BOLT12 signing support, expanded HTLC monitoring,
+and a cleaner dependency setup. Ongoing work covers splicing, dual funding,
 improved recovery flows, running the signer on secure enclaves, and filling out the
 integration docs. LND support is the most requested next integration target,
 but it depends on changes upstream in LND before VLS can be wired in.

--- a/data/projects/vls.mdx
+++ b/data/projects/vls.mdx
@@ -8,6 +8,7 @@ coverImage: '/static/images/projects/vls.png'
 git: 'https://gitlab.com/lightning-signer/validating-lightning-signer'
 tags: ['Bitcoin', 'Lightning']
 fund: general
+totalSatsSent: 543348832
 announcementLink: '/blog/bitcoin-grants-december-2023#validating-lightning-signer'
 ---
 

--- a/data/projects/wireguard.mdx
+++ b/data/projects/wireguard.mdx
@@ -9,7 +9,7 @@ coverImage: '/static/images/projects/wireguard.png'
 git: 'https://www.wireguard.com/repositories/'
 tags: ['Privacy', 'Protocol', 'Infrastructure']
 fund: general
-totalSatsSent: 605079918
+totalSatsSent: 605079968
 announcementLink: '/blog/jason-donenfeld-lts-grant'
 ---
 

--- a/data/projects/wireguard.mdx
+++ b/data/projects/wireguard.mdx
@@ -9,7 +9,7 @@ coverImage: '/static/images/projects/wireguard.png'
 git: 'https://www.wireguard.com/repositories/'
 tags: ['Privacy', 'Protocol', 'Infrastructure']
 fund: general
-totalSatsSent: 605079952
+totalSatsSent: 605079918
 announcementLink: '/blog/jason-donenfeld-lts-grant'
 ---
 

--- a/data/projects/wireguard.mdx
+++ b/data/projects/wireguard.mdx
@@ -9,6 +9,7 @@ coverImage: '/static/images/projects/wireguard.png'
 git: 'https://www.wireguard.com/repositories/'
 tags: ['Privacy', 'Protocol', 'Infrastructure']
 fund: general
+totalSatsSent: 605079952
 announcementLink: '/blog/jason-donenfeld-lts-grant'
 ---
 

--- a/data/projects/zapstore.mdx
+++ b/data/projects/zapstore.mdx
@@ -9,7 +9,7 @@ git: 'https://github.com/zapstore/zapstore'
 tags: ['Nostr', 'Android', 'Mobile']
 showcase: true
 fund: nostr
-totalSatsSent: 101204472
+totalSatsSent: 101204345
 announcementLink: '/blog/10th-wave-of-nostr-grants#zapstore'
 ---
 

--- a/data/projects/zapstore.mdx
+++ b/data/projects/zapstore.mdx
@@ -9,7 +9,7 @@ git: 'https://github.com/zapstore/zapstore'
 tags: ['Nostr', 'Android', 'Mobile']
 showcase: true
 fund: nostr
-totalSatsSent: 101204467
+totalSatsSent: 101204472
 announcementLink: '/blog/10th-wave-of-nostr-grants#zapstore'
 ---
 

--- a/layouts/ProjectLayout.tsx
+++ b/layouts/ProjectLayout.tsx
@@ -125,8 +125,9 @@ export default function PageLayout({
                       {showSatsInfo && (
                         <span className="absolute left-1/2 top-full z-10 mt-2 block w-64 -translate-x-1/2 whitespace-normal rounded-lg bg-gray-900 p-3 text-left text-xs font-normal normal-case tracking-normal text-gray-100 shadow-lg dark:bg-gray-700">
                           Approximate all-time sats sent to the project. These
-                          are past payouts, not balances: the money has been
-                          spent on the work it was given for.{' '}
+                          are past payouts and don't reflect current or
+                          historical balances. Sats are sent monthly and spent
+                          on the work the grant was given for.{' '}
                           <Link href="/transparency" className="underline">
                             Learn more
                           </Link>

--- a/layouts/ProjectLayout.tsx
+++ b/layouts/ProjectLayout.tsx
@@ -93,7 +93,7 @@ export default function PageLayout({
             {totalSatsSent && (
               <div
                 className="pb-6 pt-14 text-center xl:w-48 xl:text-left"
-                title={`Total sats sent to ${title} by OpenSats`}
+                title={`Approximate total of sats sent to ${title} by OpenSats`}
               >
                 <div className="inline-flex flex-col">
                   <p className="flex items-center gap-2 text-2xl font-medium tabular-nums tracking-tight text-gray-600 dark:text-gray-300">
@@ -104,7 +104,7 @@ export default function PageLayout({
                     total sats sent
                     <Link
                       href="/transparency"
-                      title={`All-time sats sent to ${title}. See how OpenSats handles funds, reporting, and grants on our transparency page.`}
+                      title={`Approximate all-time sats sent to ${title}. These are past payouts, not balances. See how OpenSats handles funds, reporting, and grants on our transparency page.`}
                       aria-label="Learn more about total sats sent"
                       className="opacity-70 transition-opacity hover:opacity-100"
                     >

--- a/layouts/ProjectLayout.tsx
+++ b/layouts/ProjectLayout.tsx
@@ -128,7 +128,7 @@ export default function PageLayout({
                           current or historical balances. Sats are sent monthly
                           and spent on the work the grant was given for.{' '}
                           <Link href="/transparency" className="underline">
-                            Learn more
+                            Learn more &rarr;
                           </Link>
                         </span>
                       )}

--- a/layouts/ProjectLayout.tsx
+++ b/layouts/ProjectLayout.tsx
@@ -124,10 +124,10 @@ export default function PageLayout({
                       </button>
                       {showSatsInfo && (
                         <span className="absolute left-1/2 top-full z-10 mt-2 block w-64 -translate-x-1/2 whitespace-normal rounded-lg bg-gray-900 p-3 text-left text-xs font-normal normal-case tracking-normal text-gray-100 shadow-lg dark:bg-gray-700">
-                          Approximate all-time sats sent to the project. These
-                          are past payouts and don't reflect current or
-                          historical balances. Sats are sent monthly and spent
-                          on the work the grant was given for.{' '}
+                          Numbers are accumulative past payouts and don't
+                          reflect current or historical balances. Sats are sent
+                          monthly and spent on the work the grant was given
+                          for.{' '}
                           <Link href="/transparency" className="underline">
                             Learn more
                           </Link>

--- a/layouts/ProjectLayout.tsx
+++ b/layouts/ProjectLayout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react'
+import { ReactNode, useEffect, useRef, useState } from 'react'
 import type { Project } from 'contentlayer/generated'
 import { FundSEO, ProjectSEO } from '@/components/SEO'
 import SocialIcon from '@/components/social-icons'
@@ -41,6 +41,19 @@ export default function PageLayout({
   } = content
   const isFund = kind === 'fund'
   const animatedSatsSent = useAnimatedCount(totalSatsSent ?? 0)
+  const [showSatsInfo, setShowSatsInfo] = useState(false)
+  const satsInfoRef = useRef<HTMLSpanElement>(null)
+
+  useEffect(() => {
+    if (!showSatsInfo) return
+    const handleClick = (event: MouseEvent) => {
+      if (!satsInfoRef.current?.contains(event.target as Node)) {
+        setShowSatsInfo(false)
+      }
+    }
+    document.addEventListener('click', handleClick)
+    return () => document.removeEventListener('click', handleClick)
+  }, [showSatsInfo])
   const heartbeatUrl = heartbeat || getHeartbeatUrl(git)
   const SEO = isFund ? FundSEO : ProjectSEO
   const seoTitle = isFund
@@ -99,14 +112,27 @@ export default function PageLayout({
                   </p>
                   <p className="flex items-center gap-1 pl-8 text-xs uppercase tracking-wide text-gray-400 dark:text-gray-500">
                     total sats sent
-                    <Link
-                      href="/transparency"
-                      title={`Approximate all-time sats sent to ${title}. These are past payouts, not balances. See how OpenSats handles funds, reporting, and grants on our transparency page.`}
-                      aria-label="Learn more about total sats sent"
-                      className="opacity-70 transition-opacity hover:opacity-100"
-                    >
-                      <CircleQuestion className="h-3.5 w-3.5 fill-current" />
-                    </Link>
+                    <span className="relative flex" ref={satsInfoRef}>
+                      <button
+                        type="button"
+                        onClick={() => setShowSatsInfo((value) => !value)}
+                        aria-label="Learn more about total sats sent"
+                        aria-expanded={showSatsInfo}
+                        className="opacity-70 transition-opacity hover:opacity-100"
+                      >
+                        <CircleQuestion className="h-3.5 w-3.5 fill-current" />
+                      </button>
+                      {showSatsInfo && (
+                        <span className="absolute left-1/2 top-full z-10 mt-2 block w-64 -translate-x-1/2 rounded-lg bg-gray-900 p-3 text-left text-xs font-normal normal-case tracking-normal text-gray-100 shadow-lg dark:bg-gray-700">
+                          Approximate all-time sats sent to {title}. These are
+                          past payouts, not balances: the money has been spent
+                          on the work it was given for.{' '}
+                          <Link href="/transparency" className="underline">
+                            Learn more
+                          </Link>
+                        </span>
+                      )}
+                    </span>
                   </p>
                 </div>
               </div>

--- a/layouts/ProjectLayout.tsx
+++ b/layouts/ProjectLayout.tsx
@@ -118,7 +118,7 @@ export default function PageLayout({
                         onClick={() => setShowSatsInfo((value) => !value)}
                         aria-label="Learn more about total sats sent"
                         aria-expanded={showSatsInfo}
-                        className="p-0 opacity-70 transition-opacity hover:opacity-100"
+                        className="p-0 text-inherit transition-colors hover:text-gray-500 dark:hover:text-gray-400"
                       >
                         <CircleQuestion className="h-3.5 w-3.5 fill-current" />
                       </button>

--- a/layouts/ProjectLayout.tsx
+++ b/layouts/ProjectLayout.tsx
@@ -110,7 +110,7 @@ export default function PageLayout({
                     <Bitcoin className="h-6 w-6 shrink-0 fill-current text-orange-500 dark:text-orange-400" />
                     {Math.round(animatedSatsSent).toLocaleString('en-US')}
                   </p>
-                  <p className="flex items-center gap-1 pl-8 text-xs uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                  <p className="flex items-center gap-1 whitespace-nowrap pl-8 text-xs uppercase tracking-wide text-gray-400 dark:text-gray-500">
                     total sats sent
                     <span className="relative flex" ref={satsInfoRef}>
                       <button
@@ -123,7 +123,7 @@ export default function PageLayout({
                         <CircleQuestion className="h-3.5 w-3.5 fill-current" />
                       </button>
                       {showSatsInfo && (
-                        <span className="absolute left-1/2 top-full z-10 mt-2 block w-64 -translate-x-1/2 rounded-lg bg-gray-900 p-3 text-left text-xs font-normal normal-case tracking-normal text-gray-100 shadow-lg dark:bg-gray-700">
+                        <span className="absolute left-1/2 top-full z-10 mt-2 block w-64 -translate-x-1/2 whitespace-normal rounded-lg bg-gray-900 p-3 text-left text-xs font-normal normal-case tracking-normal text-gray-100 shadow-lg dark:bg-gray-700">
                           Approximate all-time sats sent to {title}. These are
                           past payouts, not balances: the money has been spent
                           on the work it was given for.{' '}

--- a/layouts/ProjectLayout.tsx
+++ b/layouts/ProjectLayout.tsx
@@ -124,7 +124,7 @@ export default function PageLayout({
                       </button>
                       {showSatsInfo && (
                         <span className="absolute left-1/2 top-full z-10 mt-2 block w-64 -translate-x-1/2 whitespace-normal rounded-lg bg-gray-900 p-3 text-left text-xs font-normal normal-case tracking-normal text-gray-100 shadow-lg dark:bg-gray-700">
-                          Numbers are accumulative past payouts and don't
+                          Numbers are cumulative past payouts and don't
                           reflect current or historical balances. Sats are sent
                           monthly and spent on the work the grant was given
                           for.{' '}

--- a/layouts/ProjectLayout.tsx
+++ b/layouts/ProjectLayout.tsx
@@ -91,10 +91,7 @@ export default function PageLayout({
               )}
             </div>
             {totalSatsSent && (
-              <div
-                className="pb-6 pt-14 text-center xl:w-48 xl:text-left"
-                title={`Approximate total of sats sent to ${title} by OpenSats`}
-              >
+              <div className="pb-6 pt-14 text-center xl:w-48 xl:text-left">
                 <div className="inline-flex flex-col">
                   <p className="flex items-center gap-2 text-2xl font-medium tabular-nums tracking-tight text-gray-600 dark:text-gray-300">
                     <Bitcoin className="h-6 w-6 shrink-0 fill-current text-orange-500 dark:text-orange-400" />

--- a/layouts/ProjectLayout.tsx
+++ b/layouts/ProjectLayout.tsx
@@ -118,7 +118,7 @@ export default function PageLayout({
                         onClick={() => setShowSatsInfo((value) => !value)}
                         aria-label="Learn more about total sats sent"
                         aria-expanded={showSatsInfo}
-                        className="opacity-70 transition-opacity hover:opacity-100"
+                        className="p-0 opacity-70 transition-opacity hover:opacity-100"
                       >
                         <CircleQuestion className="h-3.5 w-3.5 fill-current" />
                       </button>

--- a/layouts/ProjectLayout.tsx
+++ b/layouts/ProjectLayout.tsx
@@ -124,10 +124,9 @@ export default function PageLayout({
                       </button>
                       {showSatsInfo && (
                         <span className="absolute left-1/2 top-full z-10 mt-2 block w-64 -translate-x-1/2 whitespace-normal rounded-lg bg-gray-900 p-3 text-left text-xs font-normal normal-case tracking-normal text-gray-100 shadow-lg dark:bg-gray-700">
-                          Numbers are cumulative past payouts and don't
-                          reflect current or historical balances. Sats are sent
-                          monthly and spent on the work the grant was given
-                          for.{' '}
+                          Numbers are cumulative past payouts and don't reflect
+                          current or historical balances. Sats are sent monthly
+                          and spent on the work the grant was given for.{' '}
                           <Link href="/transparency" className="underline">
                             Learn more
                           </Link>

--- a/layouts/ProjectLayout.tsx
+++ b/layouts/ProjectLayout.tsx
@@ -124,9 +124,9 @@ export default function PageLayout({
                       </button>
                       {showSatsInfo && (
                         <span className="absolute left-1/2 top-full z-10 mt-2 block w-64 -translate-x-1/2 whitespace-normal rounded-lg bg-gray-900 p-3 text-left text-xs font-normal normal-case tracking-normal text-gray-100 shadow-lg dark:bg-gray-700">
-                          Approximate all-time sats sent to {title}. These are
-                          past payouts, not balances: the money has been spent
-                          on the work it was given for.{' '}
+                          Approximate all-time sats sent to the project. These
+                          are past payouts, not balances: the money has been
+                          spent on the work it was given for.{' '}
                           <Link href="/transparency" className="underline">
                             Learn more
                           </Link>

--- a/scripts/generate-author-og.mjs
+++ b/scripts/generate-author-og.mjs
@@ -23,14 +23,7 @@ import {
 // (light bg, Inter type, faint network decoration) but with a circular
 // avatar on the right replacing the dense network cluster, so the
 // person, not the abstract pattern, is the focal point.
-const outputDir = path.join(
-  ROOT,
-  'public',
-  'static',
-  'images',
-  'authors',
-  'og'
-)
+const outputDir = path.join(ROOT, 'public', 'static', 'images', 'authors', 'og')
 
 // Authors who don't get a custom OG card and fall back to the default
 // brand image. Keep this list in sync with AUTHORS_WITHOUT_OG in
@@ -185,7 +178,10 @@ async function writeAuthorImage(author) {
     console.warn(`Missing avatar for ${author.slug}: ${author.avatar}`)
   }
   const svg = renderAuthorSvg(author, avatarDataUri)
-  await writePng(path.join(outputDir, `${author.slug}.png`), renderSvgToPng(svg))
+  await writePng(
+    path.join(outputDir, `${author.slug}.png`),
+    renderSvgToPng(svg)
+  )
 }
 
 async function main() {

--- a/scripts/generate-default-og.mjs
+++ b/scripts/generate-default-og.mjs
@@ -71,9 +71,7 @@ function renderDefaultSvg(wordmarkDataUri, logoDataUri) {
   const linesCount = HEADLINE_LINES.length
   const headlineBaselineLift = 24
   const headlineStartY =
-    logoBottomY -
-    headlineBaselineLift -
-    (linesCount - 1) * headlineLineHeight
+    logoBottomY - headlineBaselineLift - (linesCount - 1) * headlineLineHeight
 
   const wordmarkX = PADDING
   const wordmarkY = 64
@@ -114,9 +112,7 @@ function renderDefaultSvg(wordmarkDataUri, logoDataUri) {
   }" font-size="22" font-family="${INTER_FONT_FAMILY}" letter-spacing="1">
         ${escapeXml(FOOTER_LABEL)}
       </text>
-      <text x="${
-        OG_WIDTH - PADDING
-      }" y="${footerY}" text-anchor="end" fill="${
+      <text x="${OG_WIDTH - PADDING}" y="${footerY}" text-anchor="end" fill="${
     COLORS.url
   }" font-size="22" font-family="${INTER_FONT_FAMILY}" letter-spacing="1">
         ${escapeXml(FOOTER_URL)}

--- a/scripts/generate-donate-banner.mjs
+++ b/scripts/generate-donate-banner.mjs
@@ -13,13 +13,7 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const root = path.resolve(__dirname, '..')
 
-const OUTPUT_DIR = path.join(
-  root,
-  'public',
-  'static',
-  'images',
-  'newsletter'
-)
+const OUTPUT_DIR = path.join(root, 'public', 'static', 'images', 'newsletter')
 // Load static-weight Inter faces so resvg's font-weight matching maps
 // reliably (its variable-font wght axis support is best-effort). The
 // embedded family name on these files is "Inter 18pt", referenced in
@@ -108,11 +102,11 @@ function renderSvg(variant) {
   const leftLineGap = 8
   const leftStackHeight = preludeSize + leftLineGap + ctaSize
   const leftPreludeBaselineY = (HEIGHT - leftStackHeight) / 2 + preludeSize
-  const leftCtaBaselineY =
-    leftPreludeBaselineY + leftLineGap + ctaSize * 0.95
+  const leftCtaBaselineY = leftPreludeBaselineY + leftLineGap + ctaSize * 0.95
 
   const rightStackHeight = preTaglineSize + leftLineGap + taglineSize
-  const rightPreTaglineBaselineY = (HEIGHT - rightStackHeight) / 2 + preTaglineSize
+  const rightPreTaglineBaselineY =
+    (HEIGHT - rightStackHeight) / 2 + preTaglineSize
   const rightTaglineBaselineY =
     rightPreTaglineBaselineY + leftLineGap + taglineSize * 0.95
 

--- a/scripts/generate-grantee-map.mjs
+++ b/scripts/generate-grantee-map.mjs
@@ -16,13 +16,7 @@ const __dirname = path.dirname(__filename)
 const root = path.resolve(__dirname, '..')
 
 const SOURCE_SVG = path.join(root, 'public', 'maps', 'world.svg')
-const OUTPUT_DIR = path.join(
-  root,
-  'public',
-  'static',
-  'images',
-  'newsletter'
-)
+const OUTPUT_DIR = path.join(root, 'public', 'static', 'images', 'newsletter')
 
 const WIDTH = 2400 // render width in pixels
 
@@ -30,10 +24,46 @@ const HIGHLIGHT_COLOR = '#f97316' // tailwind orange-500
 
 // Keep this in sync with components/GranteeMap.tsx
 const GRANTEE_COUNTRY_CODES = [
-  'US', 'CA', 'DE', 'GB', 'IT', 'JP', 'NL', 'CH', 'CN', 'BR',
-  'AR', 'IE', 'HK', 'GE', 'SE', 'ES', 'PT', 'NO', 'GR', 'AU',
-  'IN', 'SI', 'KR', 'FI', 'CZ', 'UG', 'BE', 'FR', 'VN', 'UA',
-  'TR', 'SV', 'NZ', 'HU', 'SK', 'NG', 'PA', 'RO', 'GT', 'ID',
+  'US',
+  'CA',
+  'DE',
+  'GB',
+  'IT',
+  'JP',
+  'NL',
+  'CH',
+  'CN',
+  'BR',
+  'AR',
+  'IE',
+  'HK',
+  'GE',
+  'SE',
+  'ES',
+  'PT',
+  'NO',
+  'GR',
+  'AU',
+  'IN',
+  'SI',
+  'KR',
+  'FI',
+  'CZ',
+  'UG',
+  'BE',
+  'FR',
+  'VN',
+  'UA',
+  'TR',
+  'SV',
+  'NZ',
+  'HU',
+  'SK',
+  'NG',
+  'PA',
+  'RO',
+  'GT',
+  'ID',
   'AE',
 ]
 
@@ -65,9 +95,7 @@ function buildStyledSvg(rawSvg, variant) {
 
   // Strip the inline width/height — viewBox alone gives resvg the aspect
   // ratio it needs and fitTo controls the output resolution.
-  svg = svg
-    .replace(/\s+width="[^"]+"/, '')
-    .replace(/\s+height="[^"]+"/, '')
+  svg = svg.replace(/\s+width="[^"]+"/, '').replace(/\s+height="[^"]+"/, '')
 
   // Make sure a viewBox exists; fall back to the original width/height
   // if mapsvg's source somehow ships without one.
@@ -81,9 +109,9 @@ function buildStyledSvg(rawSvg, variant) {
     }
   }
 
-  const highlightSelector = GRANTEE_COUNTRY_CODES
-    .map((code) => `#${escapeForCss(code)}`)
-    .join(', ')
+  const highlightSelector = GRANTEE_COUNTRY_CODES.map(
+    (code) => `#${escapeForCss(code)}`
+  ).join(', ')
 
   // Inject a stylesheet right after the opening <svg ...> tag. resvg-js
   // supports SVG <style> elements with simple selectors.
@@ -99,10 +127,7 @@ function buildStyledSvg(rawSvg, variant) {
     }
   `
 
-  return svg.replace(
-    /<svg([^>]*)>/,
-    `<svg$1><style><![CDATA[${css}]]></style>`
-  )
+  return svg.replace(/<svg([^>]*)>/, `<svg$1><style><![CDATA[${css}]]></style>`)
 }
 
 async function main() {

--- a/scripts/generate-heartbeat-button.mjs
+++ b/scripts/generate-heartbeat-button.mjs
@@ -16,13 +16,7 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const root = path.resolve(__dirname, '..')
 
-const OUTPUT_DIR = path.join(
-  root,
-  'public',
-  'static',
-  'images',
-  'newsletter'
-)
+const OUTPUT_DIR = path.join(root, 'public', 'static', 'images', 'newsletter')
 
 // See generate-donate-banner.mjs for the rationale behind embedding
 // static-weight Inter faces under the "Inter 18pt" family.

--- a/scripts/generate-project-og.mjs
+++ b/scripts/generate-project-og.mjs
@@ -169,9 +169,9 @@ function renderSvg(project, coverImage, logomark) {
   const summarySvg = summaryLines
     .map(
       (line, index) =>
-        `<tspan x="84" dy="${
-          index === 0 ? 0 : summaryLineHeight
-        }">${escapeXml(line)}</tspan>`
+        `<tspan x="84" dy="${index === 0 ? 0 : summaryLineHeight}">${escapeXml(
+          line
+        )}</tspan>`
     )
     .join('')
 

--- a/scripts/generate-topic-og.mjs
+++ b/scripts/generate-topic-og.mjs
@@ -58,7 +58,12 @@ function renderTopicSvg(topic) {
   )
   const summaryLines =
     maxSummaryLines > 0 && summaryText
-      ? wrapText(summaryText, 52, maxSummaryLines, `topic ${topic.slug} summary`)
+      ? wrapText(
+          summaryText,
+          52,
+          maxSummaryLines,
+          `topic ${topic.slug} summary`
+        )
       : []
 
   const summarySvg = summaryLines

--- a/scripts/lib/og-network.mjs
+++ b/scripts/lib/og-network.mjs
@@ -242,9 +242,9 @@ export function networkDecor({
   for (const n of nodes) {
     nodesSvg += `<circle cx="${n.x.toFixed(1)}" cy="${n.y.toFixed(
       1
-    )}" r="${n.r.toFixed(
-      1
-    )}" fill="${color}" fill-opacity="${n.opacity.toFixed(2)}" />`
+    )}" r="${n.r.toFixed(1)}" fill="${color}" fill-opacity="${n.opacity.toFixed(
+      2
+    )}" />`
   }
 
   return `<g>${edgesSvg}${nodesSvg}</g>`
@@ -252,7 +252,9 @@ export function networkDecor({
 
 export function backgroundDecor(seed, options = {}) {
   return `
-    <rect width="${OG_WIDTH}" height="${OG_HEIGHT}" fill="${COLORS.background}" />
+    <rect width="${OG_WIDTH}" height="${OG_HEIGHT}" fill="${
+    COLORS.background
+  }" />
     ${networkDecor({ seed, ...options })}
   `
 }


### PR DESCRIPTION
Adds `totalSatsSent` to all general fund projects (plus GrapheneOS and Bitcoin Design) and refreshes the existing nostr fund numbers. Also replaces the native `title` tooltip on the sats counter with a tap-to-open popover, so the disclaimer about the numbers is visible on mobile too.

- add sats totals to general fund projects and update all existing totals
- replace the `(?)` tooltip with a popover explaining that numbers are cumulative past payouts, not balances
- fix label wrapping, button padding, and icon color quirks inherited from global button styles, and apply prettier to touched files

Closes OpenSats/content#23

Build previews:
- [/projects/bitcoin-core](https://os-website-git-general-fund-sats-sent-opensats.vercel.app/projects/bitcoin-core)
- [/projects/grapheneos](https://os-website-git-general-fund-sats-sent-opensats.vercel.app/projects/grapheneos)
- [/projects/bdk](https://os-website-git-general-fund-sats-sent-opensats.vercel.app/projects/bdk)
- [/projects/splicing](https://os-website-git-general-fund-sats-sent-opensats.vercel.app/projects/splicing)
- [/projects/bitcoindesign](https://os-website-git-general-fund-sats-sent-opensats.vercel.app/projects/bitcoindesign)
- [/projects/damus](https://os-website-git-general-fund-sats-sent-opensats.vercel.app/projects/damus)
- [/projects/routstr](https://os-website-git-general-fund-sats-sent-opensats.vercel.app/projects/routstr)
