### PR TITLE
Add FROST topic page

### DIFF
--- a/data/blog/fifteenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/fifteenth-wave-of-bitcoin-grants.mdx
@@ -83,7 +83,7 @@ License: AGPL-3.0
 [beads]: https://github.com/braidpool/braidpool/blob/main/docs/braid_consensus.md
 [Audit Mode]: https://github.com/braidpool/braidpool/pull/305
 [UHPO]: https://github.com/braidpool/braidpool/blob/main/docs/braidpool_spec.md#unspent-hasher-payment-output
-[FROST]: https://www.rfc-editor.org/rfc/rfc9591.html
+[FROST]: /topics/frost
 [braidpool/braidpool]: https://github.com/braidpool/braidpool
 
 ### BlindBit Suite

--- a/data/blog/twelfth-wave-of-nostr-grants.mdx
+++ b/data/blog/twelfth-wave-of-nostr-grants.mdx
@@ -49,7 +49,7 @@ nostr.
 ### Frostr
 
 [Frostr](https://www.frostr.org/) is a threshold signing protocol tailored for
-nostr, built on the [FROST](https://eprint.iacr.org/2020/852) (Flexible
+nostr, built on the [FROST](/topics/frost) (Flexible
 Round‑Optimized Schnorr Threshold) signature scheme. It provides security by
 splitting a user's nsec key into distributable shares across devices or
 services, enabling

--- a/data/projects/frostr.mdx
+++ b/data/projects/frostr.mdx
@@ -13,7 +13,7 @@ announcementLink: '/blog/twelfth-wave-of-nostr-grants#frostr'
 ---
 
 [Frostr](https://frostr.org/) is a threshold signing protocol for nostr
-built on top of [FROST](https://eprint.iacr.org/2020/852) (Flexible
+built on top of [FROST](/topics/frost) (Flexible
 Round-Optimized Schnorr Threshold signatures). An `nsec` key is split into
 shares that live on different devices or services. Any `t-of-n` quorum of
 those shares can sign a nostr event together, but a single compromised share

--- a/data/topics/frost.mdx
+++ b/data/topics/frost.mdx
@@ -1,0 +1,21 @@
+---
+title: 'FROST'
+summary: 'A threshold Schnorr signature scheme that lets a group produce one standard signature without giving one party the full private key.'
+category: 'Bitcoin'
+aliases:
+  [
+    'Flexible Round-Optimized Schnorr Threshold Signatures',
+    'threshold Schnorr signatures',
+  ]
+---
+
+`FROST` stands for Flexible Round-Optimized Schnorr Threshold Signatures. It is a threshold signing scheme for Schnorr keys. A secret key is split into shares, and a quorum of participants can cooperate to produce one valid signature without reconstructing the full key in one place.
+
+That matters anywhere one signer is a liability. A `t-of-n` policy can distribute trust across people, devices, or servers while still tolerating some offline or compromised participants. To outside verifiers, the result still looks like a normal Schnorr signature.
+
+In the Bitcoin ecosystem, FROST is relevant to wallet security, custody, federated systems, and protocols that need threshold signing without exposing a multisig policy on chain. OpenSats-funded work in this area includes [Frostr](/projects/frostr), a nostr threshold signing protocol built on FROST. FROST also fits naturally alongside [Taproot](/topics/taproot), which brought Schnorr signatures to Bitcoin.
+
+## References
+
+- [RFC 9591: The Flexible Round-Optimized Schnorr Threshold (FROST) Protocol](https://www.rfc-editor.org/rfc/rfc9591.html)
+- [CFRG FROST draft repository](https://github.com/cfrg/draft-irtf-cfrg-frost)


### PR DESCRIPTION
Adds a new `FROST` topic page and links existing FROST references to the new internal topic page.

- adds `data/topics/frost.mdx` with a concise overview of threshold Schnorr signing and why it matters
- links the new topic from the `Frostr` project page and the twelfth and fifteenth wave grant posts

Closes https://github.com/OpenSats/content/issues/261

---

Build preview:
- [/topics/frost](https://os-website-git-content-add-frost-topic-page-261-opensats.vercel.app/topics/frost)
- [/projects/frostr](https://os-website-git-content-add-frost-topic-page-261-opensats.vercel.app/projects/frostr)
- [/blog/twelfth-wave-of-nostr-grants](https://os-website-git-content-add-frost-topic-page-261-opensats.vercel.app/blog/twelfth-wave-of-nostr-grants)
- [/blog/fifteenth-wave-of-bitcoin-grants](https://os-website-git-content-add-frost-topic-page-261-opensats.vercel.app/blog/fifteenth-wave-of-bitcoin-grants)