### PR TITLE
Update total sats sent for July 2026

### DIFF
--- a/data/projects/0xchat.mdx
+++ b/data/projects/0xchat.mdx
@@ -11,7 +11,7 @@ nostr: 'npub10td4yrp6cl9kmjp9x5yd7r8pm96a5j07lk5mtj2kw39qf8frpt8qm9x2wl'
 zapstore: 'https://zapstore.dev/apps/com.oxchat.nostr'
 tags: ['Nostr', 'Mobile', 'iOS', 'Android', 'Desktop']
 fund: nostr
-totalSatsSent: 457899204
+totalSatsSent: 457899286
 announcementLink: '/blog/nostr-grants-october-2023#0xchat'
 ---
 

--- a/data/projects/amber.mdx
+++ b/data/projects/amber.mdx
@@ -10,7 +10,7 @@ nostr: 'npub1w4uswmv6lu9yel005l3qgheysmr7tk9uvwluddznju3nuxalevvs2d0jr5'
 zapstore: 'https://zapstore.dev/apps/com.greenart7c3.nostrsigner'
 tags: ['Nostr', 'Signing', 'Mobile', 'Android']
 fund: nostr
-totalSatsSent: 88358968
+totalSatsSent: 95296063
 announcementLink: '/blog/greenart7c3-receives-lts-grant'
 ---
 

--- a/data/projects/amethyst.mdx
+++ b/data/projects/amethyst.mdx
@@ -12,7 +12,7 @@ zapstore: 'https://zapstore.dev/apps/com.vitorpamplona.amethyst'
 tags: ['Nostr', 'Mobile', 'Android', 'Desktop']
 showcase: true
 fund: nostr
-totalSatsSent: 318869029
+totalSatsSent: 370203912
 announcementLink: '/blog/nostr-grants-july-2023#amethyst'
 ---
 

--- a/data/projects/applesauce.mdx
+++ b/data/projects/applesauce.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/applesauce.png'
 git: 'https://github.com/hzrd149/applesauce'
 tags: ['Nostr', 'TypeScript', 'Library', 'SDK']
 fund: nostr
-totalSatsSent: 291347550
+totalSatsSent: 291347576
 announcementLink: '/blog/hzrd149-receives-lts-grant'
 ---
 

--- a/data/projects/asmap.mdx
+++ b/data/projects/asmap.mdx
@@ -9,7 +9,7 @@ darkCoverImage: '/static/images/projects/asmap-dark.png'
 git: 'https://github.com/asmap/kartograf'
 tags: ['Bitcoin', 'Security', 'Networking']
 fund: general
-totalSatsSent: 128871586
+totalSatsSent: 128871668
 announcementLink: '/blog/bitcoin-grants-september-2024-7th-wave#asmap'
 ---
 

--- a/data/projects/bdk.mdx
+++ b/data/projects/bdk.mdx
@@ -10,7 +10,7 @@ twitter: 'bitcoindevkit'
 tags: ['Bitcoin', 'Library']
 showcase: true
 fund: general
-totalSatsSent: 1266201245
+totalSatsSent: 1312448835
 announcementLink: '/blog/bitcoin-and-nostr-grants-august-2023#bdk'
 ---
 

--- a/data/projects/bitaxe.mdx
+++ b/data/projects/bitaxe.mdx
@@ -11,7 +11,7 @@ containCoverImage: true
 git: 'https://github.com/bitaxeorg'
 tags: ['Bitcoin', 'Mining', 'Hardware']
 fund: general
-totalSatsSent: 257477456
+totalSatsSent: 257477413
 announcementLink: '/blog/bitcoin-grants-feb-2024#the-bitaxe'
 ---
 

--- a/data/projects/bitcoin-core.mdx
+++ b/data/projects/bitcoin-core.mdx
@@ -10,7 +10,7 @@ twitter: 'bitcoincoreorg'
 tags: ['Bitcoin']
 showcase: true
 fund: general
-totalSatsSent: 3938619594
+totalSatsSent: 4249634228
 announcementLink: '/blog/announcing-lts-grant-program-to-support-bitcoin-core-contributors'
 ---
 

--- a/data/projects/bitcoindesign.mdx
+++ b/data/projects/bitcoindesign.mdx
@@ -13,7 +13,7 @@ twitter: 'bitcoin_design'
 personalTwitter: 'GBKS'
 tags: ['Bitcoin', 'Design', 'UX']
 fund: general
