### PR TITLE
chore: update Ville's author profile

### DIFF
--- a/data/authors/ville.mdx
+++ b/data/authors/ville.mdx
@@ -21,6 +21,4 @@ He is now building a dataset of financial censorship cases from around the world
 to be displayed on a website called [debankd.org](https://debankd.org/). Ville
 believes Bitcoin can help everyone, though proper education is absolutely
 fundamental. He sees a dire need for open source software, especially as the
-space grows more corporate and profit-seeking. That is why he is here. Ville
-creates content alongside like-minded, enthusiastic people at OpenSats, and looks
-forward to contributing, growing, and bringing everyone together.
+space grows more corporate and profit-seeking.

--- a/data/authors/ville.mdx
+++ b/data/authors/ville.mdx
@@ -4,7 +4,6 @@ nym: ville
 avatar: /static/images/team/ville.jpg
 occupation: Writer
 company: debankd
-email: ville@opensats.org
 nostr: npub10apyf3uh7tw80hm8ycqqz8m55zfmn0tzk9wylvxg9jv2vk73sr0q6mvrxt
 github: https://github.com/Kokkomaki
 ---

--- a/data/authors/ville.mdx
+++ b/data/authors/ville.mdx
@@ -2,7 +2,7 @@
 name: Ville
 nym: ville
 avatar: /static/images/team/ville.jpg
-occupation: Content Editor
+occupation: Writer
 company: OpenSats
 email: ville@opensats.org
 nostr: npub10apyf3uh7tw80hm8ycqqz8m55zfmn0tzk9wylvxg9jv2vk73sr0q6mvrxt

--- a/data/authors/ville.mdx
+++ b/data/authors/ville.mdx
@@ -3,7 +3,7 @@ name: Ville
 nym: ville
 avatar: /static/images/team/ville.jpg
 occupation: Writer
-company: OpenSats
+company: debankd
 email: ville@opensats.org
 nostr: npub10apyf3uh7tw80hm8ycqqz8m55zfmn0tzk9wylvxg9jv2vk73sr0q6mvrxt
 github: https://github.com/Kokkomaki

--- a/data/authors/ville.mdx
+++ b/data/authors/ville.mdx
@@ -7,7 +7,6 @@ company: OpenSats
 email: ville@opensats.org
 nostr: npub10apyf3uh7tw80hm8ycqqz8m55zfmn0tzk9wylvxg9jv2vk73sr0q6mvrxt
 github: https://github.com/Kokkomaki
-ops: true
 ---
 
 Ville is an avid bitcoiner from Finland who learned the hard way. He writes a


### PR DESCRIPTION
Removes the `ops: true` flag from Ville's profile. His author page at `/about/ville` still builds from the file itself, so existing bylines and direct links stay intact.

Build preview:
- [/about](https://os-website-git-rm-ville-opensats.vercel.app/about)
- [/about/ville](https://os-website-git-rm-ville-opensats.vercel.app/about/ville)
