### PR TITLE
Add Git topic page

### DIFF
--- a/data/topics/git.mdx
+++ b/data/topics/git.mdx
@@ -25,7 +25,9 @@ Git does not require one specific hosting service. Projects often use GitHub,
 GitLab, Forgejo, sourcehut, mailing lists, or self-hosted servers as
 collaboration layers on top of Git. OpenSats has also funded
 [ngit](/projects/ngit), a Git plugin that uses [Nostr](/topics/nostr) for
-repository announcements, patch sharing, and social context around code.
+repository announcements, patch sharing, and social context around code, and
+[Grasp](/blog/thirteenth-wave-of-nostr-grants#grasp), a distributed,
+nostr-native Git host built on the same foundation.
 
 ## References
 
@@ -34,3 +36,4 @@ repository announcements, patch sharing, and social context around code.
 - [Wikipedia: Git](https://en.wikipedia.org/wiki/Git)
 - [W3Schools: Git Tutorial](https://www.w3schools.com/git/git_intro.asp?remote=github)
 - [ngit](/projects/ngit)
+- [Grasp](/blog/thirteenth-wave-of-nostr-grants#grasp)

--- a/data/topics/git.mdx
+++ b/data/topics/git.mdx
@@ -1,0 +1,35 @@
+---
+title: 'Git'
+summary: 'A distributed version control system that lets developers track source-code history, review changes, branch safely, and collaborate without depending on one central server.'
+category: 'Open Source'
+aliases: ['version control', 'distributed version control', 'DVCS']
+---
+
+Git is a distributed version control system. Developers use it to track changes
+to source code, split work into branches, review patches, and merge finished
+work back into a shared project history.
+
+Unlike older centralized version control systems, every Git clone contains the
+full project history. That makes ordinary work fast and local, and it lets
+contributors inspect, branch, commit, and compare changes even when they are not
+connected to the server that hosts the project's main repository.
+
+Git is one of the basic tools of [FOSS](/topics/foss) development. It gives
+maintainers a shared record of who changed what and why, while pull requests,
+patches, and signed tags give projects common review and release workflows. Most
+OpenSats-funded software projects use Git repositories to publish their code and
+coordinate work in the open.
+
+Git does not require one specific hosting service. Projects often use GitHub,
+GitLab, Forgejo, sourcehut, mailing lists, or self-hosted servers as
+collaboration layers on top of Git. OpenSats has also funded
+[ngit](/projects/ngit), a Git plugin that uses [Nostr](/topics/nostr) for
+repository announcements, patch sharing, and social context around code.
+
+## References
+
+- [Git](https://git-scm.com/)
+- [Git: About Version Control](https://git-scm.com/book/en/v2/Getting-Started-About-Version-Control)
+- [Wikipedia: Git](https://en.wikipedia.org/wiki/Git)
+- [W3Schools: Git Tutorial](https://www.w3schools.com/git/git_intro.asp?remote=github)
+- [ngit](/projects/ngit)

--- a/data/topics/git.mdx
+++ b/data/topics/git.mdx
@@ -10,7 +10,7 @@ Git is a distributed version control system. Developers use it to track changes
 to source code, split work into branches, review patches, and merge finished
 work back into a shared project history.
 
-Unlike older centralized version control systems, every Git clone contains the
+Unlike older centralized version control systems, every Git repository clone contains the
 full project history. That makes ordinary work fast and local, and it lets
 contributors inspect, branch, commit, and compare changes even when they are not
 connected to the server that hosts the project's main repository.

--- a/data/topics/git.mdx
+++ b/data/topics/git.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Git'
 summary: 'A distributed version control system that lets developers track source-code history, review changes, branch safely, and collaborate without depending on one central server.'
+ogSummary: 'Distributed version control for tracking code history, reviewing changes, and collaborating across open-source projects.'
 category: 'Open Source'
 aliases: ['version control', 'distributed version control', 'DVCS']
 ---

--- a/data/topics/git.mdx
+++ b/data/topics/git.mdx
@@ -35,5 +35,3 @@ nostr-native Git host built on the same foundation.
 - [Git: About Version Control](https://git-scm.com/book/en/v2/Getting-Started-About-Version-Control)
 - [Wikipedia: Git](https://en.wikipedia.org/wiki/Git)
 - [W3Schools: Git Tutorial](https://www.w3schools.com/git/git_intro.asp?remote=github)
-- [ngit](/projects/ngit)
-- [Grasp](/blog/thirteenth-wave-of-nostr-grants#grasp)


### PR DESCRIPTION
Adds a Git topic page covering distributed version control, open-source collaboration workflows, and the OpenSats-funded ngit project.

Closes OpenSats/content#292

---

**Build preview:**

- [x] [/topics/git](https://os-website-git-content-add-git-topic-page-292-opensats.vercel.app/topics/git)

**Evidence:**

- `npx contentlayer build && node ./scripts/generate-topic-og.mjs` generated 298 documents and topic OG images
- Verified added external links with `curl --head --location --fail`
- Verified the path-specific preview returned HTTP 200
- GitHub `build` check and Vercel deployment passed on the latest commit