-totalSatsSent: 190648124
+totalSatsSent: 190648276
 announcementLink: '/blog/bitcoin-grants-december-2023#bitcoin-core-app'
 ---
 

--- a/data/projects/bitcoinfuzz.mdx
+++ b/data/projects/bitcoinfuzz.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/bitcoinfuzz.png'
 git: 'https://github.com/bitcoinfuzz/bitcoinfuzz'
 tags: ['Bitcoin', 'Core']
 fund: general
-totalSatsSent: 335220951
+totalSatsSent: 342158073
 announcementLink: '/blog/bruno-garcia-receives-lts-grant'
 ---
 

--- a/data/projects/bitcoinresearchkit.mdx
+++ b/data/projects/bitcoinresearchkit.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/bitcoinresearchkit.svg'
 git: 'https://github.com/bitcoinresearchkit/brk'
 tags: ['Bitcoin', 'Research', 'Infrastructure']
 fund: general
-totalSatsSent: 84296023
+totalSatsSent: 103242894
 announcementLink: '/blog/twelfth-wave-of-bitcoin-grants#bitcoin-research-kit'
 ---
 

--- a/data/projects/bitshala.mdx
+++ b/data/projects/bitshala.mdx
@@ -9,7 +9,7 @@ invertDarkImage: true
 git: 'https://github.com/Bitshala'
 tags: ['Bitcoin', 'Education']
 fund: general
-totalSatsSent: 448454702
+totalSatsSent: 504182936
 announcementLink: '/blog/let-a-thousand-flowers-bloom#bitshala'
 ---
 

--- a/data/projects/blitz-wallet.mdx
+++ b/data/projects/blitz-wallet.mdx
@@ -11,7 +11,7 @@ nostr: 'npub14l69mauhjyu9j8pgmhj04vjqauzq43ch9yp9g2yx9j9tc4n8xh8s5l9dz2'
 zapstore: 'https://zapstore.dev/apps/com.blitzwallet'
 tags: ['Bitcoin', 'Lightning', 'Wallet']
 fund: general
-totalSatsSent: 153818413
+totalSatsSent: 172342124
 announcementLink: '/blog/bitcoin-grants-july-2024-6th-wave#blitz-wallet'
 ---
 

--- a/data/projects/blixt.mdx
+++ b/data/projects/blixt.mdx
@@ -12,7 +12,7 @@ nostr: 'npub1v4v57fu60zvc9d2uq23cey4fnwvxlzga9q2vta2n6xalu03rs57s0mxwu8'
 zapstore: 'https://zapstore.dev/apps/com.blixtwallet'
 tags: ['Bitcoin', 'Lightning', 'Wallet']
 fund: general
-totalSatsSent: 352235630
+totalSatsSent: 352235585
 announcementLink: '/blog/bitcoin-grants-july-2023#blixt-wallet'
 ---
 

--- a/data/projects/btcpayserver.mdx
+++ b/data/projects/btcpayserver.mdx
@@ -12,7 +12,7 @@ personalTwitter: 'NicolasDorier'
 tags: ['Bitcoin', 'Lightning', 'Wallet', 'Node', 'Commerce', 'Infrastructure']
 showcase: true
 fund: general
-totalSatsSent: 1813908843
+totalSatsSent: 1886054896
 announcementLink: '/blog/bitcoin-grants-july-2023#btcpay-server'
 ---
 

--- a/data/projects/cashu.mdx
+++ b/data/projects/cashu.mdx
@@ -12,7 +12,7 @@ nostr: 'npub17fzkepv3q2szsvdefmws9znhhpzx9kvhgl2p3jqk9tm5z6sjalvsg49yxv'
 tags: ['Bitcoin', 'Lightning', 'ecash']
 showcase: true
 fund: general
-totalSatsSent: 719944691
+totalSatsSent: 808508876
 announcementLink: '/blog/bitcoin-grants-july-2023#cashu'
 ---
 

--- a/data/projects/cdk.mdx
+++ b/data/projects/cdk.mdx
@@ -10,7 +10,7 @@ git: 'https://github.com/cashubtc/cdk'
 nostr: 'npub1qjgcmlpkeyl8mdkvp4s0xls4ytcux6my606tgfx9xttut907h0zs76lgjw'
 tags: ['Bitcoin', 'Lightning', 'ecash', 'Library']
 fund: general
-totalSatsSent: 120998948
+totalSatsSent: 148747418
 announcementLink: '/blog/thirteenth-wave-of-bitcoin-grants#cdk--sats-app'
 ---
 

