### PR TITLE
Add BIP 32 topic page

### DIFF
--- a/data/topics/bip-32.mdx
+++ b/data/topics/bip-32.mdx
@@ -1,0 +1,21 @@
+---
+title: 'BIP 32'
+summary: 'The standard for hierarchical deterministic wallets, including derivation paths and extended keys such as `xpubs` and `xprvs`.'
+category: 'Bitcoin'
+aliases:
+  ['BIP32', 'Hierarchical Deterministic Wallets', 'HD wallets', 'xpub', 'xprv']
+---
+
+BIP 32 is the standard for hierarchical deterministic wallets. Instead of storing a pile of unrelated private keys, a BIP 32 wallet derives a whole tree of keys from one master seed. That gives wallets a common structure for accounts, branches, and address chains, and it removes the need to back up every new key separately.
+
+It also defines extended keys. An extended private key (`xprv`) can derive child private keys and child public keys. A matching extended public key (`xpub`) can derive child public keys only, which makes watch-only wallets, accounting systems, and multisig coordinators possible without exposing spending keys.
+
+BIP 32 also distinguishes between normal and hardened child derivation. Normal child keys can be derived from an `xpub`. Hardened child keys cannot, which is why common wallet paths mark account-level steps with `h`, `'`, or `H`. That split lets wallets share some branches safely while keeping higher-level secrets private.
+
+Modern wallet software still builds on BIP 32 even when the user mostly sees a seed phrase or an [output descriptor](/topics/output-descriptors). Descriptors often carry BIP 32 origin information and extended public keys so another wallet can reconstruct the same receive addresses and signing structure.
+
+## References
+
+- [BIP 32: Hierarchical Deterministic Wallets](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)
+- [bips.dev: BIP 32 rendered](https://bips.dev/32/)
+- [Bitcoin Optech: HD key generation](https://bitcoinops.org/en/topics/hd-key-generation/)


### PR DESCRIPTION
Adds a new `BIP 32` topic page with a concise explanation of hierarchical deterministic wallets, extended keys, and hardened derivation.

- adds `data/topics/bip-32.mdx` with verified references to the BIP, `bips.dev`, and Bitcoin Optech

Closes https://github.com/OpenSats/website/issues/869

---

Build preview:
- [/topics/bip-32](https://os-website-git-topic-add-bip-32-topic-page-869-opensats.vercel.app/topics/bip-32)
