### PR TITLE
Add LNHANCE topic page

### DIFF
--- a/data/blog/fifteenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/fifteenth-wave-of-bitcoin-grants.mdx
@@ -251,7 +251,7 @@ to levels suitable for hardware wallets.
 Repositories: [LNHANCE-Expedition]  
 Licenses: CC0-1.0, CC BY 4.0, MIT
 
-[LNhance soft fork]: https://lnhance.org/
+[LNhance soft fork]: /topics/lnhance
 [Eltoo]: /topics/eltoo
 [hArk]: https://delvingbitcoin.org/t/evolving-the-ark-protocol-using-ctv-and-csfs/1602#p-4785-hark-hash-lock-ark-10
 [vaults]: /topics/vaults

--- a/data/topics/lnhance.mdx
+++ b/data/topics/lnhance.mdx
@@ -1,0 +1,18 @@
+---
+title: 'LNHANCE'
+summary: 'A proposed Bitcoin soft fork bundle that combines new script features to enable richer Lightning, Ark, vault, and shared-UTXO designs.'
+category: 'Bitcoin'
+aliases: ['LNhance', 'LNHANCE soft fork', 'LNhance soft fork']
+---
+
+LNHANCE is a proposed Bitcoin soft fork bundle aimed at making advanced contract constructions easier to express on chain. The proposal combines [OP_CTV](/topics/op-ctv), [OP_CSFS](/topics/op-csfs), `OP_PAIRCOMMIT`, and `OP_INTERNALKEY` to support protocols that need more structured spending conditions than Bitcoin exposes today.
+
+Its designers frame the bundle around practical second-layer and custody use cases. The proposal is meant to improve designs for [Eltoo](/topics/eltoo)-style Lightning channels, [Ark](/topics/ark)-like systems, vaults, payment pools, and other shared-UTXO constructions that benefit from predictable transaction trees and more flexible signature checks.
+
+LNHANCE remains a proposal. It has not been activated on Bitcoin, and the tradeoffs are still being explored in research, specifications, and proof-of-concept implementations such as the LNHANCE Expedition work funded by OpenSats.
+
+## References
+
+- [lnhance.org](https://lnhance.org/)
+- [Bitcoin Optech Newsletter #285](https://bitcoinops.org/en/newsletters/2024/01/17/)
+- [LNHANCE-Expedition](https://github.com/LNHANCE-Expedition)

--- a/data/topics/lnhance.mdx
+++ b/data/topics/lnhance.mdx
@@ -7,12 +7,12 @@ aliases: ['LNhance', 'LNHANCE soft fork', 'LNhance soft fork']
 
 LNHANCE is a proposed Bitcoin soft fork bundle aimed at making advanced contract constructions easier to express on chain. The proposal combines [OP_CTV](/topics/op-ctv), [OP_CSFS](/topics/op-csfs), `OP_PAIRCOMMIT`, and `OP_INTERNALKEY` to support protocols that need more structured spending conditions than Bitcoin exposes today.
 
-Its designers frame the bundle around practical second-layer and custody use cases. The proposal is meant to improve designs for [Eltoo](/topics/eltoo)-style Lightning channels, [Ark](/topics/ark)-like systems, vaults, payment pools, and other shared-UTXO constructions that benefit from predictable transaction trees and more flexible signature checks.
+Its designers frame the bundle around practical second-layer and custody use cases. The proposal is meant to improve designs for [Eltoo](/topics/eltoo)-style Lightning channels, [Ark](/topics/ark)-like systems, [vaults][/topics/vaults], payment pools, and other shared-UTXO constructions that benefit from predictable transaction trees and more flexible signature checks.
 
-LNHANCE remains a proposal. It has not been activated on Bitcoin, and the tradeoffs are still being explored in research, specifications, and proof-of-concept implementations such as the LNHANCE Expedition work funded by OpenSats.
+LNHANCE remains a proposal. It has not been activated on Bitcoin, and the tradeoffs are still being explored in research, specifications, and proof-of-concept implementations such as the [LNHANCE Expedition][/blog/fifteenth-wave-of-bitcoin-grants#lnhance] work funded by OpenSats.
 
 ## References
 
 - [lnhance.org](https://lnhance.org/)
-- [Bitcoin Optech Newsletter #285](https://bitcoinops.org/en/newsletters/2024/01/17/)
+- [Bitcoin Optech Newsletter #285](https://bitcoinops.org/en/newsletters/2024/01/17/#new-lnhance-combination-soft-fork-proposed)
 - [LNHANCE-Expedition](https://github.com/LNHANCE-Expedition)


### PR DESCRIPTION
Adds a new `LNHANCE` topic page and links the existing fifteenth wave grant post to it.

- adds `data/topics/lnhance.mdx`
- replaces the external `LNhance soft fork` footnote in `fifteenth-wave-of-bitcoin-grants.mdx` with an internal topic link

Closes https://github.com/OpenSats/content/issues/260

---

Build preview:
- [`/topics/lnhance`](https://os-website-git-content-add-lnhance-topic-page-260-opensats.vercel.app/topics/lnhance)
- [`/blog/fifteenth-wave-of-bitcoin-grants`](https://os-website-git-content-add-lnhance-topic-page-260-opensats.vercel.app/blog/fifteenth-wave-of-bitcoin-grants)
