### PR TITLE
Update LTS application form with 2026 criteria

### DIFF
--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -1,9 +1,6 @@
-import { useRef, useState } from 'react'
-import { useRouter } from 'next/router'
-import { useForm } from 'react-hook-form'
-import { fetchPostJSON } from '../utils/api-helpers'
-import StepIndicator from './grant-application/StepIndicator'
-import StepNavigation from './grant-application/StepNavigation'
+import MultiStepApplicationForm, {
+  StepConfig,
+} from './grant-application/MultiStepApplicationForm'
 import Prerequisites from './grant-application/steps/Prerequisites'
 import ApplicantDetails from './grant-application/steps/ApplicantDetails'
 import ProjectDetails from './grant-application/steps/ProjectDetails'
@@ -12,19 +9,85 @@ import Timeline from './grant-application/steps/Timeline'
 import Budget from './grant-application/steps/Budget'
 import ReferencesReview from './grant-application/steps/ReferencesReview'
 import AnythingElse from './grant-application/steps/AnythingElse'
-import Review from './grant-application/steps/Review'
-import { FormValues } from './grant-application/types'
+import Review, { ReviewSection } from './grant-application/steps/Review'
 
-const STEPS = [
+const REVIEW_SECTIONS: ReviewSection[] = [
+  {
+    title: 'Applicant',
+    fields: [
+      ['Your Name', 'your_name'],
+      ['Email', 'email'],
+      ['Personal GitHub', 'personal_github'],
+      ['Other Contact Details', 'other_contact'],
+      ['Lead Developer or Maintainer', 'are_you_lead'],
+      ['Project Lead', 'other_lead'],
+    ],
+  },
+  {
+    title: 'Project',
+    fields: [
+      ['Main Focus', 'main_focus'],
+      ['Project Name', 'project_name'],
+      ['Project Description', 'short_description'],
+      ['Potential Impact', 'potential_impact'],
+    ],
+  },
+  {
+    title: 'Written References',
+    fields: [
+      ['References', 'references'],
+      ['Prior Contributions', 'bios'],
+      ['Years of Developer Experience', 'years_experience'],
+    ],
+  },
+  {
+    title: 'Source Code',
+    fields: [
+      ['Repository', 'github'],
+      ['Open-Source License', 'license'],
+      ['Project Website', 'website'],
+      ['Screenshots / Videos', 'screenshots_videos'],
+    ],
+  },
+  {
+    title: 'Timeline',
+    fields: [
+      ['Duration', 'duration'],
+      ['Time Commitment', 'commitment'],
+      ['Project Timeline and Potential Milestones', 'timelines'],
+    ],
+  },
+  {
+    title: 'Budget',
+    fields: [
+      ['Costs & Proposed Budget', 'proposed_budget'],
+      ['Prior Funding', 'has_received_funding'],
+      ['Prior Funding Details', 'what_funding'],
+      ['Additional Funding Sources', 'has_additional_funding'],
+      ['Additional Funding Details', 'additional_funding'],
+    ],
+  },
+  {
+    title: 'Final',
+    fields: [
+      ['Video Application', 'video_application'],
+      ['Anything Else', 'anything_else'],
+    ],
+  },
+]
+
+const STEPS: StepConfig[] = [
   {
     id: 'prerequisites',
     title: 'Prerequisites',
     fields: ['read_criteria', 'read_faq', 'has_references', 'free_open_source'],
+    render: (props) => <Prerequisites {...props} />,
   },
   {
     id: 'applicant',
     title: 'Applicant',
     fields: ['your_name', 'email'],
+    render: (props) => <ApplicantDetails {...props} />,
   },
   {
     id: 'project',
@@ -35,21 +98,25 @@ const STEPS = [
       'short_description',
       'potential_impact',
     ],
+    render: (props) => <ProjectDetails {...props} />,
   },
   {
     id: 'references',
     title: 'Written References',
     fields: ['references', 'bios', 'years_experience'],
+    render: (props) => <ReferencesReview {...props} />,
   },
   {
     id: 'source',
     title: 'Source Code',
     fields: ['github', 'license'],
+    render: (props) => <SourceCode {...props} />,
   },
   {
     id: 'timeline',
     title: 'Timeline',
     fields: ['duration', 'timelines', 'commitment'],
+    render: (props) => <Timeline {...props} />,
   },
   {
     id: 'budget',
@@ -61,148 +128,31 @@ const STEPS = [
       'has_additional_funding',
       'additional_funding',
     ],
+    render: (props) => <Budget {...props} />,
   },
   {
     id: 'anything_else',
     title: 'Final',
     fields: ['no_vibed_garbage', 'human_in_charge', 'discipline_and_agency'],
+    render: (props) => <AnythingElse {...props} />,
   },
   {
     id: 'review',
     title: 'Review',
     fields: [],
+    render: (props) => (
+      <Review watch={props.watch} sections={REVIEW_SECTIONS} />
+    ),
   },
-] as const
+]
 
