### PR TITLE
Add Liquid Network topic page

### DIFF
--- a/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
@@ -151,7 +151,7 @@ License: MIT
 [`embit`]: https://embit.rocks/#/
 [Krux]: /blog/bitcoin-grants-december-2023#krux
 [SeedSigner]: https://seedsigner.com/
-[Liquid Network]: https://liquid.net/
+[Liquid Network]: /topics/liquid-network
 [`BIP-85`]: https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki
 [cryptoadvance/specter-diy]: https://github.com/cryptoadvance/specter-diy
 

--- a/data/topics/liquid-network.mdx
+++ b/data/topics/liquid-network.mdx
@@ -1,0 +1,18 @@
+---
+title: 'Liquid Network'
+summary: 'A federated Bitcoin sidechain for faster settlement, confidential transfers, and the issuance of additional assets.'
+category: 'Bitcoin'
+aliases: ['Liquid', 'Liquid sidechain', 'L-BTC']
+---
+
+Liquid Network is a federated Bitcoin sidechain designed for faster settlement and asset issuance. Users can move BTC from the Bitcoin mainchain onto Liquid through a two-way peg and use it on the sidechain as L-BTC.
+
+Liquid blocks are signed by a federation of functionaries and targeted at one-minute intervals, with finality after two confirmations. That structure gives exchanges, traders, and wallet builders a faster settlement environment than the Bitcoin mainchain, while asking users to accept the Liquid Federation's trust model.
+
+Liquid also supports confidential transactions, which hide transferred amounts and asset types from public observers. The network is used for stablecoins, tokenized assets, swaps, and wallet features that benefit from quicker turnover and multi-asset support.
+
+## References
+
+- [Liquid.net](https://liquid.net/)
+- [What is the Liquid Network?](https://help.blockstream.com/liquid-network/faqs/what-is-the-liquid-network)
+- [Blockstream: The Liquid Network](https://blockstream.com/liquid/)


### PR DESCRIPTION
Adds a new `Liquid Network` topic page and links the existing Specter DIY grant post to it.

- adds `data/topics/liquid-network.mdx`
- replaces the external `Liquid Network` footnote in `seventeenth-wave-of-bitcoin-grants.mdx` with an internal topic link

Closes https://github.com/OpenSats/content/issues/259

---

Build preview:
- [`/topics/liquid-network`](https://os-website-git-content-add-liquid-network-topic-db6837-opensats.vercel.app/topics/liquid-network)
- [`/blog/seventeenth-wave-of-bitcoin-grants`](https://os-website-git-content-add-liquid-network-topic-db6837-opensats.vercel.app/blog/seventeenth-wave-of-bitcoin-grants)
