### PR TITLE
Add OP_VAULT topic page

### DIFF
--- a/data/topics/covenant.mdx
+++ b/data/topics/covenant.mdx
@@ -8,7 +8,7 @@ aliases: ['covenant', 'Bitcoin covenant']
 
 Covenants are proposed changes to Bitcoin's spending rules that let an output constrain some part of a future spend, most commonly the scripts or destinations that the spending transaction may create. Instead of only checking whether the current spender is authorized, a covenant also narrows what an authorized spender is allowed to do next.
 
-Bitcoin does not currently support general covenants on mainnet. The term describes a family of proposals rather than one specific feature. [OP_CTV](/topics/op-ctv), for example, is a minimal covenant proposal that commits an output to one specific future transaction template.
+Bitcoin does not currently support general covenants on mainnet. The term describes a family of proposals rather than one specific feature. [OP_CTV](/topics/op-ctv), for example, is a minimal covenant proposal that commits an output to one specific future transaction template. BIP 345's [OP_VAULT](/topics/op-vault) is a narrower proposal built specifically around delayed withdrawals and recovery paths for vaults.
 
 People are interested in covenants because they could enable vaults, congestion-controlled batching, payment pools, and other constructions that trade some future spending flexibility for stronger safety or coordination guarantees. The main debate is over how much expressiveness is useful, how much complexity is acceptable, and which design keeps the security model understandable for wallets and node software.
 

--- a/data/topics/op-vault.mdx
+++ b/data/topics/op-vault.mdx
@@ -1,0 +1,18 @@
+---
+title: 'OP_VAULT'
+summary: 'A proposed pair of Bitcoin opcodes for vault withdrawals with a built-in recovery path.'
+category: 'Bitcoin'
+aliases: ['BIP 345', 'OP_VAULT_RECOVER', 'vault opcode']
+---
+
+`OP_VAULT` is a proposed tapscript opcode described in BIP 345. The proposal pairs `OP_VAULT` with `OP_VAULT_RECOVER` to support a specialized kind of [covenant](/topics/covenant) built for [vaults](/topics/vaults). Together, the opcodes aim to enforce a delayed withdrawal path while preserving a prespecified recovery path that can move the coins to safety before the delay expires.
+
+`OP_VAULT` focuses on one use case: staged vault withdrawals. That specialization gives vault designs predictable safety rules, simpler wallet behavior, and a recovery flow that stays available until the final withdrawal completes. The proposal is often discussed alongside [OP_CTV](/topics/op-ctv), which BIP 345 uses as part of the overall design.
+
+BIP 345 is closed. The proposal still serves as a useful reference point in discussions about covenant-enabled vault design. It helps show the tradeoff between general-purpose covenant tools and opcodes designed for one narrow security model.
+
+## References
+
+- [BIP 345: `OP_VAULT`](https://github.com/bitcoin/bips/blob/master/bip-0345.mediawiki)
+- [bips.dev: `OP_VAULT`](https://bips.dev/345/)
+- [Bitcoin Optech: Vaults](https://bitcoinops.org/en/topics/vaults/)

--- a/data/topics/vaults.mdx
+++ b/data/topics/vaults.mdx
@@ -2,14 +2,14 @@
 title: 'Vaults'
 summary: 'Bitcoin custody constructions that delay withdrawals and preserve a recovery path if a key is stolen or a spend is coerced.'
 category: 'Bitcoin'
-aliases: ['vault', 'bitcoin vault', 'OP_VAULT', 'BIP 345']
+aliases: ['vault', 'bitcoin vault']
 ---
 
 Vaults are Bitcoin custody constructions that separate a withdrawal into stages. A first transaction starts the withdrawal and enforces a delay. During that delay, the owner can trigger a recovery path and move the coins to safety if a key was stolen or a spend was coerced.
 
 The goal is simple: turn key compromise from an instant loss into a security incident with response time. Different vault designs offer different delays, recovery paths, and assumptions about how many keys, devices, or pre-signed transactions must stay safe.
 
-Some vaults can be built today with timelocks, pre-signed transactions, and careful key management. Proposed [covenants](/topics/covenant) could make them simpler and more flexible. [OP_CTV](/topics/op-ctv) can express predefined vault trees, and BIP 345 proposes `OP_VAULT` and `OP_VAULT_RECOVER` as opcodes tailored to this use case.
+Some vaults can be built today with timelocks, pre-signed transactions, and careful key management. Proposed [covenants](/topics/covenant) could make them simpler and more flexible. [OP_CTV](/topics/op-ctv) can express predefined vault trees, and BIP 345's [OP_VAULT](/topics/op-vault) and `OP_VAULT_RECOVER` are opcodes tailored to this use case.
 
 Vaults matter for self-custody, inheritance planning, institutional storage, and coercion resistance. They also introduce tradeoffs in setup complexity, recovery procedures, and how tightly future spending paths are constrained.
 


### PR DESCRIPTION
Adds a dedicated `OP_VAULT` topic page and links the existing `Vaults` and `Covenants` pages to it.

- adds `data/topics/op-vault.mdx` with verified references to BIP 345, `bips.dev`, and Bitcoin Optech
- links `OP_VAULT` from the existing `Vaults` and `Covenants` topic pages and moves the `OP_VAULT` and `BIP 345` aliases off the broader `Vaults` page

Closes https://github.com/OpenSats/content/issues/280

---

Build preview:
- [`/topics/op-vault`](https://os-website-git-content-add-op-vault-topic-page-280-opensats.vercel.app/topics/op-vault)
- [`/topics/vaults`](https://os-website-git-content-add-op-vault-topic-page-280-opensats.vercel.app/topics/vaults)
- [`/topics/covenant`](https://os-website-git-content-add-op-vault-topic-page-280-opensats.vercel.app/topics/covenant)
