### PR TITLE
Add WireGuard heartbeat link

### DIFF
--- a/data/projects/wireguard.mdx
+++ b/data/projects/wireguard.mdx
@@ -7,6 +7,7 @@ website: 'https://www.wireguard.com/'
 donationLink: 'https://www.wireguard.com/donations/'
 coverImage: '/static/images/projects/wireguard.png'
 git: 'https://www.wireguard.com/repositories/'
+heartbeat: 'https://heartbeat.opensats.org/?q=wireguard'
 tags: ['Privacy', 'Protocol', 'Infrastructure']
 fund: general
 totalSatsSent: 605079968

--- a/pages/projects/[...slug].tsx
+++ b/pages/projects/[...slug].tsx
@@ -77,7 +77,8 @@ export default function ProjectPage({
             </PageActionLink>
           )}
           {(() => {
-            const heartbeatUrl = getHeartbeatUrl(project.git)
+            const heartbeatUrl =
+              project.heartbeat || getHeartbeatUrl(project.git)
             return heartbeatUrl ? (
               <PageActionLink
                 variant="outlineMuted"


### PR DESCRIPTION
Now that Heartbeat tracks WireGuard repos on git.zx2c4.com, this adds a heartbeat link to the WireGuard project page and fixes the project action button to respect explicit `heartbeat` frontmatter values.

- adds `heartbeat: 'https://heartbeat.opensats.org/?q=wireguard'` to `data/projects/wireguard.mdx`
- updates the project action button to use `project.heartbeat` when set, matching `ProjectLayout` behavior

Build preview:
- [/projects/wireguard](https://os-website-git-wireguard-heartbeat-opensats.vercel.app/projects/wireguard)
