### PR TITLE
Redirect /tags/spotlight to /spotlight

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -76,6 +76,11 @@ module.exports = () => {
     async redirects() {
       return [
         {
+          source: '/tags/spotlight',
+          destination: '/spotlight',
+          permanent: true,
+        },
+        {
           source: '/projects/nostr',
           destination: '/funds/nostr',
           permanent: true,


### PR DESCRIPTION
Permanently redirects `/tags/spotlight` to `/spotlight` so tag URLs land on the dedicated spotlight page.

- add redirect in `next.config.js`

Build preview: 
- [/tags/spotlight](https://os-website-git-spotlight-tag-forward-opensats.vercel.app/tags/spotlight)