--- a/data/projects/citrine.mdx
+++ b/data/projects/citrine.mdx
@@ -10,7 +10,7 @@ nostr: 'npub1w4uswmv6lu9yel005l3qgheysmr7tk9uvwluddznju3nuxalevvs2d0jr5'
 zapstore: 'https://zapstore.dev/apps/com.greenart7c3.citrine'
 tags: ['Nostr', 'Relay', 'Mobile', 'Android']
 fund: nostr
-totalSatsSent: 4902796
+totalSatsSent: 4902789
 announcementLink: '/blog/greenart7c3-receives-lts-grant'
 ---
 

--- a/data/projects/contextvm.mdx
+++ b/data/projects/contextvm.mdx
@@ -12,7 +12,7 @@ git: 'https://github.com/ContextVM'
 tags: ['Nostr', 'MCP', 'Protocol', 'SDK']
 showcase: true
 fund: nostr
-totalSatsSent: 52691630
+totalSatsSent: 80440250
 announcementLink: '/blog/fifteenth-wave-of-nostr-grants#contextvm'
 ---
 

--- a/data/projects/coracle.mdx
+++ b/data/projects/coracle.mdx
@@ -13,7 +13,7 @@ zapstore: 'https://zapstore.dev/apps/social.coracle.app'
 tags: ['Nostr']
 showcase: true
 fund: nostr
-totalSatsSent: 693072327
+totalSatsSent: 725445503
 announcementLink: '/blog/nostr-grants-july-2023#coracle'
 ---
 

--- a/data/projects/cove.mdx
+++ b/data/projects/cove.mdx
@@ -11,7 +11,7 @@ twitter: 'covewallet'
 tags: ['Bitcoin', 'Wallet']
 showcase: true
 fund: general
-totalSatsSent: 347103822
+totalSatsSent: 386853516
 announcementLink: '/blog/bitcoin-grants-july-2024#cove'
 ---
 

--- a/data/projects/damus.mdx
+++ b/data/projects/damus.mdx
@@ -11,7 +11,7 @@ nostr: 'npub1xtscya34g58tk0z605fvr788k263gsu6cy9x0mhnm87echrgufzsevkk5s'
 tags: ['Nostr', 'Mobile', 'iOS']
 showcase: true
 fund: nostr
-totalSatsSent: 846761996
+totalSatsSent: 881447544
 announcementLink: '/blog/nostr-grants-july-2023#damus'
 ---
 

--- a/data/projects/dana-wallet.mdx
+++ b/data/projects/dana-wallet.mdx
@@ -12,7 +12,7 @@ nostr: 'npub17vjlv6u4dg2ypyy5je9zc3lpeyfrnfrpmzgwt8v4rc289p2m79cqepwz5q'
 zapstore: 'https://zapstore.dev/apps/dev.silentpayments.danawallet'
 tags: ['Bitcoin', 'Privacy', 'Wallet', 'Mobile']
 fund: general
-totalSatsSent: 26345719
+totalSatsSent: 51782038
 announcementLink: '/blog/fifteenth-wave-of-bitcoin-grants#dana-wallet'
 ---
 

--- a/data/projects/floresta.mdx
+++ b/data/projects/floresta.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/floresta.png'
 git: 'https://github.com/getfloresta/Floresta'
 tags: ['Bitcoin', 'Core']
 fund: general
-totalSatsSent: 80717987
+totalSatsSent: 101315442
 announcementLink: '/blog/bitcoin-grants-september-2024-7th-wave#floresta'
 ---
 

--- a/data/projects/frostr.mdx
+++ b/data/projects/frostr.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/frostr.png'
 git: 'https://github.com/FROSTR-ORG'
 tags: ['Nostr', 'Signing']
 fund: nostr
-totalSatsSent: 140328396
+totalSatsSent: 155364935
 announcementLink: '/blog/twelfth-wave-of-nostr-grants#frostr'
 ---
 

--- a/data/projects/jumble.mdx
+++ b/data/projects/jumble.mdx
@@ -11,7 +11,7 @@ git: 'https://github.com/CodyTseng/jumble'
 tags: ['Nostr', 'Web', 'PWA']
 showcase: true
 fund: nostr
-totalSatsSent: 63318635
+totalSatsSent: 77193012
 announcementLink: '/blog/twelfth-wave-of-nostr-grants#jumble'
 ---
 

