### PR TITLE
fix(newsletter): correct Q2 2026 publish date to July 30

### DIFF
--- a/data/newsletter/2026-Q2.mdx
+++ b/data/newsletter/2026-Q2.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Sats Well Spent'
 issueNumber: 2
-date: '2026-07-31'
+date: '2026-07-30'
 quarter: '2026-Q2'
 headline: 'Territory of Freedom'
 summary: 'Someone has to do it: how OpenSats is funding the builders behind a free and open internet.'


### PR DESCRIPTION
Corrects the Q2 2026 newsletter publish date from July 31 to July 30.

- Update `date` in `data/newsletter/2026-Q2.mdx` to `2026-07-30`

Build preview: 
- [/newsletter/2026-Q2](https://website-git-2026-q2-date-fix-open-sats.vercel.app/newsletter/2026-Q2)
