### PR TITLE
Add custom social previews for map and transparency pages

### DIFF
--- a/components/LifetimeStats.tsx
+++ b/components/LifetimeStats.tsx
@@ -1,11 +1,16 @@
 import React from 'react'
 import {
   formatLifetimeStatDisplay,
+  type LifetimeStat,
   useAnimatedLifetimeStats,
 } from '@/utils/lifetimeStats'
 
-const LifetimeStats = () => {
-  const items = useAnimatedLifetimeStats()
+type LifetimeStatsProps = {
+  initialStats?: LifetimeStat[] | null
+}
+
+const LifetimeStats = ({ initialStats }: LifetimeStatsProps) => {
+  const items = useAnimatedLifetimeStats(initialStats)
 
   return (
     <div className="py-4">

--- a/components/LifetimeStats.tsx
+++ b/components/LifetimeStats.tsx
@@ -1,5 +1,8 @@
 import React from 'react'
-import { formatNumber, useAnimatedLifetimeStats } from '@/utils/lifetimeStats'
+import {
+  formatLifetimeStatDisplay,
+  useAnimatedLifetimeStats,
+} from '@/utils/lifetimeStats'
 
 const LifetimeStats = () => {
   const items = useAnimatedLifetimeStats()
@@ -14,9 +17,7 @@ const LifetimeStats = () => {
                 {item.label}
               </dt>
               <dt className="order-first text-center text-4xl font-semibold tracking-tight text-orange-600">
-                {index == 1 ? '$ ' : ''}
-                {index == 2 ? '~' : ''}
-                {formatNumber(item.value)}
+                {formatLifetimeStatDisplay(index, item.value)}
               </dt>
             </div>
           ))}

--- a/components/StatsSentence.tsx
+++ b/components/StatsSentence.tsx
@@ -1,6 +1,6 @@
 import Link from '@/components/Link'
 import {
-  formatNumber,
+  formatStatsSentenceValues,
   type LifetimeStat,
   useAnimatedCount,
   useAnimatedLifetimeStats,
@@ -16,12 +16,9 @@ export default function StatsSentence({
   initialStats,
 }: StatsSentenceProps) {
   const stats = useAnimatedLifetimeStats(initialStats)
-
-  // stats[0] = grants given, stats[1] = USD allocated, stats[2] = sats sent
-  const grantsGiven = formatNumber(stats[0]?.value ?? 0)
-  const usdAllocated = Math.round(stats[1]?.value ?? 0).toLocaleString()
-  const satsSent = formatNumber(stats[2]?.value ?? 0).replace('B', 'billion')
-  const countryCount = Math.round(useAnimatedCount(40))
+  const { grantsGiven, usdAllocated, satsSent, countryCount } =
+    formatStatsSentenceValues(stats)
+  const animatedCountryCount = Math.round(useAnimatedCount(countryCount))
 
   return (
     <p className={className}>
@@ -51,7 +48,7 @@ export default function StatsSentence({
         href="/map"
         className="-mx-1 whitespace-nowrap rounded bg-primary-100/50 px-1 no-underline hover:bg-primary-100 dark:bg-primary-900/20 dark:hover:bg-primary-900/40"
       >
-        {countryCount}+ countries
+        {animatedCountryCount}+ countries
       </Link>
       .
     </p>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "next dev",
     "dev": "cross-env INIT_CWD=$PWD next dev",
-    "build": "npx contentlayer build && node ./scripts/generate-default-og.mjs && node ./scripts/generate-project-og.mjs && node ./scripts/generate-fund-og.mjs && node ./scripts/generate-newsletter-og.mjs && node ./scripts/generate-topic-og.mjs && node ./scripts/generate-page-og.mjs && node ./scripts/generate-author-og.mjs && node ./scripts/generate-heartbeat-og.mjs && cross-env INIT_CWD=$PWD next build && node -r esbuild-register ./scripts/postbuild.mjs",
+    "build": "npx contentlayer build && node ./scripts/generate-default-og.mjs && node ./scripts/generate-project-og.mjs && node ./scripts/generate-fund-og.mjs && node ./scripts/generate-newsletter-og.mjs && node ./scripts/generate-topic-og.mjs && node -r esbuild-register ./scripts/generate-page-og.mjs && node ./scripts/generate-author-og.mjs && node ./scripts/generate-heartbeat-og.mjs && cross-env INIT_CWD=$PWD next build && node -r esbuild-register ./scripts/postbuild.mjs",
     "serve": "next start",
     "analyze": "cross-env ANALYZE=true next build",
     "generate:default-og": "node ./scripts/generate-default-og.mjs",
@@ -13,7 +13,7 @@
     "generate:fund-og": "node ./scripts/generate-fund-og.mjs",
     "generate:newsletter-og": "node ./scripts/generate-newsletter-og.mjs",
     "generate:topic-og": "node ./scripts/generate-topic-og.mjs",
-    "generate:page-og": "node ./scripts/generate-page-og.mjs",
+    "generate:page-og": "node -r esbuild-register ./scripts/generate-page-og.mjs",
     "generate:author-og": "node ./scripts/generate-author-og.mjs",
     "generate:heartbeat-og": "node ./scripts/generate-heartbeat-og.mjs",
     "lint": "next lint --fix --dir pages --dir components --dir lib --dir layouts --dir scripts",

--- a/pages/map.tsx
+++ b/pages/map.tsx
@@ -97,6 +97,7 @@ export default function MapPage({
       <PageSEO
         title="Map - OpenSats"
         description="Countries where OpenSats has awarded grants."
+        slug="map"
       />
 
       <div>

--- a/pages/transparency.tsx
+++ b/pages/transparency.tsx
@@ -1,23 +1,48 @@
-import { InferGetStaticPropsType } from 'next'
+import { GetStaticProps, InferGetStaticPropsType } from 'next'
 import { allPages } from 'contentlayer/generated'
 import { MDXLayoutRenderer } from 'pliny/mdx-components'
 import { MDXComponents } from '@/components/MDXComponents'
+import LifetimeStats from '@/components/LifetimeStats'
+import {
+  resolveLifetimeStats,
+  type LifetimeStat,
+} from '@/utils/lifetimeStats'
 
 const DEFAULT_LAYOUT = 'PageLayout'
 
-export const getStaticProps = async () => {
+type TransparencyProps = {
+  page: NonNullable<ReturnType<typeof allPages.find>>
+  lifetimeStats: LifetimeStat[]
+}
+
+export const getStaticProps: GetStaticProps<TransparencyProps> = async () => {
   const page = allPages.find((p) => p.slug === 'transparency')
-  return { props: { page: page } }
+  if (!page) {
+    return { notFound: true }
+  }
+
+  const lifetimeStats = await resolveLifetimeStats()
+
+  return {
+    props: { page, lifetimeStats },
+    revalidate: 60 * 60 * 12,
+  }
 }
 
 export default function Transparency({
   page,
+  lifetimeStats,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
+  const components = {
+    ...MDXComponents,
+    LifetimeStats: () => <LifetimeStats initialStats={lifetimeStats} />,
+  }
+
   return (
     <MDXLayoutRenderer
       layout={page.layout || DEFAULT_LAYOUT}
       content={page}
-      MDXComponents={MDXComponents}
+      MDXComponents={components}
     />
   )
 }

--- a/pages/transparency.tsx
+++ b/pages/transparency.tsx
@@ -3,10 +3,7 @@ import { allPages } from 'contentlayer/generated'
 import { MDXLayoutRenderer } from 'pliny/mdx-components'
 import { MDXComponents } from '@/components/MDXComponents'
 import LifetimeStats from '@/components/LifetimeStats'
-import {
-  resolveLifetimeStats,
-  type LifetimeStat,
-} from '@/utils/lifetimeStats'
+import { resolveLifetimeStats, type LifetimeStat } from '@/utils/lifetimeStats'
 
 const DEFAULT_LAYOUT = 'PageLayout'
 

--- a/scripts/generate-grantee-map.mjs
+++ b/scripts/generate-grantee-map.mjs
@@ -9,138 +9,51 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { Resvg } from '@resvg/resvg-js'
+import {
+  buildStyledGranteeMapSvg,
+  loadWorldSvg,
+  renderGranteeMapPng,
+} from './lib/grantee-map.mjs'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const root = path.resolve(__dirname, '..')
 
-const SOURCE_SVG = path.join(root, 'public', 'maps', 'world.svg')
 const OUTPUT_DIR = path.join(root, 'public', 'static', 'images', 'newsletter')
-
-const WIDTH = 2400 // render width in pixels
-
-const HIGHLIGHT_COLOR = '#f97316' // tailwind orange-500
-
-// Keep this in sync with components/GranteeMap.tsx
-const GRANTEE_COUNTRY_CODES = [
-  'US',
-  'CA',
-  'DE',
-  'GB',
-  'IT',
-  'JP',
-  'NL',
-  'CH',
-  'CN',
-  'BR',
-  'AR',
-  'IE',
-  'HK',
-  'GE',
-  'SE',
-  'ES',
-  'PT',
-  'NO',
-  'GR',
-  'AU',
-  'IN',
-  'SI',
-  'KR',
-  'FI',
-  'CZ',
-  'UG',
-  'BE',
-  'FR',
-  'VN',
-  'UA',
-  'TR',
-  'SV',
-  'NZ',
-  'HU',
-  'SK',
-  'NG',
-  'PA',
-  'RO',
-  'GT',
-  'ID',
-  'AE',
-]
 
 const VARIANTS = [
   {
     name: 'grantee-map-light',
-    base: '#d4d4d8', // zinc-300 — sits softly on white/cream
+    base: '#d4d4d8',
     baseOpacity: 1,
+    stroke: 'none',
+    strokeWidth: 0,
   },
   {
     name: 'grantee-map-dark',
-    base: '#404040', // neutral-700 — sits softly on dark-mode black/charcoal
+    base: '#404040',
     baseOpacity: 1,
+    stroke: 'none',
+    strokeWidth: 0,
   },
   {
     name: 'grantee-map-neutral',
-    base: '#9ca3af', // gray-400 — readable on either background
+    base: '#9ca3af',
     baseOpacity: 0.6,
+    stroke: 'none',
+    strokeWidth: 0,
   },
 ]
 
-function escapeForCss(value) {
-  return value.replace(/[^a-zA-Z0-9_-]/g, '\\$&')
-}
-
-function buildStyledSvg(rawSvg, variant) {
-  // Strip XML declaration so resvg doesn't choke on the `<?xml ?>` prologue.
-  let svg = rawSvg.replace(/<\?xml[\s\S]*?\?>\s*/i, '').trim()
-
-  // Strip the inline width/height — viewBox alone gives resvg the aspect
-  // ratio it needs and fitTo controls the output resolution.
-  svg = svg.replace(/\s+width="[^"]+"/, '').replace(/\s+height="[^"]+"/, '')
-
-  // Make sure a viewBox exists; fall back to the original width/height
-  // if mapsvg's source somehow ships without one.
-  if (!/viewBox=/.test(svg)) {
-    const widthMatch = rawSvg.match(/width="([^"]+)"/)
-    const heightMatch = rawSvg.match(/height="([^"]+)"/)
-    if (widthMatch && heightMatch) {
-      const w = parseFloat(widthMatch[1])
-      const h = parseFloat(heightMatch[1])
-      svg = svg.replace('<svg', `<svg viewBox="0 0 ${w} ${h}"`)
-    }
-  }
-
-  const highlightSelector = GRANTEE_COUNTRY_CODES.map(
-    (code) => `#${escapeForCss(code)}`
-  ).join(', ')
-
-  // Inject a stylesheet right after the opening <svg ...> tag. resvg-js
-  // supports SVG <style> elements with simple selectors.
-  const css = `
-    path {
-      fill: ${variant.base};
-      fill-opacity: ${variant.baseOpacity};
-      stroke: none;
-    }
-    ${highlightSelector} {
-      fill: ${HIGHLIGHT_COLOR};
-      fill-opacity: 1;
-    }
-  `
-
-  return svg.replace(/<svg([^>]*)>/, `<svg$1><style><![CDATA[${css}]]></style>`)
-}
+const WIDTH = 2400
 
 async function main() {
-  const rawSvg = await fs.readFile(SOURCE_SVG, 'utf8')
+  const rawSvg = await loadWorldSvg()
   await fs.mkdir(OUTPUT_DIR, { recursive: true })
 
   for (const variant of VARIANTS) {
-    const styledSvg = buildStyledSvg(rawSvg, variant)
-    const resvg = new Resvg(styledSvg, {
-      fitTo: { mode: 'width', value: WIDTH },
-      background: 'rgba(0,0,0,0)', // transparent
-    })
-    const png = resvg.render().asPng()
+    const styledSvg = buildStyledGranteeMapSvg(rawSvg, variant)
+    const png = renderGranteeMapPng(styledSvg, WIDTH)
     const outPath = path.join(OUTPUT_DIR, `${variant.name}.png`)
     await fs.writeFile(outPath, png)
     const kb = (png.byteLength / 1024).toFixed(1)

--- a/scripts/generate-page-og.mjs
+++ b/scripts/generate-page-og.mjs
@@ -22,6 +22,7 @@ import {
   hashString,
   loadContentlayerIndex,
   loadFaviconDataUri,
+  measureTextBBoxWithResvg,
   measureTextWidthWithResvg,
   networkDecor,
   renderSvgToPng,
@@ -261,23 +262,25 @@ function lineToRuns(line) {
   return runs
 }
 
+// Even padding inside the pill on both sides; a small gap separates the pill
+// from the following plain text so the two never touch.
+const HIGHLIGHT_PAD = 14
+const AFTER_HIGHLIGHT_GAP = 8
+
+function advanceWidth(text, fontSize) {
+  const { x, width } = measureTextBBoxWithResvg(text, fontSize)
+  return x + width
+}
+
 function tokenWidth(token, fontSize) {
   if (token.kind === 'highlight') {
-    return (
-      measureTextWidthWithResvg(token.text, fontSize) +
-      HIGHLIGHT_PAD_LEFT +
-      HIGHLIGHT_PAD_RIGHT
-    )
+    return advanceWidth(token.text, fontSize) + HIGHLIGHT_PAD * 2 + AFTER_HIGHLIGHT_GAP
   }
   if (token.atomic) {
     return measureTextWidthWithResvg(token.text, fontSize)
   }
   return measureText(token.text, fontSize)
 }
-
-const HIGHLIGHT_PAD_LEFT = 10
-const HIGHLIGHT_PAD_RIGHT = 3
-const AFTER_HIGHLIGHT_GAP = 8
 
 function layoutHighlightedSentence(segments, options) {
   const {
@@ -345,9 +348,16 @@ function layoutHighlightedSentence(segments, options) {
 
     for (const run of lineToRuns(trimmed)) {
       if (run.kind === 'highlight') {
-        const pillWidth = measureTextWidthWithResvg(run.text, fontSize)
-        const rectWidth = pillWidth + HIGHLIGHT_PAD_LEFT + HIGHLIGHT_PAD_RIGHT
-        svg += `<rect x="${xCursor - HIGHLIGHT_PAD_LEFT}" y="${
+        const { x: inkX, width: inkWidth } = measureTextBBoxWithResvg(
+          run.text,
+          fontSize
+        )
+        // Anchor the pill on the actual ink so left/right padding is equal,
+        // independent of the glyph's left side bearing.
+        const inkLeft = xCursor + inkX
+        const rectX = inkLeft - HIGHLIGHT_PAD
+        const rectWidth = inkWidth + HIGHLIGHT_PAD * 2
+        svg += `<rect x="${rectX}" y="${
           lineY - fontSize - padY + 8
         }" width="${rectWidth}" height="${
           fontSize + padY * 2
@@ -355,7 +365,7 @@ function layoutHighlightedSentence(segments, options) {
         svg += `<text x="${xCursor}" y="${lineY}" fill="${textColor}" font-size="${fontSize}" font-family="${INTER_FONT_FAMILY}">${escapeXml(
           run.text
         )}</text>`
-        xCursor += pillWidth + HIGHLIGHT_PAD_RIGHT + AFTER_HIGHLIGHT_GAP
+        xCursor = rectX + rectWidth + AFTER_HIGHLIGHT_GAP
         continue
       }
 

--- a/scripts/generate-page-og.mjs
+++ b/scripts/generate-page-og.mjs
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import {
   formatLifetimeStatDisplay,
+  formatMapOgSentence,
   resolveLifetimeStats,
 } from '../utils/lifetimeStats.ts'
 import {
@@ -193,7 +194,7 @@ function renderTransparencySvg(stats) {
   `
 }
 
-function renderMapSvg(mapDataUri) {
+function renderMapSvg(mapDataUri, stats) {
   const pageUrl = 'opensats.org/map'
   const seed = hashString('page:map')
 
@@ -211,9 +212,9 @@ function renderMapSvg(mapDataUri) {
   const separatorY = urlY - 36
 
   const summaryLines = wrapText(
-    'Countries where OpenSats has awarded grants.',
-    24,
-    3,
+    formatMapOgSentence(stats),
+    26,
+    4,
     'page map summary'
   )
 
@@ -221,7 +222,7 @@ function renderMapSvg(mapDataUri) {
     .map(
       (line, index) =>
         `<tspan x="${PADDING}" dy="${
-          index === 0 ? 0 : 38
+          index === 0 ? 0 : 34
         }">${escapeXml(line)}</tspan>`
     )
     .join('')
@@ -249,7 +250,7 @@ function renderMapSvg(mapDataUri) {
 
       <text x="${PADDING}" y="${titleStartY}" fill="${COLORS.title}" font-size="88" font-weight="900" font-family="${INTER_FONT_FAMILY}" letter-spacing="-3">Map</text>
 
-      <text x="${PADDING}" y="${summaryStartY}" fill="${COLORS.summary}" font-size="28" font-family="${INTER_FONT_FAMILY}">
+      <text x="${PADDING}" y="${summaryStartY}" fill="${COLORS.summary}" font-size="24" font-family="${INTER_FONT_FAMILY}">
         ${summarySvg}
       </text>
 
@@ -297,7 +298,7 @@ async function main() {
 
   for (const page of EXTRA_PAGES) {
     if (page.slug === 'map') {
-      await writeImage('map', renderMapSvg(mapDataUri))
+      await writeImage('map', renderMapSvg(mapDataUri, transparencyStats))
     } else {
       await writeImage(page.slug, renderPageSvg(page))
     }

--- a/scripts/generate-page-og.mjs
+++ b/scripts/generate-page-og.mjs
@@ -1,5 +1,10 @@
 import path from 'node:path'
 import {
+  formatLifetimeStatDisplay,
+  getLifetimeStats,
+  normalizeLifetimeStats,
+} from '../utils/lifetimeStats.ts'
+import {
   ROOT,
   OG_WIDTH,
   OG_HEIGHT,
@@ -18,11 +23,10 @@ import {
   writePng,
 } from './lib/og-network.mjs'
 
-// Generates per-slug OG images for static MDX-driven pages
-// (data/pages/*.mdx). Visually it's the topic OG template — same light
-// surface, network decoration, Inter type — so every standalone page
-// gets a coherent, on-brand share card without falling back to the
-// generic default.
+// Generates per-slug OG images for MDX-driven pages (data/pages/*.mdx) and a
+// small set of TSX-only routes. Visually it's the topic OG template — same
+// light surface, network decoration, Inter type — except transparency, which
+// foregrounds the three lifetime stats shown on the live page.
 const outputDir = path.join(ROOT, 'public', 'static', 'images', 'pages', 'og')
 
 // Most page slugs collide 1:1 with their URL path. The exceptions all
@@ -33,6 +37,15 @@ const SLUG_TO_URL_PATH = {
   'faq-grantees': 'faq/grantee',
   'report-success': 'reports/success',
 }
+
+// TSX-only routes that are not backed by data/pages/*.mdx.
+const EXTRA_PAGES = [
+  {
+    slug: 'map',
+    title: 'Map',
+    summary: 'Countries where OpenSats has awarded grants.',
+  },
+]
 
 // Utility / legal / form-result pages that don't benefit from a custom
 // social card and look better falling back to the default brand OG.
@@ -133,6 +146,49 @@ function renderPageSvg(page) {
   `
 }
 
+function renderTransparencySvg(stats) {
+  const pageUrl = 'opensats.org/transparency'
+  const seed = hashString('page:transparency')
+
+  const logoSize = 72
+  const logoX = PADDING
+  const logoY = PADDING + 8
+  const titleX = logoX + logoSize + 24
+  const titleY = logoY + logoSize / 2 + 18
+
+  const colWidth = CONTENT_WIDTH / 3
+  const numberY = 360
+  const labelY = 430
+  const urlY = 568
+  const separatorY = urlY - 36
+
+  const statColumns = stats
+    .map((stat, index) => {
+      const centerX = PADDING + colWidth * index + colWidth / 2
+      const value = formatLifetimeStatDisplay(index, stat.value)
+      return `
+        <text x="${centerX}" y="${numberY}" fill="${COLORS.accent}" font-size="56" font-weight="700" font-family="${INTER_FONT_FAMILY}" text-anchor="middle">${escapeXml(value)}</text>
+        <text x="${centerX}" y="${labelY}" fill="${COLORS.summary}" font-size="26" font-family="${INTER_FONT_FAMILY}" text-anchor="middle">${escapeXml(stat.label)}</text>
+      `
+    })
+    .join('')
+
+  return `
+    <svg width="${OG_WIDTH}" height="${OG_HEIGHT}" viewBox="0 0 ${OG_WIDTH} ${OG_HEIGHT}" fill="none" xmlns="http://www.w3.org/2000/svg">
+      ${backgroundDecor(seed)}
+
+      <image href="${faviconDataUri}" x="${logoX}" y="${logoY}" width="${logoSize}" height="${logoSize}" />
+
+      <text x="${titleX}" y="${titleY}" fill="${COLORS.title}" font-size="56" font-weight="900" font-family="${INTER_FONT_FAMILY}" letter-spacing="-2">Transparency</text>
+
+      ${statColumns}
+
+      <rect x="${PADDING}" y="${separatorY}" width="${CONTENT_WIDTH}" height="1" fill="${COLORS.separator}" />
+      <text x="${PADDING}" y="${urlY}" fill="${COLORS.url}" font-size="22" font-family="${INTER_FONT_FAMILY}" letter-spacing="1">${escapeXml(pageUrl)}</text>
+    </svg>
+  `
+}
+
 async function writeImage(slug, svg) {
   await writePng(path.join(outputDir, `${slug}.png`), renderSvgToPng(svg))
 }
@@ -142,18 +198,30 @@ async function main() {
   faviconDataUri = await loadFaviconDataUri()
 
   const pages = await loadContentlayerIndex('Pages')
+  const transparencyStats = normalizeLifetimeStats(await getLifetimeStats())
 
   let written = 0
   for (const page of pages) {
     if (SKIP_SLUGS.has(page.slug)) continue
+
+    if (page.slug === 'transparency') {
+      await writeImage('transparency', renderTransparencySvg(transparencyStats))
+    } else {
+      await writeImage(page.slug, renderPageSvg(page))
+    }
+
+    written += 1
+  }
+
+  for (const page of EXTRA_PAGES) {
     await writeImage(page.slug, renderPageSvg(page))
     written += 1
   }
 
+  const skipped = pages.filter((page) => SKIP_SLUGS.has(page.slug)).length
+
   console.log(
-    `Generated ${written} page OG images (skipped ${
-      pages.length - written
-    } utility page${pages.length - written === 1 ? '' : 's'}).`
+    `Generated ${written} page OG images (skipped ${skipped} utility page${skipped === 1 ? '' : 's'}, plus ${EXTRA_PAGES.length} TSX route${EXTRA_PAGES.length === 1 ? '' : 's'}).`
   )
 }
 

--- a/scripts/generate-page-og.mjs
+++ b/scripts/generate-page-og.mjs
@@ -4,6 +4,10 @@ import {
   resolveLifetimeStats,
 } from '../utils/lifetimeStats.ts'
 import {
+  renderGranteeMapDataUri,
+  WORLD_MAP_ASPECT,
+} from './lib/grantee-map.mjs'
+import {
   ROOT,
   OG_WIDTH,
   OG_HEIGHT,
@@ -17,6 +21,7 @@ import {
   hashString,
   loadContentlayerIndex,
   loadFaviconDataUri,
+  networkDecor,
   renderSvgToPng,
   wrapText,
   writePng,
@@ -188,6 +193,74 @@ function renderTransparencySvg(stats) {
   `
 }
 
+function renderMapSvg(mapDataUri) {
+  const pageUrl = 'opensats.org/map'
+  const seed = hashString('page:map')
+
+  const mapWidth = 560
+  const mapHeight = mapWidth / WORLD_MAP_ASPECT
+  const mapX = OG_WIDTH - PADDING - mapWidth
+  const mapY = (OG_HEIGHT - mapHeight - 48) / 2 - 16
+
+  const logoSize = 72
+  const logoX = PADDING
+  const logoY = PADDING + 8
+  const titleStartY = logoY + logoSize + 72
+  const summaryStartY = titleStartY + 72
+  const urlY = 568
+  const separatorY = urlY - 36
+
+  const summaryLines = wrapText(
+    'Countries where OpenSats has awarded grants.',
+    24,
+    3,
+    'page map summary'
+  )
+
+  const summarySvg = summaryLines
+    .map(
+      (line, index) =>
+        `<tspan x="${PADDING}" dy="${
+          index === 0 ? 0 : 38
+        }">${escapeXml(line)}</tspan>`
+    )
+    .join('')
+
+  const networkSvg = networkDecor({
+    seed,
+    minX: mapX - 40,
+    maxX: OG_WIDTH - 30,
+    minY: 40,
+    maxY: OG_HEIGHT - 60,
+    spacing: 60,
+    jitter: 14,
+    dropRate: 0.22,
+    centerOffsetX: 0,
+    centerOffsetY: 0,
+    fadeFactor: 1.0,
+  })
+
+  return `
+    <svg width="${OG_WIDTH}" height="${OG_HEIGHT}" viewBox="0 0 ${OG_WIDTH} ${OG_HEIGHT}" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect width="${OG_WIDTH}" height="${OG_HEIGHT}" fill="${COLORS.background}" />
+      ${networkSvg}
+
+      <image href="${faviconDataUri}" x="${logoX}" y="${logoY}" width="${logoSize}" height="${logoSize}" />
+
+      <text x="${PADDING}" y="${titleStartY}" fill="${COLORS.title}" font-size="88" font-weight="900" font-family="${INTER_FONT_FAMILY}" letter-spacing="-3">Map</text>
+
+      <text x="${PADDING}" y="${summaryStartY}" fill="${COLORS.summary}" font-size="28" font-family="${INTER_FONT_FAMILY}">
+        ${summarySvg}
+      </text>
+
+      <image href="${mapDataUri}" x="${mapX}" y="${mapY}" width="${mapWidth}" height="${mapHeight}" />
+
+      <rect x="${PADDING}" y="${separatorY}" width="${CONTENT_WIDTH}" height="1" fill="${COLORS.separator}" />
+      <text x="${PADDING}" y="${urlY}" fill="${COLORS.url}" font-size="22" font-family="${INTER_FONT_FAMILY}" letter-spacing="1">${escapeXml(pageUrl)}</text>
+    </svg>
+  `
+}
+
 async function writeImage(slug, svg) {
   await writePng(path.join(outputDir, `${slug}.png`), renderSvgToPng(svg))
 }
@@ -198,6 +271,16 @@ async function main() {
 
   const pages = await loadContentlayerIndex('Pages')
   const transparencyStats = await resolveLifetimeStats()
+  const mapDataUri = await renderGranteeMapDataUri(
+    {
+      base: '#e5e7eb',
+      baseOpacity: 1,
+      highlight: COLORS.accent,
+      stroke: '#ffffff',
+      strokeWidth: 0.5,
+    },
+    900
+  )
 
   let written = 0
   for (const page of pages) {
@@ -213,7 +296,11 @@ async function main() {
   }
 
   for (const page of EXTRA_PAGES) {
-    await writeImage(page.slug, renderPageSvg(page))
+    if (page.slug === 'map') {
+      await writeImage('map', renderMapSvg(mapDataUri))
+    } else {
+      await writeImage(page.slug, renderPageSvg(page))
+    }
     written += 1
   }
 

--- a/scripts/generate-page-og.mjs
+++ b/scripts/generate-page-og.mjs
@@ -22,6 +22,7 @@ import {
   hashString,
   loadContentlayerIndex,
   loadFaviconDataUri,
+  measureTextWidthWithResvg,
   networkDecor,
   renderSvgToPng,
   wrapText,
@@ -214,21 +215,14 @@ function measureText(text, fontSize) {
 function buildRenderTokens(segments) {
   const tokens = []
 
-  for (let i = 0; i < segments.length; i++) {
-    const segment = segments[i]
-    const next = segments[i + 1]
-
+  for (const segment of segments) {
     if (segment.highlight) {
-      const glue =
-        next && !next.highlight && /^\s+(to|in)\s+$/.test(next.text)
-          ? next.text.trimStart()
-          : ''
-      tokens.push({
-        kind: 'highlight',
-        text: segment.text,
-        glue,
-      })
-      if (glue) i += 1
+      tokens.push({ kind: 'highlight', text: segment.text, atomic: true })
+      continue
+    }
+
+    if (/^\s+(to|in)\s+$/.test(segment.text)) {
+      tokens.push({ kind: 'plain', text: segment.text, atomic: true })
       continue
     }
 
@@ -247,7 +241,7 @@ function lineToRuns(line) {
   let plain = ''
 
   for (const token of line) {
-    if (token.kind === 'plain') {
+    if (token.kind === 'plain' && !token.atomic) {
       plain += token.text
       continue
     }
@@ -256,6 +250,7 @@ function lineToRuns(line) {
       runs.push({ kind: 'plain', text: plain })
       plain = ''
     }
+
     runs.push(token)
   }
 
@@ -268,10 +263,21 @@ function lineToRuns(line) {
 
 function tokenWidth(token, fontSize) {
   if (token.kind === 'highlight') {
-    return measureText(token.text + (token.glue || ''), fontSize)
+    return (
+      measureTextWidthWithResvg(token.text, fontSize) +
+      HIGHLIGHT_PAD_LEFT +
+      HIGHLIGHT_PAD_RIGHT
+    )
+  }
+  if (token.atomic) {
+    return measureTextWidthWithResvg(token.text, fontSize)
   }
   return measureText(token.text, fontSize)
 }
+
+const HIGHLIGHT_PAD_LEFT = 10
+const HIGHLIGHT_PAD_RIGHT = 3
+const AFTER_HIGHLIGHT_GAP = 8
 
 function layoutHighlightedSentence(segments, options) {
   const {
@@ -282,7 +288,6 @@ function layoutHighlightedSentence(segments, options) {
     lineHeight,
     textColor,
     highlightBg = HIGHLIGHT_BG,
-    padX = 8,
     padY = 8,
   } = options
 
@@ -306,7 +311,7 @@ function layoutHighlightedSentence(segments, options) {
     }
 
     if (
-      token.kind === 'highlight' &&
+      token.atomic &&
       currentWidth + width > maxWidth &&
       currentLine.length
     ) {
@@ -340,30 +345,27 @@ function layoutHighlightedSentence(segments, options) {
 
     for (const run of lineToRuns(trimmed)) {
       if (run.kind === 'highlight') {
-        const textWidth = measureText(run.text, fontSize)
-        svg += `<rect x="${xCursor - padX}" y="${
+        const pillWidth = measureTextWidthWithResvg(run.text, fontSize)
+        const rectWidth = pillWidth + HIGHLIGHT_PAD_LEFT + HIGHLIGHT_PAD_RIGHT
+        svg += `<rect x="${xCursor - HIGHLIGHT_PAD_LEFT}" y="${
           lineY - fontSize - padY + 8
-        }" width="${textWidth + padX * 2}" height="${
+        }" width="${rectWidth}" height="${
           fontSize + padY * 2
         }" rx="10" fill="${highlightBg}" />`
         svg += `<text x="${xCursor}" y="${lineY}" fill="${textColor}" font-size="${fontSize}" font-family="${INTER_FONT_FAMILY}">${escapeXml(
           run.text
         )}</text>`
-        xCursor += textWidth
-
-        if (run.glue) {
-          svg += `<text x="${xCursor}" y="${lineY}" fill="${textColor}" font-size="${fontSize}" font-family="${INTER_FONT_FAMILY}">${escapeXml(
-            run.glue
-          )}</text>`
-          xCursor += measureText(run.glue, fontSize)
-        }
+        xCursor += pillWidth + HIGHLIGHT_PAD_RIGHT + AFTER_HIGHLIGHT_GAP
         continue
       }
 
       svg += `<text x="${xCursor}" y="${lineY}" fill="${textColor}" font-size="${fontSize}" font-family="${INTER_FONT_FAMILY}">${escapeXml(
         run.text
       )}</text>`
-      xCursor += measureText(run.text, fontSize)
+      xCursor +=
+        run.kind === 'plain' && run.atomic
+          ? measureTextWidthWithResvg(run.text, fontSize)
+          : measureText(run.text, fontSize)
     }
 
     lineY += lineHeight

--- a/scripts/generate-page-og.mjs
+++ b/scripts/generate-page-og.mjs
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import {
   formatLifetimeStatDisplay,
-  formatMapOgSentence,
+  formatMapOgSentenceSegments,
   resolveLifetimeStats,
 } from '../utils/lifetimeStats.ts'
 import {
@@ -194,6 +194,98 @@ function renderTransparencySvg(stats) {
   `
 }
 
+// Tailwind primary-100 — matches StatsSentence highlight pills on light bg.
+const HIGHLIGHT_BG = '#ffedd5'
+
+function estimateTextWidth(text, fontSize) {
+  return text.length * fontSize * 0.52
+}
+
+function segmentsToWords(segments) {
+  const words = []
+  for (const segment of segments) {
+    for (const part of segment.text.split(/(\s+)/)) {
+      if (part) {
+        words.push({ text: part, highlight: segment.highlight })
+      }
+    }
+  }
+  return words
+}
+
+function layoutHighlightedSentence(segments, options) {
+  const {
+    x,
+    y,
+    maxWidth,
+    fontSize,
+    lineHeight,
+    textColor,
+    highlightBg = HIGHLIGHT_BG,
+  } = options
+
+  const words = segmentsToWords(segments)
+  const lines = []
+  let currentLine = []
+  let currentWidth = 0
+
+  for (const word of words) {
+    const width = estimateTextWidth(word.text, fontSize)
+    const isSpace = /^\s+$/.test(word.text)
+
+    if (
+      currentLine.length &&
+      !isSpace &&
+      currentWidth + width > maxWidth
+    ) {
+      lines.push(currentLine)
+      currentLine = []
+      currentWidth = 0
+    }
+
+    currentLine.push(word)
+    currentWidth += width
+  }
+
+  if (currentLine.length) {
+    lines.push(currentLine)
+  }
+
+  let svg = ''
+  let lineY = y
+
+  for (const line of lines) {
+    let xCursor = x
+
+    for (const word of line) {
+      const width = estimateTextWidth(word.text, fontSize)
+      if (word.highlight && word.text.trim()) {
+        const padX = 8
+        const padY = 6
+        svg += `<rect x="${xCursor - padX}" y="${
+          lineY - fontSize - padY + 6
+        }" width="${width + padX * 2}" height="${
+          fontSize + padY * 2
+        }" rx="8" fill="${highlightBg}" />`
+      }
+      xCursor += width
+    }
+
+    xCursor = x
+    for (const word of line) {
+      const width = estimateTextWidth(word.text, fontSize)
+      svg += `<text x="${xCursor}" y="${lineY}" fill="${textColor}" font-size="${fontSize}" font-family="${INTER_FONT_FAMILY}">${escapeXml(
+        word.text
+      )}</text>`
+      xCursor += width
+    }
+
+    lineY += lineHeight
+  }
+
+  return svg
+}
+
 function renderMapSvg(mapDataUri, stats) {
   const pageUrl = 'opensats.org/map'
   const seed = hashString('page:map')
@@ -206,26 +298,23 @@ function renderMapSvg(mapDataUri, stats) {
   const logoSize = 72
   const logoX = PADDING
   const logoY = PADDING + 8
-  const titleStartY = logoY + logoSize + 72
-  const summaryStartY = titleStartY + 72
+  const sentenceX = PADDING
+  const sentenceY = logoY + logoSize + 112
+  const sentenceMaxWidth = mapX - PADDING - 32
   const urlY = 568
   const separatorY = urlY - 36
 
-  const summaryLines = wrapText(
-    formatMapOgSentence(stats),
-    26,
-    4,
-    'page map summary'
+  const sentenceSvg = layoutHighlightedSentence(
+    formatMapOgSentenceSegments(stats),
+    {
+      x: sentenceX,
+      y: sentenceY,
+      maxWidth: sentenceMaxWidth,
+      fontSize: 32,
+      lineHeight: 52,
+      textColor: COLORS.summary,
+    }
   )
-
-  const summarySvg = summaryLines
-    .map(
-      (line, index) =>
-        `<tspan x="${PADDING}" dy="${
-          index === 0 ? 0 : 34
-        }">${escapeXml(line)}</tspan>`
-    )
-    .join('')
 
   const networkSvg = networkDecor({
     seed,
@@ -248,11 +337,7 @@ function renderMapSvg(mapDataUri, stats) {
 
       <image href="${faviconDataUri}" x="${logoX}" y="${logoY}" width="${logoSize}" height="${logoSize}" />
 
-      <text x="${PADDING}" y="${titleStartY}" fill="${COLORS.title}" font-size="88" font-weight="900" font-family="${INTER_FONT_FAMILY}" letter-spacing="-3">Map</text>
-
-      <text x="${PADDING}" y="${summaryStartY}" fill="${COLORS.summary}" font-size="24" font-family="${INTER_FONT_FAMILY}">
-        ${summarySvg}
-      </text>
+      ${sentenceSvg}
 
       <image href="${mapDataUri}" x="${mapX}" y="${mapY}" width="${mapWidth}" height="${mapHeight}" />
 

--- a/scripts/generate-page-og.mjs
+++ b/scripts/generate-page-og.mjs
@@ -1,8 +1,7 @@
 import path from 'node:path'
 import {
   formatLifetimeStatDisplay,
-  getLifetimeStats,
-  normalizeLifetimeStats,
+  resolveLifetimeStats,
 } from '../utils/lifetimeStats.ts'
 import {
   ROOT,
@@ -198,7 +197,7 @@ async function main() {
   faviconDataUri = await loadFaviconDataUri()
 
   const pages = await loadContentlayerIndex('Pages')
-  const transparencyStats = normalizeLifetimeStats(await getLifetimeStats())
+  const transparencyStats = await resolveLifetimeStats()
 
   let written = 0
   for (const page of pages) {

--- a/scripts/generate-page-og.mjs
+++ b/scripts/generate-page-og.mjs
@@ -204,9 +204,14 @@ function estimateTextWidth(text, fontSize) {
 function segmentsToWords(segments) {
   const words = []
   for (const segment of segments) {
+    if (segment.highlight) {
+      words.push({ text: segment.text, highlight: true, atomic: true })
+      continue
+    }
+
     for (const part of segment.text.split(/(\s+)/)) {
       if (part) {
-        words.push({ text: part, highlight: segment.highlight })
+        words.push({ text: part, highlight: false, atomic: false })
       }
     }
   }
@@ -238,6 +243,12 @@ function layoutHighlightedSentence(segments, options) {
       !isSpace &&
       currentWidth + width > maxWidth
     ) {
+      lines.push(currentLine)
+      currentLine = []
+      currentWidth = 0
+    }
+
+    if (word.atomic && currentWidth + width > maxWidth && currentLine.length) {
       lines.push(currentLine)
       currentLine = []
       currentWidth = 0

--- a/scripts/generate-page-og.mjs
+++ b/scripts/generate-page-og.mjs
@@ -197,25 +197,80 @@ function renderTransparencySvg(stats) {
 // Tailwind primary-100 — matches StatsSentence highlight pills on light bg.
 const HIGHLIGHT_BG = '#ffedd5'
 
-function estimateTextWidth(text, fontSize) {
-  return text.length * fontSize * 0.52
+function measureText(text, fontSize) {
+  let width = 0
+  for (const char of text) {
+    if (char === ' ') {
+      width += fontSize * 0.34
+    } else if (/[0-9~$+]/.test(char)) {
+      width += fontSize * 0.58
+    } else {
+      width += fontSize * 0.52
+    }
+  }
+  return width
 }
 
-function segmentsToWords(segments) {
-  const words = []
-  for (const segment of segments) {
+function buildRenderTokens(segments) {
+  const tokens = []
+
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i]
+    const next = segments[i + 1]
+
     if (segment.highlight) {
-      words.push({ text: segment.text, highlight: true, atomic: true })
+      const glue =
+        next && !next.highlight && /^\s+(to|in)\s+$/.test(next.text)
+          ? next.text.trimStart()
+          : ''
+      tokens.push({
+        kind: 'highlight',
+        text: segment.text,
+        glue,
+      })
+      if (glue) i += 1
       continue
     }
 
     for (const part of segment.text.split(/(\s+)/)) {
       if (part) {
-        words.push({ text: part, highlight: false, atomic: false })
+        tokens.push({ kind: 'plain', text: part })
       }
     }
   }
-  return words
+
+  return tokens
+}
+
+function lineToRuns(line) {
+  const runs = []
+  let plain = ''
+
+  for (const token of line) {
+    if (token.kind === 'plain') {
+      plain += token.text
+      continue
+    }
+
+    if (plain) {
+      runs.push({ kind: 'plain', text: plain })
+      plain = ''
+    }
+    runs.push(token)
+  }
+
+  if (plain) {
+    runs.push({ kind: 'plain', text: plain })
+  }
+
+  return runs
+}
+
+function tokenWidth(token, fontSize) {
+  if (token.kind === 'highlight') {
+    return measureText(token.text + (token.glue || ''), fontSize)
+  }
+  return measureText(token.text, fontSize)
 }
 
 function layoutHighlightedSentence(segments, options) {
@@ -227,16 +282,18 @@ function layoutHighlightedSentence(segments, options) {
     lineHeight,
     textColor,
     highlightBg = HIGHLIGHT_BG,
+    padX = 8,
+    padY = 8,
   } = options
 
-  const words = segmentsToWords(segments)
+  const tokens = buildRenderTokens(segments)
   const lines = []
   let currentLine = []
   let currentWidth = 0
 
-  for (const word of words) {
-    const width = estimateTextWidth(word.text, fontSize)
-    const isSpace = /^\s+$/.test(word.text)
+  for (const token of tokens) {
+    const width = tokenWidth(token, fontSize)
+    const isSpace = token.kind === 'plain' && /^\s+$/.test(token.text)
 
     if (
       currentLine.length &&
@@ -248,13 +305,17 @@ function layoutHighlightedSentence(segments, options) {
       currentWidth = 0
     }
 
-    if (word.atomic && currentWidth + width > maxWidth && currentLine.length) {
+    if (
+      token.kind === 'highlight' &&
+      currentWidth + width > maxWidth &&
+      currentLine.length
+    ) {
       lines.push(currentLine)
       currentLine = []
       currentWidth = 0
     }
 
-    currentLine.push(word)
+    currentLine.push(token)
     currentWidth += width
   }
 
@@ -266,29 +327,43 @@ function layoutHighlightedSentence(segments, options) {
   let lineY = y
 
   for (const line of lines) {
-    let xCursor = x
-
-    for (const word of line) {
-      const width = estimateTextWidth(word.text, fontSize)
-      if (word.highlight && word.text.trim()) {
-        const padX = 8
-        const padY = 6
-        svg += `<rect x="${xCursor - padX}" y="${
-          lineY - fontSize - padY + 6
-        }" width="${width + padX * 2}" height="${
-          fontSize + padY * 2
-        }" rx="8" fill="${highlightBg}" />`
-      }
-      xCursor += width
+    let trimmed = line
+    while (
+      trimmed.length &&
+      trimmed[0].kind === 'plain' &&
+      /^\s+$/.test(trimmed[0].text)
+    ) {
+      trimmed = trimmed.slice(1)
     }
 
-    xCursor = x
-    for (const word of line) {
-      const width = estimateTextWidth(word.text, fontSize)
+    let xCursor = x
+
+    for (const run of lineToRuns(trimmed)) {
+      if (run.kind === 'highlight') {
+        const textWidth = measureText(run.text, fontSize)
+        svg += `<rect x="${xCursor - padX}" y="${
+          lineY - fontSize - padY + 8
+        }" width="${textWidth + padX * 2}" height="${
+          fontSize + padY * 2
+        }" rx="10" fill="${highlightBg}" />`
+        svg += `<text x="${xCursor}" y="${lineY}" fill="${textColor}" font-size="${fontSize}" font-family="${INTER_FONT_FAMILY}">${escapeXml(
+          run.text
+        )}</text>`
+        xCursor += textWidth
+
+        if (run.glue) {
+          svg += `<text x="${xCursor}" y="${lineY}" fill="${textColor}" font-size="${fontSize}" font-family="${INTER_FONT_FAMILY}">${escapeXml(
+            run.glue
+          )}</text>`
+          xCursor += measureText(run.glue, fontSize)
+        }
+        continue
+      }
+
       svg += `<text x="${xCursor}" y="${lineY}" fill="${textColor}" font-size="${fontSize}" font-family="${INTER_FONT_FAMILY}">${escapeXml(
-        word.text
+        run.text
       )}</text>`
-      xCursor += width
+      xCursor += measureText(run.text, fontSize)
     }
 
     lineY += lineHeight
@@ -310,8 +385,8 @@ function renderMapSvg(mapDataUri, stats) {
   const logoX = PADDING
   const logoY = PADDING + 8
   const sentenceX = PADDING
-  const sentenceY = logoY + logoSize + 112
-  const sentenceMaxWidth = mapX - PADDING - 32
+  const sentenceY = logoY + logoSize + 96
+  const sentenceMaxWidth = mapX - PADDING - 24
   const urlY = 568
   const separatorY = urlY - 36
 
@@ -321,8 +396,8 @@ function renderMapSvg(mapDataUri, stats) {
       x: sentenceX,
       y: sentenceY,
       maxWidth: sentenceMaxWidth,
-      fontSize: 32,
-      lineHeight: 52,
+      fontSize: 38,
+      lineHeight: 58,
       textColor: COLORS.summary,
     }
   )

--- a/scripts/lib/grantee-map.mjs
+++ b/scripts/lib/grantee-map.mjs
@@ -1,0 +1,128 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { Resvg } from '@resvg/resvg-js'
+import { ROOT } from './og-network.mjs'
+
+export const WORLD_SVG_PATH = path.join(ROOT, 'public', 'maps', 'world.svg')
+
+export const WORLD_MAP_ASPECT = 1009.6727 / 665.96301
+
+// Keep in sync with pages/map.tsx and components/GranteeMap.tsx
+export const GRANTEE_COUNTRY_CODES = [
+  'US',
+  'CA',
+  'DE',
+  'GB',
+  'IT',
+  'JP',
+  'NL',
+  'CH',
+  'CN',
+  'BR',
+  'AR',
+  'IE',
+  'HK',
+  'GE',
+  'SE',
+  'ES',
+  'PT',
+  'NO',
+  'GR',
+  'AU',
+  'IN',
+  'SI',
+  'KR',
+  'FI',
+  'CZ',
+  'UG',
+  'BE',
+  'FR',
+  'VN',
+  'UA',
+  'TR',
+  'SV',
+  'NZ',
+  'HU',
+  'SK',
+  'NG',
+  'PA',
+  'RO',
+  'GT',
+  'ID',
+  'AE',
+]
+
+function escapeForCss(value) {
+  return value.replace(/[^a-zA-Z0-9_-]/g, '\\$&')
+}
+
+export async function loadWorldSvg() {
+  const rawSvg = await fs.readFile(WORLD_SVG_PATH, 'utf8')
+  let svg = rawSvg.replace(/<\?xml[\s\S]*?\?>\s*/i, '').trim()
+
+  svg = svg.replace(/\s+width="[^"]+"/, '').replace(/\s+height="[^"]+"/, '')
+
+  if (!/viewBox=/.test(svg)) {
+    const widthMatch = rawSvg.match(/width="([^"]+)"/)
+    const heightMatch = rawSvg.match(/height="([^"]+)"/)
+    if (widthMatch && heightMatch) {
+      const w = parseFloat(widthMatch[1])
+      const h = parseFloat(heightMatch[1])
+      svg = svg.replace('<svg', `<svg viewBox="0 0 ${w} ${h}"`)
+    }
+  }
+
+  return svg
+}
+
+export function buildStyledGranteeMapSvg(
+  rawSvg,
+  {
+    base = '#e5e7eb',
+    baseOpacity = 1,
+    highlight = '#f97316',
+    stroke = '#ffffff',
+    strokeWidth = 0.5,
+  } = {}
+) {
+  const highlightSelector = GRANTEE_COUNTRY_CODES.map(
+    (code) => `#${escapeForCss(code)}`
+  ).join(', ')
+
+  const css = `
+    path {
+      fill: ${base};
+      fill-opacity: ${baseOpacity};
+      stroke: ${stroke};
+      stroke-width: ${strokeWidth};
+    }
+    ${highlightSelector} {
+      fill: ${highlight};
+      fill-opacity: 1;
+    }
+  `
+
+  return svgWithStyles(rawSvg, css)
+}
+
+function svgWithStyles(rawSvg, css) {
+  return rawSvg.replace(
+    /<svg([^>]*)>/,
+    `<svg$1><style><![CDATA[${css}]]></style>`
+  )
+}
+
+export function renderGranteeMapPng(styledSvg, width) {
+  const resvg = new Resvg(styledSvg, {
+    fitTo: { mode: 'width', value: width },
+    background: 'rgba(0,0,0,0)',
+  })
+  return resvg.render().asPng()
+}
+
+export async function renderGranteeMapDataUri(style, width) {
+  const rawSvg = await loadWorldSvg()
+  const styledSvg = buildStyledGranteeMapSvg(rawSvg, style)
+  const png = renderGranteeMapPng(styledSvg, width)
+  return `data:image/png;base64,${png.toString('base64')}`
+}

--- a/scripts/lib/og-network.mjs
+++ b/scripts/lib/og-network.mjs
@@ -271,13 +271,17 @@ export function renderSvgToPng(svg) {
   return resvg.render().asPng()
 }
 
-const textWidthCache = new Map()
+const textBBoxCache = new Map()
 
-/** Measure rendered text width using the same Inter + resvg stack as OG output. */
-export function measureTextWidthWithResvg(text, fontSize) {
+/**
+ * Measure rendered text using the same Inter + resvg stack as OG output.
+ * Returns the ink bounding box relative to a glyph origin at x=0, so callers
+ * can account for the left side bearing when drawing tight highlight pills.
+ */
+export function measureTextBBoxWithResvg(text, fontSize) {
   const key = `${fontSize}\0${text}`
-  if (textWidthCache.has(key)) {
-    return textWidthCache.get(key)
+  if (textBBoxCache.has(key)) {
+    return textBBoxCache.get(key)
   }
 
   const svgHeight = Math.ceil(fontSize * 2)
@@ -292,9 +296,14 @@ export function measureTextWidthWithResvg(text, fontSize) {
     },
   })
   const bbox = resvg.getBBox()
-  const width = bbox?.width ?? 0
-  textWidthCache.set(key, width)
-  return width
+  const result = { x: bbox?.x ?? 0, width: bbox?.width ?? 0 }
+  textBBoxCache.set(key, result)
+  return result
+}
+
+/** Measure rendered text width using the same Inter + resvg stack as OG output. */
+export function measureTextWidthWithResvg(text, fontSize) {
+  return measureTextBBoxWithResvg(text, fontSize).width
 }
 
 // Removes and recreates the directory so stale output never ships.

--- a/scripts/lib/og-network.mjs
+++ b/scripts/lib/og-network.mjs
@@ -271,6 +271,32 @@ export function renderSvgToPng(svg) {
   return resvg.render().asPng()
 }
 
+const textWidthCache = new Map()
+
+/** Measure rendered text width using the same Inter + resvg stack as OG output. */
+export function measureTextWidthWithResvg(text, fontSize) {
+  const key = `${fontSize}\0${text}`
+  if (textWidthCache.has(key)) {
+    return textWidthCache.get(key)
+  }
+
+  const svgHeight = Math.ceil(fontSize * 2)
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="${svgHeight}">
+    <text x="0" y="${fontSize}" font-size="${fontSize}" font-family="${INTER_FONT_FAMILY}">${escapeXml(text)}</text>
+  </svg>`
+  const resvg = new Resvg(svg, {
+    font: {
+      fontFiles: INTER_FONT_FILES,
+      loadSystemFonts: false,
+      defaultFontFamily: INTER_FONT_FAMILY,
+    },
+  })
+  const bbox = resvg.getBBox()
+  const width = bbox?.width ?? 0
+  textWidthCache.set(key, width)
+  return width
+}
+
 // Removes and recreates the directory so stale output never ships.
 export async function ensureCleanDir(dir) {
   await fs.rm(dir, { recursive: true, force: true })

--- a/utils/lifetimeStats.ts
+++ b/utils/lifetimeStats.ts
@@ -7,9 +7,9 @@ export const LIFETIME_STATS_SHEET_ID =
   '1mLEbHcrJibLN2PKxYq1LHJssq0CGuJRRoaZwot-ncZQ'
 
 export const DEFAULT_LIFETIME_STATS: LifetimeStat[] = [
-  { label: 'Grants given', value: 404 },
-  { label: 'USD allocated', value: 34668655 },
-  { label: 'Sats sent', value: 39524655813 },
+  { label: 'Grants given', value: 319 },
+  { label: 'USD allocated', value: 27400000 },
+  { label: 'Sats sent', value: 31200000000 },
 ]
 
 let lifetimeStatsPromise: Promise<LifetimeStat[] | null> | null = null
@@ -37,18 +37,35 @@ export function formatLifetimeStatDisplay(
   return formatted
 }
 
+function coerceStatValue(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value.replace(/,/g, '').trim())
+    if (Number.isFinite(parsed)) {
+      return parsed
+    }
+  }
+
+  return null
+}
+
 export function normalizeLifetimeStats(
   data: LifetimeStat[] | null | undefined,
   fallback: LifetimeStat[] = DEFAULT_LIFETIME_STATS
 ): LifetimeStat[] {
   return fallback.map((fallbackItem, index) => {
     const item = data?.[index]
+    const coercedValue = coerceStatValue(item?.value)
+
     return {
       label:
         typeof item?.label === 'string' && item.label.length > 0
           ? item.label
           : fallbackItem.label,
-      value: typeof item?.value === 'number' ? item.value : fallbackItem.value,
+      value: coercedValue ?? fallbackItem.value,
     }
   })
 }
@@ -129,6 +146,11 @@ export async function getLifetimeStats(): Promise<LifetimeStat[] | null> {
   }
 
   return lifetimeStatsPromise
+}
+
+/** Build-time helper: always returns a full stats array, using defaults on fetch failure. */
+export async function resolveLifetimeStats(): Promise<LifetimeStat[]> {
+  return normalizeLifetimeStats(await getLifetimeStats())
 }
 
 export function useAnimatedCount(

--- a/utils/lifetimeStats.ts
+++ b/utils/lifetimeStats.ts
@@ -37,6 +37,24 @@ export function formatLifetimeStatDisplay(
   return formatted
 }
 
+/** Matches the country count shown in StatsSentence (`40+ countries`). */
+export const STATS_COUNTRY_COUNT = 40
+
+export function formatStatsSentenceValues(stats: LifetimeStat[]) {
+  return {
+    grantsGiven: formatNumber(stats[0]?.value ?? 0),
+    usdAllocated: Math.round(stats[1]?.value ?? 0).toLocaleString(),
+    satsSent: formatNumber(stats[2]?.value ?? 0).replace('B', 'billion'),
+    countryCount: STATS_COUNTRY_COUNT,
+  }
+}
+
+export function formatMapOgSentence(stats: LifetimeStat[]): string {
+  const { satsSent, grantsGiven, countryCount } =
+    formatStatsSentenceValues(stats)
+  return `OpenSats has sent ~${satsSent} sats to ${grantsGiven} grantees in ${countryCount}+ countries`
+}
+
 function coerceStatValue(value: unknown): number | null {
   if (typeof value === 'number' && Number.isFinite(value)) {
     return value

--- a/utils/lifetimeStats.ts
+++ b/utils/lifetimeStats.ts
@@ -6,7 +6,7 @@ export type LifetimeStat = { label: string; value: number }
 export const LIFETIME_STATS_SHEET_ID =
   '1mLEbHcrJibLN2PKxYq1LHJssq0CGuJRRoaZwot-ncZQ'
 
-const DEFAULT_LIFETIME_STATS: LifetimeStat[] = [
+export const DEFAULT_LIFETIME_STATS: LifetimeStat[] = [
   { label: 'Grants given', value: 404 },
   { label: 'USD allocated', value: 34668655 },
   { label: 'Sats sent', value: 39524655813 },
@@ -27,7 +27,17 @@ export function formatNumber(num: number): string {
   return Math.round(num).toString()
 }
 
-function normalizeLifetimeStats(
+export function formatLifetimeStatDisplay(
+  index: number,
+  value: number
+): string {
+  const formatted = formatNumber(value)
+  if (index === 1) return `$ ${formatted}`
+  if (index === 2) return `~${formatted}`
+  return formatted
+}
+
+export function normalizeLifetimeStats(
   data: LifetimeStat[] | null | undefined,
   fallback: LifetimeStat[] = DEFAULT_LIFETIME_STATS
 ): LifetimeStat[] {

--- a/utils/lifetimeStats.ts
+++ b/utils/lifetimeStats.ts
@@ -50,9 +50,25 @@ export function formatStatsSentenceValues(stats: LifetimeStat[]) {
 }
 
 export function formatMapOgSentence(stats: LifetimeStat[]): string {
+  return formatMapOgSentenceSegments(stats)
+    .map((segment) => segment.text)
+    .join('')
+}
+
+export function formatMapOgSentenceSegments(
+  stats: LifetimeStat[]
+): Array<{ text: string; highlight: boolean }> {
   const { satsSent, grantsGiven, countryCount } =
     formatStatsSentenceValues(stats)
-  return `OpenSats has sent ~${satsSent} sats to ${grantsGiven} grantees in ${countryCount}+ countries`
+
+  return [
+    { text: 'OpenSats has sent ', highlight: false },
+    { text: `~${satsSent} sats`, highlight: true },
+    { text: ' to ', highlight: false },
+    { text: `${grantsGiven} grantees`, highlight: true },
+    { text: ' in ', highlight: false },
+    { text: `${countryCount}+ countries`, highlight: true },
+  ]
 }
 
 function coerceStatValue(value: unknown): number | null {


### PR DESCRIPTION
Adds custom build-time OG images for `/map` and `/transparency` instead of generic MDX title cards. The map preview embeds the grantee world map and a dynamic stats sentence styled like `StatsSentence`, with resvg-measured highlight pills. The transparency preview shows the three lifetime stats. Stats formatting is shared via `utils/lifetimeStats.ts`, sheet values are coerced to numbers, and both pages pull live stats at build time.

- Generate `map.png` with world map, stats sentence, and orange highlight pills
- Generate `transparency.png` with lifetime donated, grantees, and countries funded
- Wire `/map` to `slug="map"` and fetch stats in transparency `getStaticProps`

Build preview:
- [/map](https://website-git-map-social-preview-opensats.vercel.app/map)
- [/transparency](https://website-git-map-social-preview-opensats.vercel.app/transparency)