--- a/data/projects/krux.mdx
+++ b/data/projects/krux.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/krux-logo.png'
 git: 'https://github.com/selfcustody/krux'
 tags: ['Bitcoin', 'Wallet', 'Signing']
 fund: general
-totalSatsSent: 163768976
+totalSatsSent: 167237494
 announcementLink: '/blog/bitcoin-grants-december-2023#krux'
 ---
 

--- a/data/projects/ldk.mdx
+++ b/data/projects/ldk.mdx
@@ -9,7 +9,7 @@ invertDarkImage: true
 git: 'https://github.com/lightningdevkit/rust-lightning'
 tags: ['Lightning', 'Rust', 'Library', 'SDK']
 fund: general
-totalSatsSent: 280286507
+totalSatsSent: 280286502
 announcementLink: '/blog/shashwat-vangani-receives-lts-grant'
 ---
 

--- a/data/projects/libbitcoin.mdx
+++ b/data/projects/libbitcoin.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/libbitcoin.svg'
 git: 'https://github.com/libbitcoin'
 tags: ['Bitcoin', 'Node', 'Library']
 fund: general
-totalSatsSent: 43910715
+totalSatsSent: 72815571
 announcementLink: '/blog/sixteenth-wave-of-bitcoin-grants#libbitcoin'
 ---
 

--- a/data/projects/lnbits.mdx
+++ b/data/projects/lnbits.mdx
@@ -9,7 +9,7 @@ git: 'https://github.com/lnbits/lnbits'
 twitter: 'lnbits'
 tags: ['Bitcoin', 'Lightning', 'Wallet', 'Infrastructure']
 fund: general
-totalSatsSent: 406588782
+totalSatsSent: 406588607
 announcementLink: '/blog/bitcoin-and-nostr-grants-august-2023#lnbits'
 ---
 

--- a/data/projects/minibits.mdx
+++ b/data/projects/minibits.mdx
@@ -9,7 +9,7 @@ git: 'https://github.com/minibits-cash/minibits_wallet'
 zapstore: 'https://zapstore.dev/apps/com.minibits_wallet'
 tags: ['Bitcoin', 'Lightning', 'ecash', 'Mobile']
 fund: general
-totalSatsSent: 81339512
+totalSatsSent: 92901470
 announcementLink: '/blog/bitcoin-grants-september-2024-7th-wave#minibits'
 ---
 

--- a/data/projects/mostro.mdx
+++ b/data/projects/mostro.mdx
@@ -12,7 +12,7 @@ twitter: 'MostroP2P'
 nostr: 'npub1m0str0d7z2ww8rdh20t2n9lx520xjwhaq24p68umqp06wwrwtsnqen40un'
 tags: ['Bitcoin', 'Lightning', 'Nostr']
 fund: nostr
-totalSatsSent: 255653806
+totalSatsSent: 255653810
 announcementLink: '/blog/nostr-grants-july-2024#mostro'
 ---
 

--- a/data/projects/nak.mdx
+++ b/data/projects/nak.mdx
@@ -9,7 +9,7 @@ git: 'https://github.com/fiatjaf/nak'
 nostr: 'npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6'
 tags: ['Nostr', 'CLI', 'Developer Tools']
 fund: nostr
-totalSatsSent: 143821152
+totalSatsSent: 143821160
 announcementLink: '/blog/fiatjaf-receives-lts-grant'
 ---
 

--- a/data/projects/ndk.mdx
+++ b/data/projects/ndk.mdx
@@ -9,7 +9,7 @@ git: 'https://github.com/nostr-dev-kit/ndk'
 nostr: 'npub1l2vyh47mk2p0qlsku7hg0vn29faehy9hy34ygaclpn66ukqp3afqutajft'
 tags: ['Nostr', 'TypeScript', 'Library', 'SDK']
 fund: nostr
-totalSatsSent: 895015483
+totalSatsSent: 929701263
 announcementLink: '/blog/nostr-grants-july-2023#ndk'
 ---
 

--- a/data/projects/ngit.mdx
+++ b/data/projects/ngit.mdx
@@ -9,7 +9,7 @@ git: 'https://github.com/DanConwayDev/ngit-cli'
 nostr: 'npub15qydau2hjma6ngxkl2cyar74wzyjshvl65za5k5rl69264ar2exs5cyejr'
 tags: ['Nostr', 'Git', 'Developer Tools']
 fund: nostr
-totalSatsSent: 643952602
+totalSatsSent: 678638371
 announcementLink: '/blog/nostr-grants-july-2023#code-collaboration-over-nostr'
 ---
 

