### PR TITLE
Update rust-bitcoin heartbeat link

### DIFF
--- a/data/projects/rust-bitcoin.mdx
+++ b/data/projects/rust-bitcoin.mdx
@@ -7,6 +7,7 @@ website: 'https://rust-bitcoin.org/'
 donationLink: 'https://github.com/sponsors/tcharding'
 coverImage: '/static/images/projects/rust-bitcoin.svg'
 git: 'https://github.com/rust-bitcoin/rust-bitcoin'
+heartbeat: 'https://heartbeat.opensats.org/?q=rust-bitcoin'
 tags: ['Bitcoin', 'Library']
 showcase: true
 fund: general


### PR DESCRIPTION
Updates the `rust-bitcoin` project page to use the broader Heartbeat view.

- Adds an explicit `heartbeat` override for the project page action.
- Keeps the existing GitHub repository link unchanged.

---
Build preview:
- [`/projects/rust-bitcoin`](https://os-website-git-fix-rust-bitcoin-heartbeat-link-opensats.vercel.app/projects/rust-bitcoin)
