### PR TITLE
fix: enable submit button on grant and LTS application forms

### DIFF
--- a/components/grant-application/StepNavigation.tsx
+++ b/components/grant-application/StepNavigation.tsx
@@ -42,9 +42,11 @@ export default function StepNavigation({
         <button
           type="button"
           onClick={onSubmit}
-          disabled={true}
+          disabled={loading}
           aria-busy={loading}
-          className="cursor-not-allowed rounded-md bg-orange-500 px-6 py-2 text-sm font-semibold text-white opacity-50"
+          className={`rounded-md bg-orange-500 px-6 py-2 text-sm font-semibold text-white ${
+            loading ? 'cursor-not-allowed opacity-50' : 'hover:bg-orange-600'
+          }`}
         >
           {loading ? 'Submitting...' : submitLabel}
         </button>


### PR DESCRIPTION
The submit button on the final step of the grant and LTS application flows had `disabled` hardcoded to `true`, so applicants could never send their application. This ties the button to the `loading` state instead, matching the other navigation buttons.

- Fix in the shared `StepNavigation` component, so both `/apply/grant` and `/apply/lts` are covered.
- Button is now only disabled while a submission is in flight, and its styling toggles between the disabled and active hover states accordingly.

Build preview:
- [/apply/grant](https://opensats.org/apply/grant)
- [/apply/lts](https://opensats.org/apply/lts)
