### PR TITLE
Remove NVK from the board and update former member bios

### DIFF
--- a/data/authors/niftynei.mdx
+++ b/data/authors/niftynei.mdx
@@ -9,10 +9,7 @@ github: https://github.com/niftynei
 board: false
 ---
 
-Nifty is a lightning spec veteran, accomplished dev, and Blockstreamer. She
-started the [bitcoin++](https://btcplusplus.dev/) dev-conf series and runs
-[Base58](https://www.base58.info/), the premier bitcoin protocol academy. Her
-current goal is to make bitcoin devs a NgU technology.
+Nifty used to be on the OpenSats board from May 2023 to June 2025.
 
 ---
 

--- a/data/authors/nvk.mdx
+++ b/data/authors/nvk.mdx
@@ -7,7 +7,7 @@ company: Coinkite
 twitter: https://twitter.com/nvk
 nostr: npub1az9xj85cmxv8e9j9y80lvqp97crsqdu2fpu3srwthd99qfu9qsgstam8y8
 github: https://github.com/nvk
-board: true
+board: false
 ---
 
 NVK is the founder of Coinkite which make many of the devices Bitcoiners love,

--- a/data/authors/nvk.mdx
+++ b/data/authors/nvk.mdx
@@ -10,9 +10,7 @@ github: https://github.com/nvk
 board: false
 ---
 
-NVK is the founder of Coinkite which make many of the devices Bitcoiners love,
-like COLDCARD, BLOCKCLOCK, OPENDIME. He is also having fun with the
-[Bitcoin.Review](https://bitcoin.review/) podcast and ham radios.
+NVK used to be on the OpenSats board from May 2023 to August 2026.
 
 ---
 


### PR DESCRIPTION
Removes NVK from the board listing and updates former board member bios to note their tenure dates.

- Set `board: false` for NVK
- Update NVK bio to May 2023–August 2026

Build preview: 
- [/about](https://website-git-rm-nvk-opensats.vercel.app/about)
- [/about/nvk](https://website-git-rm-nvk-opensats.vercel.app/about/nvk)
