### PR TITLE
Add CoinJoinXT topic page

### DIFF
--- a/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
@@ -74,7 +74,7 @@ License: MIT
 [JoinMarket protocol]: https://github.com/JoinMarket-Org/joinmarket-clientserver
 [Neutrino]: https://github.com/lightninglabs/neutrino?tab=readme-ov-file#neutrino-privacy-preserving-bitcoin-light-client
 [nostr relay]: https://github.com/nostr-protocol/nostr?tab=readme-ov-file#how-it-works
-[CoinJoinXT]: https://en.bitcoin.it/wiki/CoinJoinXT
+[CoinJoinXT]: /topics/coinjoinxt
 [Lightning]: https://lightning.network/
 [ecash]: https://cashu.space/
 [joinmarket-ng/joinmarket-ng]: https://github.com/m0wer/joinmarket-ng

--- a/data/topics/coinjoinxt.mdx
+++ b/data/topics/coinjoinxt.mdx
@@ -1,0 +1,18 @@
+---
+title: 'CoinJoinXT'
+summary: 'A proposed multi-transaction CoinJoin design that spreads a collaborative spend across a graph of linked transactions to improve on-chain privacy.'
+category: 'Privacy'
+aliases: ['CoinJoin XT', 'proposed transaction graph', 'PTG']
+---
+
+CoinJoinXT is a proposed Bitcoin privacy protocol that extends the basic idea behind [CoinJoin](/topics/coinjoin). Instead of combining everyone into one shared transaction, participants build a connected set of transactions, often described as a proposed transaction graph, that moves funds through intermediate outputs and returns each participant the value they put in.
+
+That structure aims to make the resulting on-chain footprint look less like a single obvious mix. If the graph blends in with ordinary transaction activity, chain analysis has a harder time identifying where the coordinated protocol starts and ends. Some designs also preserve CoinJoin-style ambiguity even after the construction is recognized, because observers still cannot reliably match equal-valued outputs back to specific inputs.
+
+The tradeoffs are extra block space, more coordination, and stricter transaction requirements. Early CoinJoinXT designs leaned on SegWit to avoid transaction malleability problems, and later writeups describe variants that would benefit from Schnorr-style aggregated signing. CoinJoinXT remains a research direction rather than a widely deployed wallet feature, though JoinMarket contributors and other privacy researchers have published design notes and proof-of-concept code.
+
+## References
+
+- [en.bitcoin.it: CoinJoinXT](https://en.bitcoin.it/wiki/CoinJoinXT)
+- [Chaumian CoinJoinXT](https://zmnscpxj.github.io/bitcoin/coinjoinxt.html)
+- [AdamISZ/CoinJoinXT-POC](https://github.com/AdamISZ/CoinJoinXT-POC)

--- a/data/topics/coinjoinxt.mdx
+++ b/data/topics/coinjoinxt.mdx
@@ -9,7 +9,7 @@ CoinJoinXT is a proposed Bitcoin privacy protocol that extends the basic idea be
 
 That structure aims to make the resulting on-chain footprint look less like a single obvious mix. If the graph blends in with ordinary transaction activity, chain analysis has a harder time identifying where the coordinated protocol starts and ends. Some designs also preserve CoinJoin-style ambiguity even after the construction is recognized, because observers still cannot reliably match equal-valued outputs back to specific inputs.
 
-The tradeoffs are extra block space, more coordination, and stricter transaction requirements. Early CoinJoinXT designs leaned on SegWit to avoid transaction malleability problems, and later writeups describe variants that would benefit from Schnorr-style aggregated signing. CoinJoinXT remains a research direction rather than a widely deployed wallet feature, though JoinMarket contributors and other privacy researchers have published design notes and proof-of-concept code.
+The tradeoffs are extra block space, more coordination, and stricter transaction requirements. Early CoinJoinXT designs leaned on [SegWit][/topics/segwit] to avoid transaction malleability problems, and later writeups describe variants that would benefit from [Schnorr][/topics/taproot]-style aggregated signing. CoinJoinXT remains a research direction rather than a widely deployed wallet feature, though JoinMarket contributors and other privacy researchers have published design notes and proof-of-concept code.
 
 ## References
 

--- a/data/topics/coinjoinxt.mdx
+++ b/data/topics/coinjoinxt.mdx
@@ -9,7 +9,7 @@ CoinJoinXT is a proposed Bitcoin privacy protocol that extends the basic idea be
 
 That structure aims to make the resulting on-chain footprint look less like a single obvious mix. If the graph blends in with ordinary transaction activity, chain analysis has a harder time identifying where the coordinated protocol starts and ends. Some designs also preserve CoinJoin-style ambiguity even after the construction is recognized, because observers still cannot reliably match equal-valued outputs back to specific inputs.
 
-The tradeoffs are extra block space, more coordination, and stricter transaction requirements. Early CoinJoinXT designs leaned on [SegWit][/topics/segwit] to avoid transaction malleability problems, and later writeups describe variants that would benefit from [Schnorr][/topics/taproot]-style aggregated signing. CoinJoinXT remains a research direction rather than a widely deployed wallet feature, though JoinMarket contributors and other privacy researchers have published design notes and proof-of-concept code.
+The tradeoffs are extra block space, more coordination, and stricter transaction requirements. Early CoinJoinXT designs leaned on [SegWit](/topics/segwit) to avoid transaction malleability problems, and later writeups describe variants that would benefit from [Schnorr](/topics/taproot)-style aggregated signing. CoinJoinXT remains a research direction rather than a widely deployed wallet feature, though JoinMarket contributors and other privacy researchers have published design notes and proof-of-concept code.
 
 ## References
 


### PR DESCRIPTION
Adds a new `CoinJoinXT` topic page and links the existing JoinMarket NG grant post to it.

- adds `data/topics/coinjoinxt.mdx`
- replaces the external `CoinJoinXT` footnote in `seventeenth-wave-of-bitcoin-grants.mdx` with an internal topic link

Closes https://github.com/OpenSats/content/issues/258

---

Build preview:
- [`/topics/coinjoinxt`](https://os-website-git-content-add-coinjoinxt-topic-page-258-opensats.vercel.app/topics/coinjoinxt)
- [`/blog/seventeenth-wave-of-bitcoin-grants`](https://os-website-git-content-add-coinjoinxt-topic-page-258-opensats.vercel.app/blog/seventeenth-wave-of-bitcoin-grants)
