### PR TITLE
Add Base58 topic page

### DIFF
--- a/data/topics/base58.mdx
+++ b/data/topics/base58.mdx
@@ -1,0 +1,21 @@
+---
+title: 'Base58'
+summary: 'The text encoding Bitcoin uses for legacy addresses, WIF keys, and extended keys. Base58Check adds version bytes and a checksum.'
+category: 'Bitcoin'
+aliases:
+  ['Base58Check', 'legacy addresses']
+---
+
+Base58 is the compact text encoding Bitcoin uses for older address and key formats. It avoids visually similar characters such as `0`, `O`, `I`, and `l`, which makes long strings easier to read, copy, and transcribe.
+
+Bitcoin rarely uses plain Base58 on its own. Most user-facing strings use Base58Check, which prepends a version byte, appends a four-byte checksum, and then encodes the result in Base58. That extra structure lets software distinguish between different payloads and catch many typing mistakes before funds move.
+
+Legacy P2PKH and P2SH addresses are Base58Check strings, which is why they often start with `1` or `3` on mainnet. [WIF](/topics/wif) private keys also use Base58Check, and [BIP 32](/topics/bip-32) extended keys such as `xpubs` and `xprvs` use the same family of encodings with different version bytes.
+
+Newer output types use different address encodings. Native [SegWit](/topics/segwit) and [Taproot](/topics/taproot) addresses use [Bech32](/topics/bech32) or Bech32m instead, which were designed specifically for witness outputs.
+
+## References
+
+- [Bitcoin Wiki: Base58Check encoding](https://en.bitcoin.it/wiki/Base58Check_encoding)
+- [Bitcoin Developer Glossary: Base58check](https://developer.bitcoin.org/glossary.html#term-Base58check)
+- [Bitcoin Core source: `src/base58.h`](https://raw.githubusercontent.com/bitcoin/bitcoin/master/src/base58.h)

--- a/data/topics/bip-32.mdx
+++ b/data/topics/bip-32.mdx
@@ -8,7 +8,7 @@ aliases:
 
 BIP 32 is the standard for hierarchical deterministic wallets. Instead of storing a pile of unrelated private keys, a BIP 32 wallet derives a whole tree of keys from one master seed. That gives wallets a common structure for accounts, branches, and address chains, and it removes the need to back up every new key separately.
 
-It also defines extended keys. An extended private key (`xprv`) can derive child private keys and child public keys. A matching extended public key (`xpub`) can derive child public keys only, which makes watch-only wallets, accounting systems, and multisig coordinators possible without exposing spending keys.
+It also defines extended keys. An extended private key (`xprv`) can derive child private keys and child public keys. A matching extended public key (`xpub`) can derive child public keys only, which makes watch-only wallets, accounting systems, and multisig coordinators possible without exposing spending keys. Those serialized `xpub` and `xprv` strings are usually [Base58Check](/topics/base58) encodings with version bytes that identify the extended key type.
 
 BIP 32 also distinguishes between normal and hardened child derivation. Normal child keys can be derived from an `xpub`. Hardened child keys cannot, which is why common wallet paths mark account-level steps with `h`, `'`, or `H`. That split lets wallets share some branches safely while keeping higher-level secrets private.
 

--- a/data/topics/wif.mdx
+++ b/data/topics/wif.mdx
@@ -6,7 +6,7 @@ aliases:
   ['Wallet Import Format', 'wallet import format', 'wallet export format']
 ---
 
-`WIF` stands for Wallet Import Format. It is the standard Base58Check encoding for a single Bitcoin private key, used when a wallet needs to import, export, sweep, or recover one key directly.
+`WIF` stands for Wallet Import Format. It is the standard [Base58Check](/topics/base58) encoding for a single Bitcoin private key, used when a wallet needs to import, export, sweep, or recover one key directly.
 
 A WIF string wraps the raw 32-byte private key with a network prefix, an optional compression marker, and a checksum. On mainnet, that prefix is `0x80`. The checksum helps catch copy errors, and the compression marker tells software whether the key should be used with compressed public keys. That is why mainnet WIF strings often start with `5`, `K`, or `L`, while testnet WIF strings often start with `9` or `c`.
 


### PR DESCRIPTION
Adds a new `Base58` topic page and links related key formats to it.

- adds `data/topics/base58.mdx` with a concise overview of `Base58` and `Base58Check`
- links the new topic from the existing `WIF` and `BIP 32` topic pages

Closes https://github.com/OpenSats/content/issues/277

---

Build preview:
- [`/topics/base58`](https://os-website-git-content-add-base58-topic-page-277-opensats.vercel.app/topics/base58)
