### PR TITLE
Add WIF topic page

### DIFF
--- a/data/topics/wif.mdx
+++ b/data/topics/wif.mdx
@@ -1,0 +1,20 @@
+---
+title: 'WIF'
+summary: 'A Base58Check-encoded string for importing or exporting a single Bitcoin private key.'
+category: 'Bitcoin'
+aliases:
+  ['Wallet Import Format', 'wallet import format', 'wallet export format']
+---
+
+`WIF` stands for Wallet Import Format. It is the standard Base58Check encoding for a single Bitcoin private key, used when a wallet needs to import, export, sweep, or recover one key directly.
+
+A WIF string wraps the raw 32-byte private key with a network prefix, an optional compression marker, and a checksum. On mainnet, that prefix is `0x80`. The checksum helps catch copy errors, and the compression marker tells software whether the key should be used with compressed public keys. That is why mainnet WIF strings often start with `5`, `K`, or `L`, while testnet WIF strings often start with `9` or `c`.
+
+WIF is a key format, not a wallet backup format. It works well for moving one standalone key between tools, but it does not describe derivation paths, script types, account structure, or multisig policies. Modern wallets usually exchange [output descriptors](/topics/output-descriptors) or seed-based backups for that broader context.
+
+Anyone who gets a WIF string controls the bitcoin locked to that key. Treat it like raw key material. If a wallet asks you to reveal a WIF, you are handing that wallet spending authority.
+
+## References
+
+- [Bitcoin Wiki: Wallet import format](https://en.bitcoin.it/wiki/Wallet_import_format)
+- [Bitcoin Developer Guide: Wallets](https://developer.bitcoin.org/devguide/wallets.html)


### PR DESCRIPTION
Adds a new `WIF` topic page with a concise explanation of wallet import format, what it encodes, and how it differs from broader wallet backup formats.

- adds `data/topics/wif.mdx` with verified references to the Bitcoin Wiki and Bitcoin Developer Guide

Closes https://github.com/OpenSats/website/issues/868

---

Build preview:
- [/topics/wif](https://os-website-git-topic-add-wif-topic-page-868-opensats.vercel.app/topics/wif)