--- a/data/projects/opencash.mdx
+++ b/data/projects/opencash.mdx
@@ -8,7 +8,7 @@ donationLink: 'https://opencash.dev/'
 coverImage: '/static/images/projects/opencash.png'
 tags: ['Bitcoin', 'Lightning', 'ecash']
 fund: general
-totalSatsSent: 214714513
+totalSatsSent: 249400099
 announcementLink: '/blog/let-a-thousand-flowers-bloom#opencash'
 ---
 

--- a/data/projects/pdk.mdx
+++ b/data/projects/pdk.mdx
@@ -11,7 +11,7 @@ twitter: 'payjoindevkit'
 tags: ['Bitcoin', 'Privacy']
 showcase: true
 fund: general
-totalSatsSent: 541454804
+totalSatsSent: 603889101
 announcementLink: '/blog/bitcoin-grants-july-2023#payjoin-dev-kit'
 ---
 

--- a/data/projects/routstr.mdx
+++ b/data/projects/routstr.mdx
@@ -11,7 +11,7 @@ git: 'https://github.com/Routstr'
 nostr: 'npub130mznv74rxs032peqym6g3wqavh472623mt3z5w73xq9r6qqdufs7ql29s'
 tags: ['Bitcoin', 'Nostr', 'Privacy', 'Protocol']
 fund: general
-totalSatsSent: 16935286
+totalSatsSent: 51621065
 ---
 
 Routstr is a decentralized AI inference protocol for private, pay-per-request access to language models. It combines [Nostr](/topics/nostr) for node discovery with [Cashu](/projects/cashu) ecash for Bitcoin micropayments, so users can connect to providers without opening accounts or handing over a credit card. The core system is OpenAI-compatible, which lets developers point existing SDKs and tools at a Routstr node instead of a centralized API.

--- a/data/projects/rust-bitcoin.mdx
+++ b/data/projects/rust-bitcoin.mdx
@@ -11,7 +11,7 @@ heartbeat: 'https://heartbeat.opensats.org/?q=rust-bitcoin'
 tags: ['Bitcoin', 'Library']
 showcase: true
 fund: general
-totalSatsSent: 688647578
+totalSatsSent: 797329383
 announcementLink: '/blog/ninth-wave-of-bitcoin-grants#rust-bitcoin'
 ---
 

--- a/data/projects/satoshinakamotoinstitute.mdx
+++ b/data/projects/satoshinakamotoinstitute.mdx
@@ -11,7 +11,7 @@ git: 'https://github.com/NakamotoInstitute/nakamotoinstitute.org'
 tags: ['Bitcoin', 'Education', 'Research']
 showcase: true
 fund: general
-totalSatsSent: 255836980
+totalSatsSent: 269711398
 announcementLink: '/blog/announcing-the-opensats-education-initiative#satoshi-nakamoto-institute'
 ---
 

--- a/data/projects/soapbox.mdx
+++ b/data/projects/soapbox.mdx
@@ -13,7 +13,7 @@ nostr: 'npub108pv4cg5ag52nq082kd5leu9ffrn2gdg6g4xdwatn73y36uzplmq9uyev6'
 zapstore: 'https://zapstore.dev/apps/pub.ditto.app'
 tags: ['Nostr']
 fund: nostr
-totalSatsSent: 942003907
+totalSatsSent: 1097760136
 announcementLink: '/blog/nostr-grants-july-2023#soapbox'
 ---
 

--- a/data/projects/splicing.mdx
+++ b/data/projects/splicing.mdx
@@ -12,7 +12,7 @@ personalTwitter: 'dusty_daemon'
 nostr: 'npub1fuk7q4y0wzqw7vjrg7xeuuva79pg7ctg69a53zsxq6gepksufrrst9mzly'
 tags: ['Lightning', 'Protocol']
 fund: general
-totalSatsSent: 652602818
+totalSatsSent: 687288361
 announcementLink: '/blog/bitcoin-grants-july-2023#splicing'
 ---
 

--- a/data/projects/stable-channels.mdx
+++ b/data/projects/stable-channels.mdx
@@ -9,7 +9,7 @@ git: 'https://github.com/toneloc/stable-channels'
 tags: ['Bitcoin', 'Lightning']
 showcase: true
 fund: general
-totalSatsSent: 157067165
+totalSatsSent: 185971682
 announcementLink: '/blog/tenth-wave-of-bitcoin-grants#stable-channels'
 ---
 