-export default function ApplicationForm() {
-  const [currentStep, setCurrentStep] = useState(0)
-  const [loading, setLoading] = useState(false)
-  const [formLoadedAt] = useState(() => Date.now())
-  const [failureReason, setFailureReason] = useState<string>()
-  const formRef = useRef<HTMLFormElement>(null)
-  const router = useRouter()
-
-  const {
-    watch,
-    register,
-    handleSubmit,
-    trigger,
-    formState: { errors },
-  } = useForm<FormValues>({
-    defaultValues: {
-      duration: '6 months',
-    },
-  })
-
-  const scrollToTop = () => {
-    formRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-  }
-
-  const handleNext = async () => {
-    if (loading) return
-    setFailureReason(undefined)
-    const fieldsToValidate = [...STEPS[currentStep].fields]
-    const isValid = await trigger(fieldsToValidate)
-    if (isValid) {
-      setCurrentStep((s) => s + 1)
-      scrollToTop()
-    }
-  }
-
-  const handleBack = () => {
-    if (loading) return
-    setFailureReason(undefined)
-    setCurrentStep((s) => s - 1)
-    scrollToTop()
-  }
-
-  const handleStepClick = (step: number) => {
-    if (loading) return
-    setFailureReason(undefined)
-    if (step < currentStep) {
-      setCurrentStep(step)
-      scrollToTop()
-    }
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const onSubmit = async (data: any) => {
-    if (currentStep !== STEPS.length - 1 || loading) return
-
-    setLoading(true)
-    const submissionData = { ...data, formLoadedAt }
-
-    try {
-      const res = await fetchPostJSON('/api/github', submissionData)
-      if (res.message === 'success') {
-        console.info('Application tracked')
-      } else {
-        // Fail silently
-      }
-    } catch (e) {
-      if (e instanceof Error) {
-        // Fail silently
-      }
-    } finally {
-      try {
-        const res = await fetchPostJSON('/api/sendgrid', submissionData)
-        if (res.message === 'success') {
-          router.push('/submitted')
-        } else {
-          setFailureReason(res.message)
-        }
-      } catch (e) {
-        if (e instanceof Error) {
-          setFailureReason(e.message)
-        }
-      } finally {
-        setLoading(false)
-      }
-    }
-  }
-
-  const stepProps = { register, watch, errors }
-
+export default function GrantApplicationForm() {
   return (
-    <form
-      ref={formRef}
-      onSubmit={(e) => e.preventDefault()}
-      className="apply flex max-w-2xl flex-col gap-4"
-    >
-      <input type="hidden" {...register('general_fund', { value: true })} />
-
-      <StepIndicator
-        steps={STEPS}
-        currentStep={currentStep}
-        onStepClick={handleStepClick}
-      />
-
-      <hr />
-
-      {currentStep === 0 && <Prerequisites {...stepProps} />}
-      {currentStep === 1 && <ApplicantDetails {...stepProps} />}
-      {currentStep === 2 && <ProjectDetails {...stepProps} />}
-      {currentStep === 3 && <ReferencesReview {...stepProps} />}
-      {currentStep === 4 && <SourceCode {...stepProps} />}
-      {currentStep === 5 && <Timeline {...stepProps} />}
-      {currentStep === 6 && <Budget {...stepProps} />}
-      {currentStep === 7 && <AnythingElse {...stepProps} />}
-      {currentStep === 8 && <Review watch={watch} />}
-
-      <StepNavigation
-        currentStep={currentStep}
-        totalSteps={STEPS.length}
-        onBack={handleBack}
-        onNext={handleNext}
-        onSubmit={handleSubmit(onSubmit)}
-        loading={loading}
-      />
-
-      {!!failureReason && (
-        <p className="rounded bg-red-500 p-4 text-white">
-          Something went wrong! {failureReason}
-        </p>
-      )}
-    </form>
+    <MultiStepApplicationForm
+      steps={STEPS}
+      hiddenFields={{ general_fund: true }}
+      defaultValues={{ duration: '6 months' }}
+      submitLabel="Submit Grant Application"
+    />
   )
 }

--- a/components/LTSApplicationForm.tsx
+++ b/components/LTSApplicationForm.tsx
@@ -1,289 +1,124 @@
-import { useRouter } from 'next/router'
-import { useState } from 'react'
-import { useForm } from 'react-hook-form'
-import { fetchPostJSON } from '../utils/api-helpers'
-import FormButton from '@/components/FormButton'
-import * as EmailValidator from 'email-validator'
-import CustomLink from './Link'
+import MultiStepApplicationForm, {
+  StepConfig,
+} from './grant-application/MultiStepApplicationForm'
+import Prerequisites from './grant-application/steps/Prerequisites'
+import ApplicantDetails from './grant-application/steps/ApplicantDetails'
+import LtsWork from './grant-application/steps/LtsWork'
+import ReferencesReview from './grant-application/steps/ReferencesReview'
+import Budget from './grant-application/steps/Budget'
+import AnythingElse from './grant-application/steps/AnythingElse'
+import Review, { ReviewSection } from './grant-application/steps/Review'
 
-export default function ApplicationForm() {
-  const [loading, setLoading] = useState(false)
-  const [formLoadedAt] = useState(() => Date.now())
-  const router = useRouter()
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm()
+const REVIEW_SECTIONS: ReviewSection[] = [
+  {
+    title: 'Applicant',
+    fields: [
+      ['Your Name', 'your_name'],
+      ['Email', 'email'],
+      ['Personal GitHub', 'personal_github'],
+      ['Other Contact Details', 'other_contact'],
+      ['Lead Developer or Maintainer', 'are_you_lead'],
+      ['Project Lead', 'other_lead'],
+    ],
+  },
+  {
+    title: 'Work',
+    fields: [
+      ['Main Focus', 'main_focus'],
+      ['Project Description', 'short_description'],
+      ['Potential Impact', 'potential_impact'],
+    ],
+  },
+  {
+    title: 'Written References',
+    fields: [
+      ['References', 'references'],
+      ['Prior Contributions', 'bios'],
+      ['Years of Developer Experience', 'years_experience'],
+    ],
+  },
+  {
+    title: 'Budget',
+    fields: [
+      ['Costs & Proposed Budget', 'proposed_budget'],
+      ['Prior Funding', 'has_received_funding'],
+      ['Prior Funding Details', 'what_funding'],
+      ['Additional Funding Sources', 'has_additional_funding'],
+      ['Additional Funding Details', 'additional_funding'],
+    ],
+  },
+  {
+    title: 'Final',
+    fields: [
+      ['Video Application', 'video_application'],
+      ['Anything Else', 'anything_else'],
+    ],
+  },
+]
 
-  const [failureReason, setFailureReason] = useState<string>()
+const STEPS: StepConfig[] = [
+  {
+    id: 'prerequisites',
+    title: 'Prerequisites',
+    fields: ['read_criteria', 'read_faq', 'has_references', 'free_open_source'],
+    render: (props) => <Prerequisites {...props} />,
+  },
+  {
+    id: 'applicant',
+    title: 'Applicant',
+    fields: ['your_name', 'email'],
+    render: (props) => <ApplicantDetails {...props} />,
+  },
+  {
+    id: 'work',
+    title: 'Work',
+    fields: ['main_focus', 'short_description', 'potential_impact'],
+    render: (props) => <LtsWork {...props} />,
+  },
+  {
+    id: 'references',
+    title: 'Written References',
+    fields: ['references', 'bios', 'years_experience'],
+    render: (props) => <ReferencesReview {...props} />,
+  },
+  {
+    id: 'budget',
+    title: 'Budget',
+    fields: [
+      'proposed_budget',
+      'has_received_funding',
+      'what_funding',
+      'has_additional_funding',
+      'additional_funding',
+    ],
+    render: (props) => <Budget {...props} />,
+  },
+  {
+    id: 'anything_else',
+    title: 'Final',
+    fields: ['no_vibed_garbage', 'human_in_charge', 'discipline_and_agency'],
+    render: (props) => <AnythingElse {...props} />,
+  },
+  {
+    id: 'review',
+    title: 'Review',
+    fields: [],
+    render: (props) => (
+      <Review watch={props.watch} sections={REVIEW_SECTIONS} />
+    ),
+  },
+]
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const onSubmit = async (data: any) => {
-    setLoading(true)
-    const submissionData = { ...data, formLoadedAt }
-
-    try {
-      // Track application in GitHub
-      const res = await fetchPostJSON('/api/github', submissionData)
-      if (res.message === 'success') {
-        console.info('Application tracked') // Succeed silently
-      } else {
-        // Fail silently
-      }
-    } catch (e) {
-      if (e instanceof Error) {
-        // Fail silently
-      }
-    } finally {
-      // Mail application to us
-      try {
-        const res = await fetchPostJSON('/api/sendgrid', submissionData)
-        if (res.message === 'success') {
-          router.push('/submitted')
-        } else {
-          setFailureReason(res.message)
-        }
-      } catch (e) {
-        if (e instanceof Error) {
-          setFailureReason(e.message)
-        }
-      } finally {
-        setLoading(false)
-      }
-    }
-  }
-
+export default function LTSApplicationForm() {
   return (
-    <form
-      onSubmit={handleSubmit(onSubmit)}
-      className="flex max-w-2xl flex-col gap-4"
-    >
-      <input
-        type="hidden"
-        {...register('project_name', { value: 'Long-term Grant' })}
-      />
-      <input
-        type="hidden"
-        {...register('timelines', { value: 'Ongoing work (LTS Grant).' })}
-      />
-      <input type="hidden" {...register('LTS', { value: true })} />
-
-      <hr />
-      <h2>Who Are You?</h2>
-      <label className="block">
-        Your Name *<br />
-        <small>Feel free to use your nym.</small>
-        <input
-          type="text"
-          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
-          placeholder="John Doe"
-          {...register('your_name', { required: true })}
-        />
-      </label>
-      <label className="block">
-        Email *
-        <input
-          type="email"
-          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
-          placeholder="satoshin@gmx.com"
-          {...register('email', {
-            required: true,
-            validate: (v) =>
-              EmailValidator.validate(v) ||
-              'Please enter a valid email address',
-          })}
-        />
-        <small className="text-red-500">
-          {errors?.email && errors.email.message.toString()}
-        </small>
-      </label>
-      <label className="block">
-        Personal Website, GitHub profile, or other Social Media
-        <input
-          type="text"
-          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
-          {...register('personal_github')}
-        />
-      </label>
-      <label className="offscreen-field block">
-        Organization Website
-        <input
-          type="text"
-          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
-          {...register('organization_website')}
-          tabIndex={-1}
-          autoComplete="off"
-        />
-      </label>
-      <label className="block">
-        Prior Contributions *<br />
-        <small>
-          Describe the contributions you've made to Bitcoin Core or other
-          Bitcoin-related open-source projects.
-        </small>
-        <textarea
-          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
-          {...register('bios', { required: true })}
-        />
-      </label>
-      <label className="block">
-        Years of Developer Experience
-        <input
-          type="text"
-          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
-          {...register('years_experience')}
-        />
-      </label>
-      <h2>What Will You Work On?</h2>
-
-      <label className="block">
-        Project Description *<br />
-        <small>
-          What do you intend to work on? Please be as specific as possible.
-        </small>
-        <textarea
-          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
-          {...register('short_description', { required: true })}
-        />
-      </label>
-
-      <label className="block">
-        Potential Impact *<br />
-        <small>
-          Why is your work important to Bitcoin or the broader free and
-          open-source community?
-        </small>
-        <textarea
-          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
-          {...register('potential_impact', { required: true })}
-        />
-      </label>
-
-      <label className="block">
-        Budget Expectations *<br />
-        <small>
-          Submit a proposed budget (in USD) around how much funding you are
-          requesting and how it will be used.
-        </small>
-        <textarea
-          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
-          {...register('proposed_budget', { required: true })}
-        />
-      </label>
-
-      <h2>Anything Else We Should Know?</h2>
-
-      <label className="block">
-        Feel free to share whatever else might be important.
-        <textarea
-          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
-          {...register('anything_else')}
-        />
-      </label>
-      <label className="inline-flex items-center">
-        <input
-          type="checkbox"
-          className="rounded-md border-gray-300 shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
-          {...register('has_received_funding')}
-        />
-        <span className="ml-2">
-          I plan to receive or am receiving funding outside of OpenSats.
-        </span>
-      </label>
-
-      <label className="block">
-        If you receive or plan to receive any other funding, include those
-        details (dates & amounts):
-        <input
-          type="text"
-          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
-          {...register('what_funding')}
-        />
-      </label>
-
-      <h2>Final Questions</h2>
-
-      <label className="block">
-        Main Focus *
-        <br />
-        <small>In which area will your project have the most impact?</small>
-        <select
-          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
-          {...register('main_focus', { required: true })}
-        >
-          <option value="">(Choose One)</option>
-          <option value="core">Bitcoin Core</option>
-          <option value="layer1">Layer1 / Bitcoin</option>
-          <option value="layer2">Layer2 / Lightning</option>
-          <option value="nostr">Nostr</option>
-          <option value="other">Other</option>
-        </select>
-      </label>
-
-      <label className="block">
-        Any References? *<br />
-        <small>
-          Please list any references from the Bitcoin community or open-source
-          space that we could contact for more information on you or your
-          project.
-        </small>
-        <textarea
-          className="mt-1 block w-full rounded-md border-gray-300 text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
-          {...register('references', { required: true })}
-        />
-      </label>
-
-      <label className="inline-flex items-center">
-        <input
-          type="checkbox"
-          className="rounded-md border-gray-300 shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50"
-          {...register('free_open_source', { required: true })}
-        />
-        <span className="ml-2">
-          Will your contributions be free and open-source? *
-        </span>
-      </label>
-      <small>
-        We focus on supporting projects that are free as in freedom and open to
-        all. Your project should have a proper open-source license and any
-        additional materials (such as documentation, educational materials,
-        etc.) should be available to the public under a{' '}
-        <CustomLink href="https://www.gnu.org/licenses/license-list.html">
-          free and open license
-        </CustomLink>
-        .
-      </small>
-
-      <div className="prose">
-        <small>
-          OpenSats requires each recipient to sign a Grant Agreement before any
-          funds are disbursed. Using the reports and presentations required by
-          the Grant Agreement, OpenSats will monitor and evaluate the
-          expenditure of funds on a quarterly basis. Any apparent misuse of
-          grant funds will be promptly investigated. If OpenSats discovers that
-          the funds have been misused, the recipient will be required to return
-          the funds immediately, and be barred from further distributions.
-          OpenSats will maintain the records required by Revenue Ruling 56-304,
-          1956-2 C.B. 306 regarding distribution of charitable funds to
-          individuals.
-        </small>
-      </div>
-
-      <FormButton
-        variant="disabled"
-        type="submit"
-        disabled={true}
-        aria-busy={loading}
-      >
-        {loading ? 'Submitting…' : 'Submit LTS Application'}
-      </FormButton>
-
-      {!!failureReason && (
-        <p className="rounded bg-red-500 p-4 text-white">
-          Something went wrong! {failureReason}
-        </p>
-      )}
-    </form>
+    <MultiStepApplicationForm
+      steps={STEPS}
+      hiddenFields={{
+        project_name: 'Long-term Grant',
+        timelines: 'Ongoing work (LTS Grant).',
+        LTS: true,
+      }}
+      submitLabel="Submit LTS Application"
+    />
   )
 }

--- a/components/LTSApplicationForm.tsx
+++ b/components/LTSApplicationForm.tsx
@@ -60,7 +60,13 @@ const STEPS: StepConfig[] = [
   {
     id: 'prerequisites',
     title: 'Prerequisites',
-    fields: ['read_criteria', 'read_faq', 'has_references', 'free_open_source'],
+    fields: [
+      'read_criteria',
+      'read_faq',
+      'has_references',
+      'free_open_source',
+      'lts_right_fit',
+    ],
     render: (props) => <Prerequisites {...props} />,
   },
   {

--- a/components/grant-application/CheckboxGroupError.tsx
+++ b/components/grant-application/CheckboxGroupError.tsx
@@ -1,0 +1,18 @@
+import { FieldErrors } from 'react-hook-form'
+
+interface CheckboxGroupErrorProps {
+  errors: FieldErrors
+  names: readonly string[]
+  message?: string
+}
+
+export default function CheckboxGroupError({
+  errors,
+  names,
+  message = 'You must acknowledge all of the above.',
+}: CheckboxGroupErrorProps) {
+  const hasError = names.some((name) => errors[name])
+  if (!hasError) return null
+
+  return <small className="block text-red-500">{message}</small>
+}

--- a/components/grant-application/MultiStepApplicationForm.tsx
+++ b/components/grant-application/MultiStepApplicationForm.tsx
@@ -128,8 +128,6 @@ export default function MultiStepApplicationForm({
         onStepClick={handleStepClick}
       />
 
-      <hr />
-
       {steps[currentStep].render(stepProps)}
 
       <StepNavigation

--- a/components/grant-application/MultiStepApplicationForm.tsx
+++ b/components/grant-application/MultiStepApplicationForm.tsx
@@ -39,7 +39,11 @@ export default function MultiStepApplicationForm({
     handleSubmit,
     trigger,
     formState: { errors },
-  } = useForm<FormValues>({ defaultValues })
+  } = useForm<FormValues>({
+    // Hidden fields are seeded as default values so watch() sees them on
+    // first render, before the hidden inputs register on mount.
+    defaultValues: { ...hiddenFields, ...defaultValues },
+  })
 
   const scrollToTop = () => {
     formRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })

--- a/components/grant-application/MultiStepApplicationForm.tsx
+++ b/components/grant-application/MultiStepApplicationForm.tsx
@@ -1,0 +1,150 @@
+import { ReactNode, useRef, useState } from 'react'
+import { useRouter } from 'next/router'
+import { DefaultValues, useForm } from 'react-hook-form'
+import { fetchPostJSON } from '../../utils/api-helpers'
+import StepIndicator from './StepIndicator'
+import StepNavigation from './StepNavigation'
+import { FormValues, StepProps } from './types'
+
+export interface StepConfig {
+  id: string
+  title: string
+  fields: readonly string[]
+  render: (props: StepProps) => ReactNode
+}
+
+interface MultiStepApplicationFormProps {
+  steps: readonly StepConfig[]
+  hiddenFields?: Record<string, string | boolean>
+  defaultValues?: DefaultValues<FormValues>
+  submitLabel: string
+}
+
+export default function MultiStepApplicationForm({
+  steps,
+  hiddenFields = {},
+  defaultValues,
+  submitLabel,
+}: MultiStepApplicationFormProps) {
+  const [currentStep, setCurrentStep] = useState(0)
+  const [loading, setLoading] = useState(false)
+  const [formLoadedAt] = useState(() => Date.now())
+  const [failureReason, setFailureReason] = useState<string>()
+  const formRef = useRef<HTMLFormElement>(null)
+  const router = useRouter()
+
+  const {
+    watch,
+    register,
+    handleSubmit,
+    trigger,
+    formState: { errors },
+  } = useForm<FormValues>({ defaultValues })
+
+  const scrollToTop = () => {
+    formRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+
+  const handleNext = async () => {
+    if (loading) return
+    setFailureReason(undefined)
+    const fieldsToValidate = [...steps[currentStep].fields]
+    const isValid = await trigger(fieldsToValidate)
+    if (isValid) {
+      setCurrentStep((s) => s + 1)
+      scrollToTop()
+    }
+  }
+
+  const handleBack = () => {
+    if (loading) return
+    setFailureReason(undefined)
+    setCurrentStep((s) => s - 1)
+    scrollToTop()
+  }
+
+  const handleStepClick = (step: number) => {
+    if (loading) return
+    setFailureReason(undefined)
+    if (step < currentStep) {
+      setCurrentStep(step)
+      scrollToTop()
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const onSubmit = async (data: any) => {
+    if (currentStep !== steps.length - 1 || loading) return
+
+    setLoading(true)
+    const submissionData = { ...data, formLoadedAt }
+
+    try {
+      const res = await fetchPostJSON('/api/github', submissionData)
+      if (res.message === 'success') {
+        console.info('Application tracked')
+      } else {
+        // Fail silently
+      }
+    } catch (e) {
+      if (e instanceof Error) {
+        // Fail silently
+      }
+    } finally {
+      try {
+        const res = await fetchPostJSON('/api/sendgrid', submissionData)
+        if (res.message === 'success') {
+          router.push('/submitted')
+        } else {
+          setFailureReason(res.message)
+        }
+      } catch (e) {
+        if (e instanceof Error) {
+          setFailureReason(e.message)
+        }
+      } finally {
+        setLoading(false)
+      }
+    }
+  }
+
+  const stepProps = { register, watch, errors }
+
+  return (
+    <form
+      ref={formRef}
+      onSubmit={(e) => e.preventDefault()}
+      className="apply flex max-w-2xl flex-col gap-4"
+    >
+      {Object.entries(hiddenFields).map(([name, value]) => (
+        <input key={name} type="hidden" {...register(name, { value })} />
+      ))}
+
+      <StepIndicator
+        steps={steps}
+        currentStep={currentStep}
+        onStepClick={handleStepClick}
+      />
+
+      <hr />
+
+      {steps[currentStep].render(stepProps)}
+
+      <StepNavigation
+        currentStep={currentStep}
+        totalSteps={steps.length}
+        onBack={handleBack}
+        onNext={handleNext}
+        onSubmit={handleSubmit(onSubmit)}
+        loading={loading}
+        submitLabel={submitLabel}
+      />
+
+      {!!failureReason && (
+        <p className="rounded bg-red-500 p-4 text-white">
+          Something went wrong! {failureReason}
+        </p>
+      )}
+    </form>
+  )
+}

--- a/components/grant-application/MultiStepApplicationForm.tsx
+++ b/components/grant-application/MultiStepApplicationForm.tsx
@@ -120,6 +120,8 @@ export default function MultiStepApplicationForm({
         <input key={name} type="hidden" {...register(name, { value })} />
       ))}
 
+      <hr />
+
       <StepIndicator
         steps={steps}
         currentStep={currentStep}

--- a/components/grant-application/StepIndicator.tsx
+++ b/components/grant-application/StepIndicator.tsx
@@ -23,7 +23,9 @@ export default function StepIndicator({
           return (
             <li
               key={step.id}
-              className="!m-0 flex items-center gap-2 !p-0 sm:gap-3"
+              className={`!m-0 flex items-center gap-2 !p-0 sm:gap-3 ${
+                i < steps.length - 1 ? 'min-w-0' : ''
+              }`}
             >
               <button
                 type="button"
@@ -41,7 +43,7 @@ export default function StepIndicator({
               </button>
               {i < steps.length - 1 && (
                 <span
-                  className={`hidden h-px sm:block sm:w-6 ${
+                  className={`hidden h-px min-w-0 shrink sm:block sm:w-6 ${
                     isCompleted
                       ? 'bg-orange-400'
                       : 'bg-gray-300 dark:bg-gray-600'

--- a/components/grant-application/StepNavigation.tsx
+++ b/components/grant-application/StepNavigation.tsx
@@ -5,6 +5,7 @@ interface StepNavigationProps {
   onNext: () => void
   onSubmit: () => void
   loading: boolean
+  submitLabel: string
 }
 
 export default function StepNavigation({
@@ -14,6 +15,7 @@ export default function StepNavigation({
   onNext,
   onSubmit,
   loading,
+  submitLabel,
 }: StepNavigationProps) {
   const isLast = currentStep === totalSteps - 1
 
@@ -44,7 +46,7 @@ export default function StepNavigation({
           aria-busy={loading}
           className="cursor-not-allowed rounded-md bg-orange-500 px-6 py-2 text-sm font-semibold text-white opacity-50"
         >
-          {loading ? 'Submitting...' : 'Submit Grant Application'}
+          {loading ? 'Submitting...' : submitLabel}
         </button>
       ) : (
         <button

--- a/components/grant-application/steps/AnythingElse.tsx
+++ b/components/grant-application/steps/AnythingElse.tsx
@@ -1,6 +1,12 @@
 import CustomLink from '@/components/Link'
-import FieldError from '../FieldError'
+import CheckboxGroupError from '../CheckboxGroupError'
 import { StepProps, inputClass, checkboxClass } from '../types'
+
+const VIBE_CHECK_FIELDS = [
+  'no_vibed_garbage',
+  'human_in_charge',
+  'discipline_and_agency',
+] as const
 
 export default function AnythingElse({ register, errors }: StepProps) {
   return (
@@ -15,11 +21,6 @@ export default function AnythingElse({ register, errors }: StepProps) {
         />
         <span>I promise to not produce vibed garbage.</span>
       </label>
-      <FieldError
-        errors={errors}
-        name="no_vibed_garbage"
-        message="Please confirm that you will not produce vibed garbage"
-      />
 
       <label className="inline-flex items-start gap-2">
         <input
@@ -32,11 +33,6 @@ export default function AnythingElse({ register, errors }: StepProps) {
           of the project.
         </span>
       </label>
-      <FieldError
-        errors={errors}
-        name="human_in_charge"
-        message="Please confirm that a human is in charge of the project"
-      />
 
       <label className="inline-flex items-start gap-2">
         <input
@@ -52,11 +48,8 @@ export default function AnythingElse({ register, errors }: StepProps) {
           to the project.
         </span>
       </label>
-      <FieldError
-        errors={errors}
-        name="discipline_and_agency"
-        message="Please confirm that you will bring discipline and agency"
-      />
+
+      <CheckboxGroupError errors={errors} names={VIBE_CHECK_FIELDS} />
 
       <small>
         The use of LLMs and coding agents is perfectly fine. These are tools,

--- a/components/grant-application/steps/LtsWork.tsx
+++ b/components/grant-application/steps/LtsWork.tsx
@@ -1,0 +1,55 @@
+import FieldError from '../FieldError'
+import { StepProps, inputClass } from '../types'
+
+export default function LtsWork({ register, errors }: StepProps) {
+  return (
+    <>
+      <h2>What Will You Work On?</h2>
+
+      <label className="block">
+        Main Focus *
+        <br />
+        <small>In which area will your work have the most impact?</small>
+        <select
+          className={inputClass}
+          {...register('main_focus', { required: true })}
+        >
+          <option value="">(Choose One)</option>
+          <option value="core">Bitcoin Core</option>
+          <option value="layer1">Layer1 / Bitcoin</option>
+          <option value="layer2">Layer2 / Lightning</option>
+          <option value="nostr">Nostr</option>
+          <option value="other">Other</option>
+        </select>
+        <FieldError errors={errors} name="main_focus" />
+      </label>
+
+      <label className="block">
+        Project Description *<br />
+        <small>
+          What do you intend to work on? Please be as specific as possible.
+        </small>
+        <textarea
+          rows={5}
+          className={inputClass}
+          {...register('short_description', { required: true })}
+        />
+        <FieldError errors={errors} name="short_description" />
+      </label>
+
+      <label className="block">
+        Potential Impact *<br />
+        <small>
+          Why is your work important to Bitcoin or the broader free and
+          open-source community?
+        </small>
+        <textarea
+          rows={5}
+          className={inputClass}
+          {...register('potential_impact', { required: true })}
+        />
+        <FieldError errors={errors} name="potential_impact" />
+      </label>
+    </>
+  )
+}

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -87,6 +87,28 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
       />
       {watch('free_open_source') && <LicenseExplainer />}
 
+      {watch('LTS') && (
+        <>
+          <label className="inline-flex items-start gap-2">
+            <input
+              type="checkbox"
+              className={`mt-1 ${checkboxClass}`}
+              {...register('lts_right_fit', { required: true })}
+            />
+            <span>
+              My track record meets the LTS criteria above, and a{' '}
+              <CustomLink href="/apply/grant">General Grant</CustomLink> would
+              not be the right fit for me
+            </span>
+          </label>
+          <FieldError
+            errors={errors}
+            name="lts_right_fit"
+            message="LTS Grants are reserved for proven long-term contributors. If this does not describe you, please consider applying for a General Grant instead."
+          />
+        </>
+      )}
+
       <h2>Prepare Your Application</h2>
       <p>
         You can{' '}

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -92,8 +92,8 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
           />
           <span>
             My track record meets the LTS criteria above, and a{' '}
-            <CustomLink href="/apply/grant">General Grant</CustomLink> would
-            not be the right fit for me
+            <CustomLink href="/apply/grant">General Grant</CustomLink> would not
+            be the right fit for me
           </span>
         </label>
       )}

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -1,9 +1,25 @@
 import CustomLink from '@/components/Link'
-import FieldError from '../FieldError'
+import CheckboxGroupError from '../CheckboxGroupError'
 import LicenseExplainer from '../LicenseExplainer'
 import { StepProps, checkboxClass } from '../types'
 
 export default function Prerequisites({ register, watch, errors }: StepProps) {
+  const isLts = watch('LTS')
+  const checkboxFields = isLts
+    ? ([
+        'read_criteria',
+        'read_faq',
+        'has_references',
+        'free_open_source',
+        'lts_right_fit',
+      ] as const)
+    : ([
+        'read_criteria',
+        'read_faq',
+        'has_references',
+        'free_open_source',
+      ] as const)
+
   return (
     <>
       <h2>Before You Begin</h2>
@@ -24,11 +40,6 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
           <CustomLink href="/apply#criteria">application criteria</CustomLink>
         </span>
       </label>
-      <FieldError
-        errors={errors}
-        name="read_criteria"
-        message="Please read the application criteria before continuing"
-      />
 
       <label className="inline-flex items-start gap-2">
         <input
@@ -41,11 +52,6 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
           <CustomLink href="/faq/application">Application FAQ</CustomLink>
         </span>
       </label>
-      <FieldError
-        errors={errors}
-        name="read_faq"
-        message="Please read the Application FAQ before continuing"
-      />
 
       <label className="inline-flex items-start gap-2">
         <input
@@ -61,11 +67,6 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
           from people familiar with my work are required
         </span>
       </label>
-      <FieldError
-        errors={errors}
-        name="has_references"
-        message="Please prepare your reference letters before continuing. Reference letters can be included as part of your application or emailed to references@opensats.org once your application is submitted. The evaluation of your application will not start until we have two references."
-      />
 
       <label className="inline-flex items-start gap-2">
         <input
@@ -80,34 +81,24 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
           </CustomLink>
         </span>
       </label>
-      <FieldError
-        errors={errors}
-        name="free_open_source"
-        message="Your project must be free and open-source to be eligible"
-      />
       {watch('free_open_source') && <LicenseExplainer />}
 
-      {watch('LTS') && (
-        <>
-          <label className="inline-flex items-start gap-2">
-            <input
-              type="checkbox"
-              className={`mt-1 ${checkboxClass}`}
-              {...register('lts_right_fit', { required: true })}
-            />
-            <span>
-              My track record meets the LTS criteria above, and a{' '}
-              <CustomLink href="/apply/grant">General Grant</CustomLink> would
-              not be the right fit for me
-            </span>
-          </label>
-          <FieldError
-            errors={errors}
-            name="lts_right_fit"
-            message="LTS Grants are reserved for proven long-term contributors. If this does not describe you, please consider applying for a General Grant instead."
+      {isLts && (
+        <label className="inline-flex items-start gap-2">
+          <input
+            type="checkbox"
+            className={`mt-1 ${checkboxClass}`}
+            {...register('lts_right_fit', { required: true })}
           />
-        </>
+          <span>
+            My track record meets the LTS criteria above, and a{' '}
+            <CustomLink href="/apply/grant">General Grant</CustomLink> would
+            not be the right fit for me
+          </span>
+        </label>
       )}
+
+      <CheckboxGroupError errors={errors} names={checkboxFields} />
 
       <h2>Prepare Your Application</h2>
       <p>

--- a/components/grant-application/steps/ReferencesReview.tsx
+++ b/components/grant-application/steps/ReferencesReview.tsx
@@ -8,7 +8,9 @@ export default function ReferencesReview({
 }: StepProps) {
   const applicantName = watch?.('your_name') || '[Applicant Name]'
   const projectName = watch?.('project_name') || '[Project Name]'
-  const suggestedSubject = `Reference Letter for ${projectName} by ${applicantName}`
+  const suggestedSubject = watch?.('LTS')
+    ? `Reference Letter for ${applicantName} (LTS)`
+    : `Reference Letter for ${projectName} by ${applicantName}`
 
   return (
     <>

--- a/components/grant-application/steps/Review.tsx
+++ b/components/grant-application/steps/Review.tsx
@@ -1,74 +1,15 @@
 import { UseFormWatch } from 'react-hook-form'
 import { FormValues } from '../types'
 
-interface ReviewProps {
-  watch: UseFormWatch<FormValues>
+export interface ReviewSection {
+  title: string
+  fields: readonly (readonly [string, string])[]
 }
 
-const sections = [
-  {
-    title: 'Applicant',
-    fields: [
-      ['Your Name', 'your_name'],
-      ['Email', 'email'],
-      ['Personal GitHub', 'personal_github'],
-      ['Other Contact Details', 'other_contact'],
-      ['Lead Developer or Maintainer', 'are_you_lead'],
-      ['Project Lead', 'other_lead'],
-    ],
-  },
-  {
-    title: 'Project',
-    fields: [
-      ['Main Focus', 'main_focus'],
-      ['Project Name', 'project_name'],
-      ['Project Description', 'short_description'],
-      ['Potential Impact', 'potential_impact'],
-    ],
-  },
-  {
-    title: 'Written References',
-    fields: [
-      ['References', 'references'],
-      ['Prior Contributions', 'bios'],
-      ['Years of Developer Experience', 'years_experience'],
-    ],
-  },
-  {
-    title: 'Source Code',
-    fields: [
-      ['Repository', 'github'],
-      ['Open-Source License', 'license'],
-      ['Project Website', 'website'],
-      ['Screenshots / Videos', 'screenshots_videos'],
-    ],
-  },
-  {
-    title: 'Timeline',
-    fields: [
-      ['Duration', 'duration'],
-      ['Time Commitment', 'commitment'],
-      ['Project Timeline and Potential Milestones', 'timelines'],
-    ],
-  },
-  {
-    title: 'Budget',
-    fields: [
-      ['Costs & Proposed Budget', 'proposed_budget'],
-      ['Prior Funding', 'has_received_funding'],
-      ['Prior Funding Details', 'what_funding'],
-      ['Additional Funding Sources', 'has_additional_funding'],
-      ['Additional Funding Details', 'additional_funding'],
-    ],
-  },
-  {
-    title: 'Final',
-    fields: [
-      ['Video Application', 'video_application'],
-      ['Anything Else', 'anything_else'],
-    ],
-  },
-] as const
+interface ReviewProps {
+  watch: UseFormWatch<FormValues>
+  sections: readonly ReviewSection[]
+}
 
 const formatValue = (value: unknown) => {
   if (typeof value === 'boolean') return value ? 'Yes' : 'No'
@@ -76,7 +17,7 @@ const formatValue = (value: unknown) => {
   return ''
 }
 
-export default function Review({ watch }: ReviewProps) {
+export default function Review({ watch, sections }: ReviewProps) {
   const values = watch()
 
   return (

--- a/pages/apply/lts.tsx
+++ b/pages/apply/lts.tsx
@@ -1,10 +1,14 @@
+import dynamic from 'next/dynamic'
 import PageSection from '@/components/PageSection'
-import LTSApplicationForm from '@/components/LTSApplicationForm'
-import Link from '@/components/Link'
 import CustomLink from '@/components/Link'
 import { PageSEO } from '@/components/SEO'
 import ClosedNotice from '@/components/ClosedNotice'
 import { areApplicationsOpen } from '@/utils/applicationWindow'
+
+const LTSApplicationForm = dynamic(
+  () => import('@/components/LTSApplicationForm'),
+  { ssr: false }
+)
 
 export default function Apply() {
   return (
@@ -47,10 +51,14 @@ export default function Apply() {
             be able to work collaboratively and constructively with potential
             users and other open-source contributors.
           </li>
+          <li>
+            show a clear step up over regular grants and renewals. LTS Grants
+            are reserved for proven contributors with a long-term track record.
+          </li>
         </ul>
         <p>
           If the above does not apply to you, please consider applying for a{' '}
-          <Link href="/apply/grant">General Grant</Link> instead.
+          <CustomLink href="/apply/grant">General Grant</CustomLink> instead.
         </p>
         <ClosedNotice />
         {areApplicationsOpen() && <LTSApplicationForm />}

--- a/utils/applicationWindow.ts
+++ b/utils/applicationWindow.ts
@@ -1,6 +1,4 @@
 // Closed during the third month of each quarter (Mar, Jun, Sep, Dec).
 export function areApplicationsOpen(date = new Date()): boolean {
-  // TEMP: forced open for build preview testing. DROP THIS COMMIT BEFORE MERGE.
-  return true
   return date.getMonth() % 3 !== 2
 }

--- a/utils/applicationWindow.ts
+++ b/utils/applicationWindow.ts
@@ -1,4 +1,6 @@
 // Closed during the third month of each quarter (Mar, Jun, Sep, Dec).
 export function areApplicationsOpen(date = new Date()): boolean {
+  // TEMP: forced open for build preview testing. DROP THIS COMMIT BEFORE MERGE.
+  return true
   return date.getMonth() % 3 !== 2
 }


### PR DESCRIPTION
Brings the LTS application form in line with the 2026 criteria that were already added to the general grant form. The form at `/apply/lts` is now built on the same multi-step flow as `/apply/grant`, so both share the prerequisites step, mandatory written references, vibe check, video application field, and submit logic. Closes OpenSats/operations#640.

- Extracts the step machinery into a shared `MultiStepApplicationForm`, reducing both forms to simple step configs
- Reuses the existing grant steps for LTS, with one new LTS-specific "What Will You Work On?" step
- Adds a criteria bullet on the LTS page stating that LTS applications must show a clear step up over regular grants and renewals

Note: the last commit temporarily forces `areApplicationsOpen()` to true so the forms render on the build preview. Drop it before merging.

Build preview:
- [/apply/lts](https://os-website-git-update-lts-form-2026-criteria-opensats.vercel.app/apply/lts)
