### PR TITLE
Add remaining opcode topic pages

### DIFF
--- a/data/blog/advancements-in-developer-libraries.mdx
+++ b/data/blog/advancements-in-developer-libraries.mdx
@@ -230,7 +230,7 @@ running smoothly, helping ensure safety across the entire `rust-bitcoin` stack.
 Additionally, OpenSats grantee Robert Netzke
 ([rustaceanrob](https://github.com/rustaceanrob)) implemented policy-level
 changes by merging upstream fixes directly into the library. He adjusted the
-`OP_RETURN` [size
+[OP_RETURN](/topics/op-return) [size
 limit](https://github.com/rust-bitcoin/rust-bitcoin/commit/e0442782c8c04bdc48c2743e70f46e41c507e5f4)—a
 rule for embedding data in transactions—to exactly match Bitcoin Core's
 80-byte cap, including the space for instructions (push opcodes), which helps

--- a/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
+++ b/data/blog/seventeenth-wave-of-bitcoin-grants.mdx
@@ -88,7 +88,7 @@ update as they work. The interface shows the raw transaction, transaction ID,
 and fees in real time. A script view walks through each step that the Bitcoin
 network checks before accepting a transaction. rawBit currently offers fourteen
 guided lessons that cover patterns such as simple payments, multisig, timelocks,
-`OP_RETURN` anchors, payment channels, [SegWit] formats, and [Taproot] key-path
+[OP_RETURN](/topics/op-return) anchors, payment channels, [SegWit] formats, and [Taproot] key-path
 and script-path spends. Each example can be broadcast to Bitcoin [testnet] for
 independent verification. This gives developers, educators, and curious learners
 a hands-on way to explore how Bitcoin transactions are structured and validated

--- a/data/topics/covenant.mdx
+++ b/data/topics/covenant.mdx
@@ -10,7 +10,7 @@ Covenants are proposed changes to Bitcoin's spending rules that let an output co
 
 Bitcoin does not currently support general covenants on mainnet. The term describes a family of proposals rather than one specific feature. [OP_CTV](/topics/op-ctv), for example, is a minimal covenant proposal that commits an output to one specific future transaction template. BIP 345's [OP_VAULT](/topics/op-vault) is a narrower proposal built specifically around delayed withdrawals and recovery paths for vaults.
 
-People are interested in covenants because they could enable vaults, congestion-controlled batching, payment pools, and other constructions that trade some future spending flexibility for stronger safety or coordination guarantees. The main debate is over how much expressiveness is useful, how much complexity is acceptable, and which design keeps the security model understandable for wallets and node software.
+People are interested in covenants because they could enable vaults, congestion-controlled batching, payment pools, and other constructions that trade some future spending flexibility for stronger safety or coordination guarantees. Proposals such as [OP_CAT](/topics/op-cat), [OP_CSFS](/topics/op-csfs), and [OP_PAIRCOMMIT](/topics/op-paircommit) are often discussed as building blocks in that design space. The main debate is over how much expressiveness is useful, how much complexity is acceptable, and which design keeps the security model understandable for wallets and node software.
 
 ## References
 

--- a/data/topics/op-cat.mdx
+++ b/data/topics/op-cat.mdx
@@ -1,0 +1,18 @@
+---
+title: 'OP_CAT'
+summary: 'A proposed Bitcoin opcode for tapscript that concatenates two stack values into one value.'
+category: 'Bitcoin'
+aliases: ['BIP 347', 'CAT']
+---
+
+OP_CAT is a proposed tapscript opcode described in BIP 347. It takes two values from the stack, joins them together in order, and pushes the combined value back onto the stack.
+
+That small operation matters because Bitcoin script has many ways to hash, compare, and check signatures, but no active opcode for building larger values from smaller stack elements. Reintroducing OP_CAT in tapscript would make it easier to express some advanced contract patterns, including Merkle-style commitments, tree signatures, and [covenant](/topics/covenant)-like constructions.
+
+OP_CAT existed in early Bitcoin versions and was disabled in 2010 along with several other opcodes. The modern proposal is narrower: it would only apply in tapscript and would keep tapscript's existing stack element size limit, so it is discussed as a soft-fork change rather than a return to the original scripting environment.
+
+## References
+
+- [BIP 347: OP_CAT in Tapscript](https://github.com/bitcoin/bips/blob/master/bip-0347.mediawiki)
+- [bips.dev: BIP 347 rendered](https://bips.dev/347/)
+- [Bitcoin Optech: OP_CAT](https://bitcoinops.org/en/topics/op_cat/)

--- a/data/topics/op-return.mdx
+++ b/data/topics/op-return.mdx
@@ -1,0 +1,18 @@
+---
+title: 'OP_RETURN'
+summary: 'A Bitcoin script opcode commonly used for provably unspendable outputs that carry small pieces of data.'
+category: 'Bitcoin'
+aliases: ['null data', 'data carrier', 'provably unspendable output']
+---
+
+OP_RETURN is a Bitcoin script opcode that immediately makes a script fail if someone tries to spend it. Wallets and protocols use that behavior to create provably unspendable outputs, most often for small data commitments that do not need to remain in the [UTXO](/topics/utxo) set.
+
+These outputs are commonly called null data outputs. They are useful when a protocol needs to anchor a commitment, identifier, or other small marker in a transaction without pretending the output can later be spent. Because the coins assigned to an OP_RETURN output are unspendable, standard OP_RETURN outputs usually carry no spendable value.
+
+OP_RETURN is not a general data-storage feature. Consensus rules and node relay policy are separate, and standardness limits have changed over time. Most applications that need larger or private data should store that data elsewhere and use OP_RETURN only for the minimal public commitment they need on chain.
+
+## References
+
+- [Bitcoin Developer Guide: Null Data](https://developer.bitcoin.org/devguide/transactions.html#null-data)
+- [Bitcoin Wiki: OP_RETURN](https://en.bitcoin.it/wiki/OP_RETURN)
+- [Bitcoin Core: script opcode definitions](https://github.com/bitcoin/bitcoin/blob/master/src/script/script.h)


### PR DESCRIPTION
Adds the remaining opcode topic coverage from the content tracker.

- adds `data/topics/op-cat.mdx` with verified references to BIP 347, `bips.dev`, and Bitcoin Optech
- adds `data/topics/op-return.mdx` with verified references to Bitcoin Developer Guide, Bitcoin Wiki, and Bitcoin Core
- links `OP_CAT` from the existing Covenants topic and links existing `OP_RETURN` mentions to the new topic page

Closes https://github.com/OpenSats/content/issues/279

---

Build preview:
- [x] [`/topics/op-cat`](https://os-website-git-content-add-remaining-opcode-top-69a3ee-opensats.vercel.app/topics/op-cat)
- [x] [`/topics/op-return`](https://os-website-git-content-add-remaining-opcode-top-69a3ee-opensats.vercel.app/topics/op-return)