--- a/data/projects/stratumv2.mdx
+++ b/data/projects/stratumv2.mdx
@@ -12,7 +12,7 @@ personalTwitter: 'StratumV2'
 tags: ['Bitcoin', 'Privacy', 'Protocol', 'Mining']
 showcase: true
 fund: general
-totalSatsSent: 376965174
+totalSatsSent: 383902211
 announcementLink: '/blog/bitcoin-and-nostr-grants-august-2023#stratum-v2-testing--benchmarking-tool'
 ---
 

--- a/data/projects/summerofbitcoin.mdx
+++ b/data/projects/summerofbitcoin.mdx
@@ -11,7 +11,7 @@ twitter: 'summerofbitcoin'
 tags: ['Bitcoin', 'Education']
 showcase: true
 fund: general
-totalSatsSent: 222771243
+totalSatsSent: 245894958
 announcementLink: '/blog/announcing-the-opensats-education-initiative#summer-of-bitcoin'
 ---
 

--- a/data/projects/tor.mdx
+++ b/data/projects/tor.mdx
@@ -13,7 +13,7 @@ zapstore: 'https://zapstore.dev/apps/org.torproject.android'
 tags: ['Privacy', 'Protocol']
 showcase: true
 fund: general
-totalSatsSent: 180331274
+totalSatsSent: 193012815
 announcementLink: '/blog/tor-receives-support-grant'
 ---
 

--- a/data/projects/utreexod.mdx
+++ b/data/projects/utreexod.mdx
@@ -9,7 +9,7 @@ invertDarkImage: true
 git: 'https://github.com/utreexo/utreexod'
 tags: ['Bitcoin', 'Core']
 fund: general
-totalSatsSent: 549878532
+totalSatsSent: 549878526
 announcementLink: '/blog/bitcoin-grants-july-2024#utreexo'
 ---
 

--- a/data/projects/vls.mdx
+++ b/data/projects/vls.mdx
@@ -8,7 +8,7 @@ coverImage: '/static/images/projects/vls.png'
 git: 'https://gitlab.com/lightning-signer/validating-lightning-signer'
 tags: ['Bitcoin', 'Lightning']
 fund: general
-totalSatsSent: 543348759
+totalSatsSent: 563710760
 announcementLink: '/blog/bitcoin-grants-december-2023#validating-lightning-signer'
 ---
 

--- a/data/projects/wireguard.mdx
+++ b/data/projects/wireguard.mdx
@@ -10,7 +10,7 @@ git: 'https://www.wireguard.com/repositories/'
 heartbeat: 'https://heartbeat.opensats.org/?q=wireguard'
 tags: ['Privacy', 'Protocol', 'Infrastructure']
 fund: general
-totalSatsSent: 605079968
+totalSatsSent: 674451354
 announcementLink: '/blog/jason-donenfeld-lts-grant'
 ---
 

--- a/data/projects/wisp.mdx
+++ b/data/projects/wisp.mdx
@@ -11,6 +11,7 @@ zapstore: 'https://zapstore.dev/apps/com.wisp.app'
 tags: ['Nostr', 'Mobile', 'Android', 'Wallet']
 fund: nostr
 announcementLink: '/blog/seventeenth-wave-of-nostr-grants#wisp'
+totalSatsSent: 33884484
 ---
 
 Wisp is an Android [nostr](/topics/nostr) client built by [Barry Deen][barry].

--- a/data/projects/zapstore.mdx
+++ b/data/projects/zapstore.mdx
@@ -9,7 +9,7 @@ git: 'https://github.com/zapstore/zapstore'
 tags: ['Nostr', 'Android', 'Mobile']
 showcase: true
 fund: nostr
-totalSatsSent: 101204345
+totalSatsSent: 115078794
 announcementLink: '/blog/10th-wave-of-nostr-grants#zapstore'
 ---
 


### PR DESCRIPTION
Updates `totalSatsSent` across listed project pages for the latest payout totals, and adds the field for Wisp (which did not have one yet). 

- refresh `totalSatsSent` for 50 existing project pages
- add `totalSatsSent` to `wisp`

Build preview: 
- [/projects/bitcoin-core](https://os-website-git-2026-july-sats-sent-opensats.vercel.app/projects/bitcoin-core)
- [/projects/wisp](https://os-website-git-2026-july-sats-sent-opensats.vercel.app/projects/wisp)
- [/projects/btcpayserver](https://os-website-git-2026-july-sats-sent-opensats.vercel.app/projects/btcpayserver)
