### PR TITLE
Add total sats sent to nak project page

### DIFF
--- a/data/projects/nak.mdx
+++ b/data/projects/nak.mdx
@@ -9,6 +9,7 @@ git: 'https://github.com/fiatjaf/nak'
 nostr: 'npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6'
 tags: ['Nostr', 'CLI', 'Developer Tools']
 fund: nostr
+totalSatsSent: 143821152
 announcementLink: '/blog/fiatjaf-receives-lts-grant'
 ---
 


### PR DESCRIPTION
Adds `totalSatsSent` to the `nak` project frontmatter so the project page shows the 143,821,152 sats OpenSats has sent to date.

- sets `totalSatsSent: 143821152` in `data/projects/nak.mdx`

Build preview:
- [/projects/nak](https://os-website-git-nak-sats-opensats.vercel.app/projects/nak)
