### PR TITLE
feat(apply): add red teaming application at /apply/red

### DIFF
--- a/components/RedApplicationForm.tsx
+++ b/components/RedApplicationForm.tsx
@@ -28,9 +28,9 @@ const REVIEW_SECTIONS: ReviewSection[] = [
   {
     title: 'Budget',
     fields: [
-      ['Duration', 'duration'],
       ['Token Spend So Far', 'token_spend_so_far'],
       ['Expected Ongoing Burn', 'estimated_token_burn'],
+      ['Duration', 'duration'],
       ['Requested Reimbursement', 'proposed_budget'],
     ],
   },

--- a/components/RedApplicationForm.tsx
+++ b/components/RedApplicationForm.tsx
@@ -22,7 +22,6 @@ const REVIEW_SECTIONS: ReviewSection[] = [
     fields: [
       ['Short Title', 'project_name'],
       ['What Are You Researching?', 'short_description'],
-      ['Potential Impact', 'potential_impact'],
       ['Disclosure Links', 'disclosure_links'],
     ],
   },
@@ -56,7 +55,7 @@ const STEPS: StepConfig[] = [
   {
     id: 'research',
     title: 'Research',
-    fields: ['project_name', 'short_description', 'potential_impact'],
+    fields: ['project_name', 'short_description'],
     render: (props) => <RedResearch {...props} />,
   },
   {

--- a/components/RedApplicationForm.tsx
+++ b/components/RedApplicationForm.tsx
@@ -31,7 +31,6 @@ const REVIEW_SECTIONS: ReviewSection[] = [
       ['Token Spend So Far', 'token_spend_so_far'],
       ['Expected Ongoing Burn', 'estimated_token_burn'],
       ['Duration', 'duration'],
-      ['Requested Reimbursement', 'proposed_budget'],
     ],
   },
 ]
@@ -62,7 +61,7 @@ const STEPS: StepConfig[] = [
   {
     id: 'budget',
     title: 'Budget',
-    fields: ['duration', 'estimated_token_burn', 'proposed_budget'],
+    fields: ['duration', 'estimated_token_burn'],
     render: (props) => <TokenReimbursement {...props} />,
   },
   {

--- a/components/RedApplicationForm.tsx
+++ b/components/RedApplicationForm.tsx
@@ -61,7 +61,7 @@ const STEPS: StepConfig[] = [
   {
     id: 'budget',
     title: 'Budget',
-    fields: ['duration', 'estimated_token_burn'],
+    fields: ['token_spend_so_far', 'estimated_token_burn', 'duration'],
     render: (props) => <TokenReimbursement {...props} />,
   },
   {

--- a/components/RedApplicationForm.tsx
+++ b/components/RedApplicationForm.tsx
@@ -41,7 +41,11 @@ const STEPS: StepConfig[] = [
   {
     id: 'prerequisites',
     title: 'Prerequisites',
-    fields: ['red_security_research', 'responsible_disclosure'],
+    fields: [
+      'red_security_research',
+      'responsible_disclosure',
+      'foss_outputs',
+    ],
     render: (props) => <Prerequisites {...props} />,
   },
   {

--- a/components/RedApplicationForm.tsx
+++ b/components/RedApplicationForm.tsx
@@ -6,6 +6,11 @@ import ApplicantDetails from './grant-application/steps/ApplicantDetails'
 import RedResearch from './grant-application/steps/RedResearch'
 import TokenReimbursement from './grant-application/steps/TokenReimbursement'
 import Review, { ReviewSection } from './grant-application/steps/Review'
+import RedLegalAcknowledgments from './grant-application/steps/RedLegalAcknowledgments'
+import {
+  RED_ACK_FIELDS,
+  RED_TERMS_EFFECTIVE,
+} from './grant-application/redTerms'
 
 const REVIEW_SECTIONS: ReviewSection[] = [
   {
@@ -68,9 +73,12 @@ const STEPS: StepConfig[] = [
   {
     id: 'review',
     title: 'Review',
-    fields: [],
+    fields: [...RED_ACK_FIELDS],
     render: (props) => (
-      <Review watch={props.watch} sections={REVIEW_SECTIONS} />
+      <>
+        <Review watch={props.watch} sections={REVIEW_SECTIONS} />
+        <RedLegalAcknowledgments {...props} />
+      </>
     ),
   },
 ]
@@ -79,9 +87,13 @@ export default function RedApplicationForm() {
   return (
     <MultiStepApplicationForm
       steps={STEPS}
-      hiddenFields={{ RED: true }}
+      hiddenFields={{
+        RED: true,
+        red_terms_effective: RED_TERMS_EFFECTIVE,
+      }}
       defaultValues={{ duration: '1 month' }}
       submitLabel="Submit Red Application"
+      submitRequiresChecked={RED_ACK_FIELDS}
     />
   )
 }

--- a/components/RedApplicationForm.tsx
+++ b/components/RedApplicationForm.tsx
@@ -28,6 +28,7 @@ const REVIEW_SECTIONS: ReviewSection[] = [
   {
     title: 'Budget',
     fields: [
+      ['Duration', 'duration'],
       ['Token Spend So Far', 'token_spend_so_far'],
       ['Expected Ongoing Burn', 'estimated_token_burn'],
       ['Requested Reimbursement', 'proposed_budget'],
@@ -61,7 +62,7 @@ const STEPS: StepConfig[] = [
   {
     id: 'budget',
     title: 'Budget',
-    fields: ['estimated_token_burn', 'proposed_budget'],
+    fields: ['duration', 'estimated_token_burn', 'proposed_budget'],
     render: (props) => <TokenReimbursement {...props} />,
   },
   {
@@ -79,6 +80,7 @@ export default function RedApplicationForm() {
     <MultiStepApplicationForm
       steps={STEPS}
       hiddenFields={{ RED: true }}
+      defaultValues={{ duration: '3 months' }}
       submitLabel="Submit Red Application"
     />
   )

--- a/components/RedApplicationForm.tsx
+++ b/components/RedApplicationForm.tsx
@@ -39,11 +39,7 @@ const STEPS: StepConfig[] = [
   {
     id: 'prerequisites',
     title: 'Prerequisites',
-    fields: [
-      'red_security_research',
-      'responsible_disclosure',
-      'foss_outputs',
-    ],
+    fields: ['red_security_research', 'responsible_disclosure', 'foss_outputs'],
     render: (props) => <Prerequisites {...props} />,
   },
   {

--- a/components/RedApplicationForm.tsx
+++ b/components/RedApplicationForm.tsx
@@ -79,7 +79,7 @@ export default function RedApplicationForm() {
     <MultiStepApplicationForm
       steps={STEPS}
       hiddenFields={{ RED: true }}
-      defaultValues={{ duration: '3 months' }}
+      defaultValues={{ duration: '1 month' }}
       submitLabel="Submit Red Application"
     />
   )

--- a/components/RedApplicationForm.tsx
+++ b/components/RedApplicationForm.tsx
@@ -61,11 +61,7 @@ const STEPS: StepConfig[] = [
   {
     id: 'tokens',
     title: 'Token Reimbursement',
-    fields: [
-      'token_spend_so_far',
-      'estimated_token_burn',
-      'proposed_budget',
-    ],
+    fields: ['estimated_token_burn', 'proposed_budget'],
     render: (props) => <TokenReimbursement {...props} />,
   },
   {

--- a/components/RedApplicationForm.tsx
+++ b/components/RedApplicationForm.tsx
@@ -23,7 +23,6 @@ const REVIEW_SECTIONS: ReviewSection[] = [
       ['Short Title', 'project_name'],
       ['What Are You Researching?', 'short_description'],
       ['Prior Work', 'prior_work'],
-      ['Disclosure Links', 'disclosure_links'],
     ],
   },
   {

--- a/components/RedApplicationForm.tsx
+++ b/components/RedApplicationForm.tsx
@@ -20,7 +20,6 @@ const REVIEW_SECTIONS: ReviewSection[] = [
   {
     title: 'Research',
     fields: [
-      ['Main Focus', 'main_focus'],
       ['Short Title', 'project_name'],
       ['What Are You Researching?', 'short_description'],
       ['Potential Impact', 'potential_impact'],
@@ -57,12 +56,7 @@ const STEPS: StepConfig[] = [
   {
     id: 'research',
     title: 'Research',
-    fields: [
-      'main_focus',
-      'project_name',
-      'short_description',
-      'potential_impact',
-    ],
+    fields: ['project_name', 'short_description', 'potential_impact'],
     render: (props) => <RedResearch {...props} />,
   },
   {

--- a/components/RedApplicationForm.tsx
+++ b/components/RedApplicationForm.tsx
@@ -26,7 +26,7 @@ const REVIEW_SECTIONS: ReviewSection[] = [
     ],
   },
   {
-    title: 'Token Reimbursement',
+    title: 'Budget',
     fields: [
       ['Token Spend So Far', 'token_spend_so_far'],
       ['Expected Ongoing Burn', 'estimated_token_burn'],
@@ -59,8 +59,8 @@ const STEPS: StepConfig[] = [
     render: (props) => <RedResearch {...props} />,
   },
   {
-    id: 'tokens',
-    title: 'Token Reimbursement',
+    id: 'budget',
+    title: 'Budget',
     fields: ['estimated_token_burn', 'proposed_budget'],
     render: (props) => <TokenReimbursement {...props} />,
   },

--- a/components/RedApplicationForm.tsx
+++ b/components/RedApplicationForm.tsx
@@ -1,0 +1,92 @@
+import MultiStepApplicationForm, {
+  StepConfig,
+} from './grant-application/MultiStepApplicationForm'
+import Prerequisites from './grant-application/steps/Prerequisites'
+import ApplicantDetails from './grant-application/steps/ApplicantDetails'
+import RedResearch from './grant-application/steps/RedResearch'
+import TokenReimbursement from './grant-application/steps/TokenReimbursement'
+import Review, { ReviewSection } from './grant-application/steps/Review'
+
+const REVIEW_SECTIONS: ReviewSection[] = [
+  {
+    title: 'Applicant',
+    fields: [
+      ['Your Name', 'your_name'],
+      ['Email', 'email'],
+      ['Personal GitHub', 'personal_github'],
+      ['Other Contact Details', 'other_contact'],
+    ],
+  },
+  {
+    title: 'Research',
+    fields: [
+      ['Main Focus', 'main_focus'],
+      ['Short Title', 'project_name'],
+      ['What Are You Researching?', 'short_description'],
+      ['Potential Impact', 'potential_impact'],
+      ['Disclosure Links', 'disclosure_links'],
+    ],
+  },
+  {
+    title: 'Token Reimbursement',
+    fields: [
+      ['Token Spend So Far', 'token_spend_so_far'],
+      ['Expected Ongoing Burn', 'estimated_token_burn'],
+      ['Requested Reimbursement', 'proposed_budget'],
+    ],
+  },
+]
+
+const STEPS: StepConfig[] = [
+  {
+    id: 'prerequisites',
+    title: 'Prerequisites',
+    fields: ['red_security_research', 'responsible_disclosure'],
+    render: (props) => <Prerequisites {...props} />,
+  },
+  {
+    id: 'applicant',
+    title: 'Applicant',
+    fields: ['your_name', 'email'],
+    render: (props) => <ApplicantDetails {...props} showLeadFields={false} />,
+  },
+  {
+    id: 'research',
+    title: 'Research',
+    fields: [
+      'main_focus',
+      'project_name',
+      'short_description',
+      'potential_impact',
+    ],
+    render: (props) => <RedResearch {...props} />,
+  },
+  {
+    id: 'tokens',
+    title: 'Token Reimbursement',
+    fields: [
+      'token_spend_so_far',
+      'estimated_token_burn',
+      'proposed_budget',
+    ],
+    render: (props) => <TokenReimbursement {...props} />,
+  },
+  {
+    id: 'review',
+    title: 'Review',
+    fields: [],
+    render: (props) => (
+      <Review watch={props.watch} sections={REVIEW_SECTIONS} />
+    ),
+  },
+]
+
+export default function RedApplicationForm() {
+  return (
+    <MultiStepApplicationForm
+      steps={STEPS}
+      hiddenFields={{ RED: true }}
+      submitLabel="Submit Red Application"
+    />
+  )
+}

--- a/components/RedApplicationForm.tsx
+++ b/components/RedApplicationForm.tsx
@@ -22,6 +22,7 @@ const REVIEW_SECTIONS: ReviewSection[] = [
     fields: [
       ['Short Title', 'project_name'],
       ['What Are You Researching?', 'short_description'],
+      ['Prior Work', 'prior_work'],
       ['Disclosure Links', 'disclosure_links'],
     ],
   },
@@ -39,7 +40,12 @@ const STEPS: StepConfig[] = [
   {
     id: 'prerequisites',
     title: 'Prerequisites',
-    fields: ['red_security_research', 'responsible_disclosure', 'foss_outputs'],
+    fields: [
+      'red_security_research',
+      'red_track_record',
+      'responsible_disclosure',
+      'foss_outputs',
+    ],
     render: (props) => <Prerequisites {...props} />,
   },
   {
@@ -51,7 +57,7 @@ const STEPS: StepConfig[] = [
   {
     id: 'research',
     title: 'Research',
-    fields: ['project_name', 'short_description'],
+    fields: ['project_name', 'short_description', 'prior_work'],
     render: (props) => <RedResearch {...props} />,
   },
   {

--- a/components/RedBeforeYouApply.tsx
+++ b/components/RedBeforeYouApply.tsx
@@ -1,0 +1,123 @@
+import CustomLink from '@/components/Link'
+
+export default function RedBeforeYouApply() {
+  return (
+    <div className="prose mb-8 max-w-2xl dark:prose-invert">
+      <h3>Before you apply</h3>
+
+      <p>
+        <strong>Do not submit vulnerability details through this form.</strong>{' '}
+        Tell us who you are, what you have worked on, and the general scope of
+        what you propose to do. Do not include exploit code, reproduction steps,
+        affected addresses or keys, or any other nonpublic technical findings.
+        This form is not a secure disclosure channel. If you have an unreported
+        vulnerability, report it through the affected project&apos;s own
+        security contact or disclosure process.
+      </p>
+
+      <p>
+        <strong>Funding is not authorization.</strong> Applying for or receiving
+        funding from OpenSats does not give you permission to access, test,
+        disrupt, or interfere with any system, device, network, account, funds,
+        or data. OpenSats does not own or operate the third-party projects and
+        systems that may be the subject of your research and cannot authorize
+        testing of them. You are solely responsible for obtaining any permission
+        your work requires and for complying with all applicable laws,
+        regulations, licenses, contracts, and third-party rights, including
+        computer-access, anti-circumvention, privacy, sanctions, and
+        export-control requirements.
+      </p>
+
+      <p>
+        <strong>How funding may be used.</strong> Funding may be used only for
+        good-faith security research conducted on code, hardware, accounts, and
+        infrastructure you are legally entitled to study. Funding may not be
+        used to test third-party systems, production services, live user
+        accounts, live funds, or public networks unless the owner or operator
+        has authorized that testing in writing.
+      </p>
+
+      <p>
+        <strong>Handle findings responsibly.</strong> Report material
+        vulnerabilities privately to the appropriate maintainer, vendor, or
+        operator, and allow a reasonable opportunity to investigate and
+        remediate before public disclosure. Do not exploit a vulnerability for
+        unauthorized access or gain, condition disclosure on payment, or sell,
+        transfer, or provide nonpublic findings to anyone who may misuse them.
+        Failure to meet these conditions may result in rejection of your
+        application or suspension or termination of funding, and repayment where
+        the applicable grant terms provide for it.
+      </p>
+
+      <p>
+        <strong>Urgent circumstances.</strong> Nothing above requires you to
+        stay silent where prompt action is reasonably necessary to prevent
+        ongoing theft or imminent harm. If that situation arises, minimize
+        access and disruption, preserve evidence, contact the affected
+        maintainer or operator promptly, and get your own legal advice about
+        whether anyone else should be notified. Do not move, access, or take
+        custody of anyone else&apos;s funds or data because you believe doing so
+        will protect them, unless you have authorization or have been advised by
+        qualified counsel.
+      </p>
+
+      <p>
+        <strong>Check your existing obligations.</strong> Before you apply,
+        confirm that the work you propose is not restricted by an employment or
+        consulting agreement, a confidentiality or intellectual property
+        obligation, bug bounty terms, or any other commitment you have made.
+        OpenSats does not assess whether your work is permitted under those
+        arrangements.
+      </p>
+
+      <p>
+        <strong>You remain independent.</strong> A grant does not make you an
+        employee, agent, partner, or representative of OpenSats, and you may not
+        state or imply that OpenSats authorized your access or endorses any
+        finding or conclusion. OpenSats may set conditions on a grant, ask for
+        information about the work, and suspend or end funding, but you remain
+        responsible for how the research is conducted and for your findings,
+        statements, and publications.
+      </p>
+
+      <p>
+        <strong>Get your own advice.</strong> OpenSats does not provide legal,
+        tax, or other professional advice and, except as expressly stated in a
+        written grant agreement, does not indemnify or defend applicants or
+        grantees or pay their legal costs. Security research can create civil,
+        criminal, and contractual exposure. If your work may approach a legal or
+        contractual line, consult qualified counsel before you start.
+      </p>
+
+      <p>
+        <strong>Applying does not guarantee funding or confidentiality.</strong>{' '}
+        OpenSats may accept or decline any application at its discretion and may
+        change or end this program at any time. Submitting an application does
+        not create a confidential, fiduciary, employment, agency, partnership,
+        or attorney-client relationship. OpenSats may share your application
+        with directors, personnel, advisers, and reviewers involved in
+        evaluating or administering it. Do not submit information you are not
+        authorized to disclose.
+      </p>
+
+      <p>
+        <strong>Payment and tax.</strong> OpenSats may require identity, tax,
+        sanctions screening, or other compliance information before making any
+        payment, and may report or withhold amounts where required by law. The
+        tax treatment of anything you receive depends on your circumstances and
+        jurisdiction. Determining and reporting it is your responsibility, and
+        you should get your own tax advice.
+      </p>
+
+      <p>
+        <em>
+          Effective August 5, 2026. These requirements are in addition to the
+          OpenSats <CustomLink href="/terms">Terms of Use</CustomLink> and{' '}
+          <CustomLink href="/privacy">Privacy Policy</CustomLink> and to any
+          grant terms provided to an approved applicant. If they conflict, the
+          applicable grant terms control as to that grant.
+        </em>
+      </p>
+    </div>
+  )
+}

--- a/components/grant-application/MultiStepApplicationForm.tsx
+++ b/components/grant-application/MultiStepApplicationForm.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useRef, useState } from 'react'
+import { ReactNode, useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/router'
 import { DefaultValues, useForm } from 'react-hook-form'
 import { fetchPostJSON } from '../../utils/api-helpers'
@@ -20,6 +20,28 @@ interface MultiStepApplicationFormProps {
   submitLabel: string
 }
 
+function resolveStepIndex(
+  steps: readonly StepConfig[],
+  stepParam: string | string[] | undefined
+): number {
+  const raw = Array.isArray(stepParam) ? stepParam[0] : stepParam
+  if (!raw) return 0
+
+  const byId = steps.findIndex((step) => step.id === raw)
+  if (byId >= 0) return byId
+
+  const asNumber = Number.parseInt(raw, 10)
+  if (
+    !Number.isNaN(asNumber) &&
+    asNumber >= 0 &&
+    asNumber < steps.length
+  ) {
+    return asNumber
+  }
+
+  return 0
+}
+
 export default function MultiStepApplicationForm({
   steps,
   hiddenFields = {},
@@ -32,6 +54,11 @@ export default function MultiStepApplicationForm({
   const [failureReason, setFailureReason] = useState<string>()
   const formRef = useRef<HTMLFormElement>(null)
   const router = useRouter()
+
+  useEffect(() => {
+    if (!router.isReady) return
+    setCurrentStep(resolveStepIndex(steps, router.query.step))
+  }, [router.isReady, router.query.step, steps])
 
   const {
     watch,

--- a/components/grant-application/MultiStepApplicationForm.tsx
+++ b/components/grant-application/MultiStepApplicationForm.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useRef, useState } from 'react'
+import { ReactNode, useRef, useState } from 'react'
 import { useRouter } from 'next/router'
 import { DefaultValues, useForm } from 'react-hook-form'
 import { fetchPostJSON } from '../../utils/api-helpers'
@@ -20,24 +20,6 @@ interface MultiStepApplicationFormProps {
   submitLabel: string
 }
 
-function resolveStepIndex(
-  steps: readonly StepConfig[],
-  stepParam: string | string[] | undefined
-): number {
-  const raw = Array.isArray(stepParam) ? stepParam[0] : stepParam
-  if (!raw) return 0
-
-  const byId = steps.findIndex((step) => step.id === raw)
-  if (byId >= 0) return byId
-
-  const asNumber = Number.parseInt(raw, 10)
-  if (!Number.isNaN(asNumber) && asNumber >= 0 && asNumber < steps.length) {
-    return asNumber
-  }
-
-  return 0
-}
-
 export default function MultiStepApplicationForm({
   steps,
   hiddenFields = {},
@@ -50,11 +32,6 @@ export default function MultiStepApplicationForm({
   const [failureReason, setFailureReason] = useState<string>()
   const formRef = useRef<HTMLFormElement>(null)
   const router = useRouter()
-
-  useEffect(() => {
-    if (!router.isReady) return
-    setCurrentStep(resolveStepIndex(steps, router.query.step))
-  }, [router.isReady, router.query.step, steps])
 
   const {
     watch,

--- a/components/grant-application/MultiStepApplicationForm.tsx
+++ b/components/grant-application/MultiStepApplicationForm.tsx
@@ -18,6 +18,8 @@ interface MultiStepApplicationFormProps {
   hiddenFields?: Record<string, string | boolean>
   defaultValues?: DefaultValues<FormValues>
   submitLabel: string
+  /** When set, submit stays disabled until every listed field is truthy. */
+  submitRequiresChecked?: readonly string[]
 }
 
 export default function MultiStepApplicationForm({
@@ -25,6 +27,7 @@ export default function MultiStepApplicationForm({
   hiddenFields = {},
   defaultValues,
   submitLabel,
+  submitRequiresChecked,
 }: MultiStepApplicationFormProps) {
   const [currentStep, setCurrentStep] = useState(0)
   const [loading, setLoading] = useState(false)
@@ -76,9 +79,11 @@ export default function MultiStepApplicationForm({
     }
   }
 
+  const submitDisabled = !!submitRequiresChecked?.some((name) => !watch(name))
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const onSubmit = async (data: any) => {
-    if (currentStep !== steps.length - 1 || loading) return
+    if (currentStep !== steps.length - 1 || loading || submitDisabled) return
 
     setLoading(true)
     const submissionData = { ...data, formLoadedAt }
@@ -142,6 +147,7 @@ export default function MultiStepApplicationForm({
         onSubmit={handleSubmit(onSubmit)}
         loading={loading}
         submitLabel={submitLabel}
+        submitDisabled={submitDisabled}
       />
 
       {!!failureReason && (

--- a/components/grant-application/MultiStepApplicationForm.tsx
+++ b/components/grant-application/MultiStepApplicationForm.tsx
@@ -31,11 +31,7 @@ function resolveStepIndex(
   if (byId >= 0) return byId
 
   const asNumber = Number.parseInt(raw, 10)
-  if (
-    !Number.isNaN(asNumber) &&
-    asNumber >= 0 &&
-    asNumber < steps.length
-  ) {
+  if (!Number.isNaN(asNumber) && asNumber >= 0 && asNumber < steps.length) {
     return asNumber
   }
 

--- a/components/grant-application/StepNavigation.tsx
+++ b/components/grant-application/StepNavigation.tsx
@@ -6,6 +6,7 @@ interface StepNavigationProps {
   onSubmit: () => void
   loading: boolean
   submitLabel: string
+  submitDisabled?: boolean
 }
 
 export default function StepNavigation({
@@ -16,8 +17,10 @@ export default function StepNavigation({
   onSubmit,
   loading,
   submitLabel,
+  submitDisabled = false,
 }: StepNavigationProps) {
   const isLast = currentStep === totalSteps - 1
+  const submitBlocked = loading || submitDisabled
 
   return (
     <div className="flex justify-between pt-4">
@@ -42,10 +45,12 @@ export default function StepNavigation({
         <button
           type="button"
           onClick={onSubmit}
-          disabled={loading}
+          disabled={submitBlocked}
           aria-busy={loading}
           className={`rounded-md bg-orange-500 px-6 py-2 text-sm font-semibold text-white ${
-            loading ? 'cursor-not-allowed opacity-50' : 'hover:bg-orange-600'
+            submitBlocked
+              ? 'cursor-not-allowed opacity-50'
+              : 'hover:bg-orange-600'
           }`}
         >
           {loading ? 'Submitting...' : submitLabel}

--- a/components/grant-application/redTerms.ts
+++ b/components/grant-application/redTerms.ts
@@ -1,0 +1,9 @@
+export const RED_TERMS_EFFECTIVE = '2026-08-05'
+
+export const RED_ACK_FIELDS = [
+  'red_ack_not_authorization',
+  'red_ack_sanctions',
+  'red_ack_llm_accounts',
+  'red_ack_accurate_responsible',
+  'red_ack_terms',
+] as const

--- a/components/grant-application/steps/ApplicantDetails.tsx
+++ b/components/grant-application/steps/ApplicantDetails.tsx
@@ -2,11 +2,16 @@ import * as EmailValidator from 'email-validator'
 import FieldError from '../FieldError'
 import { StepProps, inputClass, checkboxClass } from '../types'
 
+interface ApplicantDetailsProps extends StepProps {
+  showLeadFields?: boolean
+}
+
 export default function ApplicantDetails({
   register,
   watch,
   errors,
-}: StepProps) {
+  showLeadFields = true,
+}: ApplicantDetailsProps) {
   return (
     <>
       <h2>Applicant Details</h2>
@@ -70,29 +75,33 @@ export default function ApplicantDetails({
         <textarea className={inputClass} {...register('other_contact')} />
       </label>
 
-      <hr />
+      {showLeadFields && (
+        <>
+          <hr />
 
-      <label className="inline-flex items-center">
-        <input
-          type="checkbox"
-          className={checkboxClass}
-          {...register('are_you_lead')}
-        />
-        <span className="ml-2">
-          I am the lead developer or maintainer of this project
-        </span>
-      </label>
+          <label className="inline-flex items-center">
+            <input
+              type="checkbox"
+              className={checkboxClass}
+              {...register('are_you_lead')}
+            />
+            <span className="ml-2">
+              I am the lead developer or maintainer of this project
+            </span>
+          </label>
 
-      {!watch('are_you_lead') && (
-        <label className="block">
-          If someone else, please list the project&apos;s lead contributor or
-          maintainer{' '}
-          <input
-            type="text"
-            className={inputClass}
-            {...register('other_lead')}
-          />
-        </label>
+          {!watch('are_you_lead') && (
+            <label className="block">
+              If someone else, please list the project&apos;s lead contributor
+              or maintainer{' '}
+              <input
+                type="text"
+                className={inputClass}
+                {...register('other_lead')}
+              />
+            </label>
+          )}
+        </>
       )}
     </>
   )

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -66,7 +66,7 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
             {...register('responsible_disclosure', { required: true })}
           />
           <span>
-            I will practice responsible disclosure when reporting
+            I accept accountability for the responsible disclosure of identified
             vulnerabilities to maintainers
           </span>
         </label>

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -8,7 +8,11 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
   const isRed = watch('RED')
 
   const checkboxFields = isRed
-    ? (['red_security_research', 'responsible_disclosure'] as const)
+    ? ([
+        'red_security_research',
+        'responsible_disclosure',
+        'foss_outputs',
+      ] as const)
     : isLts
     ? ([
         'read_criteria',
@@ -55,6 +59,18 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
           <span>
             I will practice responsible disclosure when reporting vulnerabilities
             to maintainers
+          </span>
+        </label>
+
+        <label className="inline-flex items-start gap-2">
+          <input
+            type="checkbox"
+            className={`mt-1 ${checkboxClass}`}
+            {...register('foss_outputs', { required: true })}
+          />
+          <span>
+            Findings, tools, and other work product from this engagement will be
+            open-sourced either directly or through OpenSats
           </span>
         </label>
 

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -59,7 +59,7 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
           />
           <span>
             I have a demonstrable track record in this space (or a closely
-            related one) and understand these applications are highly selective
+            related one)
           </span>
         </label>
 

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -33,11 +33,7 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
     return (
       <>
         <h2>Before You Begin</h2>
-        <p>
-          This track is for security researchers red-teaming Bitcoin and related
-          free and open-source software. Applications are focused on supporting
-          that work, including reimbursement for LLM token spend.
-        </p>
+        <p>Confirm the following before continuing.</p>
 
         <label className="inline-flex items-start gap-2">
           <input

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -71,8 +71,7 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
           <span>
             I agree that publishable outputs from this engagement (findings,
             tools, and other work product) will be released under a free and
-            open-source license through OpenSats after any needed coordinated
-            disclosure
+            open-source license after any needed coordinated disclosure
           </span>
         </label>
 

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -5,7 +5,11 @@ import { StepProps, checkboxClass } from '../types'
 
 export default function Prerequisites({ register, watch, errors }: StepProps) {
   const isLts = watch('LTS')
-  const checkboxFields = isLts
+  const isRed = watch('RED')
+
+  const checkboxFields = isRed
+    ? (['red_security_research', 'responsible_disclosure'] as const)
+    : isLts
     ? ([
         'read_criteria',
         'read_faq',
@@ -19,6 +23,45 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
         'has_references',
         'free_open_source',
       ] as const)
+
+  if (isRed) {
+    return (
+      <>
+        <h2>Before You Begin</h2>
+        <p>
+          This track is for security researchers red-teaming Bitcoin and related
+          free and open-source software. Applications are focused on supporting
+          that work, including reimbursement for LLM token spend.
+        </p>
+
+        <label className="inline-flex items-start gap-2">
+          <input
+            type="checkbox"
+            className={`mt-1 ${checkboxClass}`}
+            {...register('red_security_research', { required: true })}
+          />
+          <span>
+            I am applying for security research / red teaming support, not a
+            general project grant
+          </span>
+        </label>
+
+        <label className="inline-flex items-start gap-2">
+          <input
+            type="checkbox"
+            className={`mt-1 ${checkboxClass}`}
+            {...register('responsible_disclosure', { required: true })}
+          />
+          <span>
+            I will practice responsible disclosure when reporting vulnerabilities
+            to maintainers
+          </span>
+        </label>
+
+        <CheckboxGroupError errors={errors} names={checkboxFields} />
+      </>
+    )
+  }
 
   return (
     <>

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -57,8 +57,8 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
             {...register('responsible_disclosure', { required: true })}
           />
           <span>
-            I will practice responsible disclosure when reporting vulnerabilities
-            to maintainers
+            I will practice responsible disclosure when reporting
+            vulnerabilities to maintainers
           </span>
         </label>
 

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -10,6 +10,7 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
   const checkboxFields = isRed
     ? ([
         'red_security_research',
+        'red_track_record',
         'responsible_disclosure',
         'foss_outputs',
       ] as const)
@@ -33,9 +34,10 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
       <>
         <h2>Before You Begin</h2>
         <p>
-          This track is for security researchers red-teaming Bitcoin and related
-          free and open-source software. Applications are focused on supporting
-          that work, including reimbursement for LLM token spend.
+          This track supports people already red-teaming Bitcoin and related
+          free and open-source software, including LLM token spend for that
+          work. It is not for generic audit harnesses or token reimbursement on
+          its own.
         </p>
 
         <label className="inline-flex items-start gap-2">
@@ -47,6 +49,18 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
           <span>
             I am applying for security research / red teaming support, not a
             general project grant
+          </span>
+        </label>
+
+        <label className="inline-flex items-start gap-2">
+          <input
+            type="checkbox"
+            className={`mt-1 ${checkboxClass}`}
+            {...register('red_track_record', { required: true })}
+          />
+          <span>
+            I have a demonstrable track record in this space (or a closely
+            related one) and understand these applications are highly selective
           </span>
         </label>
 

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -85,15 +85,6 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
         </label>
 
         <CheckboxGroupError errors={errors} names={checkboxFields} />
-
-        <div className="prose">
-          <small>
-            If approved, you will be asked to sign a written agreement covering
-            custody of work product, coordinated disclosure, and free and
-            open-source release of publishable outputs. More detailed terms may
-            follow.
-          </small>
-        </div>
       </>
     )
   }

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -76,6 +76,15 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
         </label>
 
         <CheckboxGroupError errors={errors} names={checkboxFields} />
+
+        <div className="prose">
+          <small>
+            If approved, you will be asked to sign a written agreement covering
+            custody of work product, coordinated disclosure, and free and
+            open-source release of publishable outputs. More detailed terms may
+            follow.
+          </small>
+        </div>
       </>
     )
   }

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -34,10 +34,9 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
       <>
         <h2>Before You Begin</h2>
         <p>
-          This track supports people already red-teaming Bitcoin and related
-          free and open-source software, including LLM token spend for that
-          work. It is not for generic audit harnesses or token reimbursement on
-          its own.
+          This track is for security researchers red-teaming Bitcoin and related
+          free and open-source software. Applications are focused on supporting
+          that work, including reimbursement for LLM token spend.
         </p>
 
         <label className="inline-flex items-start gap-2">

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -69,8 +69,10 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
             {...register('foss_outputs', { required: true })}
           />
           <span>
-            Findings, tools, and other work product from this engagement will be
-            open-sourced either directly or through OpenSats
+            I agree that publishable outputs from this engagement (findings,
+            tools, and other work product) will be released under a free and
+            open-source license through OpenSats after any needed coordinated
+            disclosure
           </span>
         </label>
 

--- a/components/grant-application/steps/RedLegalAcknowledgments.tsx
+++ b/components/grant-application/steps/RedLegalAcknowledgments.tsx
@@ -1,0 +1,87 @@
+import CustomLink from '@/components/Link'
+import CheckboxGroupError from '../CheckboxGroupError'
+import { RED_ACK_FIELDS } from '../redTerms'
+import { StepProps, checkboxClass } from '../types'
+
+export default function RedLegalAcknowledgments({
+  register,
+  errors,
+}: StepProps) {
+  return (
+    <>
+      <hr />
+      <h2>Acknowledgments</h2>
+      <p>All of the following are required before you can submit.</p>
+
+      <label className="inline-flex items-start gap-2">
+        <input
+          type="checkbox"
+          className={`mt-1 ${checkboxClass}`}
+          {...register('red_ack_not_authorization', { required: true })}
+        />
+        <span>
+          I understand that OpenSats funding is not authorization to access or
+          test any system, device, network, account, funds, or data, and that I
+          am responsible for obtaining any permission my work requires and for
+          ensuring that it is lawful.
+        </span>
+      </label>
+
+      <label className="inline-flex items-start gap-2">
+        <input
+          type="checkbox"
+          className={`mt-1 ${checkboxClass}`}
+          {...register('red_ack_sanctions', { required: true })}
+        />
+        <span>
+          I represent that neither my participation in this program nor any
+          payment to me is prohibited under applicable sanctions or
+          export-control law, and that I will provide compliance information
+          reasonably requested before payment.
+        </span>
+      </label>
+
+      <label className="inline-flex items-start gap-2">
+        <input
+          type="checkbox"
+          className={`mt-1 ${checkboxClass}`}
+          {...register('red_ack_llm_accounts', { required: true })}
+        />
+        <span>
+          Any LLM, compute, hosting, or similar services that OpenSats funds or
+          reimburses will be obtained through accounts I am authorized to use
+          and in compliance with the provider&apos;s terms.
+        </span>
+      </label>
+
+      <label className="inline-flex items-start gap-2">
+        <input
+          type="checkbox"
+          className={`mt-1 ${checkboxClass}`}
+          {...register('red_ack_accurate_responsible', { required: true })}
+        />
+        <span>
+          The information in this application is accurate to the best of my
+          knowledge. I will report vulnerabilities responsibly as described
+          above, and will not exploit, threaten to exploit, or improperly sell
+          or transfer nonpublic findings.
+        </span>
+      </label>
+
+      <label className="inline-flex items-start gap-2">
+        <input
+          type="checkbox"
+          className={`mt-1 ${checkboxClass}`}
+          {...register('red_ack_terms', { required: true })}
+        />
+        <span>
+          I have read and agree to the requirements above and to the OpenSats{' '}
+          <CustomLink href="/terms">Terms of Use</CustomLink> and{' '}
+          <CustomLink href="/privacy">Privacy Policy</CustomLink>.
+        </span>
+      </label>
+
+      <CheckboxGroupError errors={errors} names={RED_ACK_FIELDS} />
+    </>
+  )
+}

--- a/components/grant-application/steps/RedResearch.tsx
+++ b/components/grant-application/steps/RedResearch.tsx
@@ -32,20 +32,6 @@ export default function RedResearch({ register, errors }: StepProps) {
       </label>
 
       <label className="block">
-        Potential Impact *<br />
-        <small>
-          Why does this research matter for Bitcoin or related free and
-          open-source software?
-        </small>
-        <textarea
-          rows={5}
-          className={inputClass}
-          {...register('potential_impact', { required: true })}
-        />
-        <FieldError errors={errors} name="potential_impact" />
-      </label>
-
-      <label className="block">
         Disclosure Links
         <br />
         <small>

--- a/components/grant-application/steps/RedResearch.tsx
+++ b/components/grant-application/steps/RedResearch.tsx
@@ -32,11 +32,26 @@ export default function RedResearch({ register, errors }: StepProps) {
       </label>
 
       <label className="block">
+        Prior Work *<br />
+        <small>
+          Links or references that show a trail of trust or prior work in
+          Bitcoin security or a closely related space (disclosures, write-ups,
+          patches, public research, etc.).
+        </small>
+        <textarea
+          rows={5}
+          className={inputClass}
+          {...register('prior_work', { required: true })}
+        />
+        <FieldError errors={errors} name="prior_work" />
+      </label>
+
+      <label className="block">
         Disclosure Links
         <br />
         <small>
-          Optional links to advisories, write-ups, coordinated disclosures, or
-          related proof-of-work.
+          Optional links specific to this engagement: advisories, write-ups, or
+          coordinated disclosures in progress.
         </small>
         <textarea className={inputClass} {...register('disclosure_links')} />
       </label>

--- a/components/grant-application/steps/RedResearch.tsx
+++ b/components/grant-application/steps/RedResearch.tsx
@@ -1,0 +1,79 @@
+import FieldError from '../FieldError'
+import { StepProps, inputClass } from '../types'
+
+export default function RedResearch({ register, errors }: StepProps) {
+  return (
+    <>
+      <h2>Research</h2>
+
+      <label className="block">
+        Main Focus *
+        <br />
+        <small>Which area are you primarily researching?</small>
+        <select
+          className={inputClass}
+          {...register('main_focus', { required: true })}
+        >
+          <option value="">(Choose One)</option>
+          <option value="core">Bitcoin Core</option>
+          <option value="layer1">Layer1 / Bitcoin</option>
+          <option value="layer2">Layer2 / Lightning</option>
+          <option value="nostr">Nostr</option>
+          <option value="other">Other</option>
+        </select>
+        <FieldError errors={errors} name="main_focus" />
+      </label>
+
+      <label className="block">
+        Short Title *<br />
+        <small>
+          A brief label for this research (e.g. target software or focus area).
+        </small>
+        <input
+          type="text"
+          className={inputClass}
+          {...register('project_name', { required: true })}
+        />
+        <FieldError errors={errors} name="project_name" />
+      </label>
+
+      <label className="block">
+        What Are You Researching? *<br />
+        <small>
+          Describe the software you are red-teaming and what you are looking
+          for. Include findings so far if you have any.
+        </small>
+        <textarea
+          rows={5}
+          className={inputClass}
+          {...register('short_description', { required: true })}
+        />
+        <FieldError errors={errors} name="short_description" />
+      </label>
+
+      <label className="block">
+        Potential Impact *<br />
+        <small>
+          Why does this research matter for Bitcoin or related free and
+          open-source software?
+        </small>
+        <textarea
+          rows={5}
+          className={inputClass}
+          {...register('potential_impact', { required: true })}
+        />
+        <FieldError errors={errors} name="potential_impact" />
+      </label>
+
+      <label className="block">
+        Disclosure Links
+        <br />
+        <small>
+          Optional links to advisories, write-ups, coordinated disclosures, or
+          related proof-of-work.
+        </small>
+        <textarea className={inputClass} {...register('disclosure_links')} />
+      </label>
+    </>
+  )
+}

--- a/components/grant-application/steps/RedResearch.tsx
+++ b/components/grant-application/steps/RedResearch.tsx
@@ -7,24 +7,6 @@ export default function RedResearch({ register, errors }: StepProps) {
       <h2>Research</h2>
 
       <label className="block">
-        Main Focus *
-        <br />
-        <small>Which area are you primarily researching?</small>
-        <select
-          className={inputClass}
-          {...register('main_focus', { required: true })}
-        >
-          <option value="">(Choose One)</option>
-          <option value="core">Bitcoin Core</option>
-          <option value="layer1">Layer1 / Bitcoin</option>
-          <option value="layer2">Layer2 / Lightning</option>
-          <option value="nostr">Nostr</option>
-          <option value="other">Other</option>
-        </select>
-        <FieldError errors={errors} name="main_focus" />
-      </label>
-
-      <label className="block">
         Short Title *<br />
         <small>
           A brief label for this research (e.g. target software or focus area).

--- a/components/grant-application/steps/RedResearch.tsx
+++ b/components/grant-application/steps/RedResearch.tsx
@@ -35,8 +35,9 @@ export default function RedResearch({ register, errors }: StepProps) {
         Prior Work *<br />
         <small>
           Links or references that show a trail of trust or prior work in
-          Bitcoin security or a closely related space (disclosures, write-ups,
-          patches, public research, etc.).
+          Bitcoin security or a closely related space, plus any disclosures or
+          write-ups for this engagement (patches, public research, advisories,
+          etc.).
         </small>
         <textarea
           rows={5}
@@ -44,16 +45,6 @@ export default function RedResearch({ register, errors }: StepProps) {
           {...register('prior_work', { required: true })}
         />
         <FieldError errors={errors} name="prior_work" />
-      </label>
-
-      <label className="block">
-        Disclosure Links
-        <br />
-        <small>
-          Optional links specific to this engagement: advisories, write-ups, or
-          coordinated disclosures in progress.
-        </small>
-        <textarea className={inputClass} {...register('disclosure_links')} />
       </label>
     </>
   )

--- a/components/grant-application/steps/RedResearch.tsx
+++ b/components/grant-application/steps/RedResearch.tsx
@@ -20,8 +20,9 @@ export default function RedResearch({ register, errors }: StepProps) {
       <label className="block">
         What Are You Researching? *<br />
         <small>
-          Describe the software you are red-teaming and what you are looking
-          for. Include findings so far if you have any.
+          Describe the software you are red-teaming and the general scope of
+          what you propose to do. Do not include exploit code, reproduction
+          steps, or other nonpublic technical findings.
         </small>
         <textarea
           rows={5}

--- a/components/grant-application/steps/RedResearch.tsx
+++ b/components/grant-application/steps/RedResearch.tsx
@@ -7,7 +7,8 @@ export default function RedResearch({ register, errors }: StepProps) {
       <h2>Research</h2>
 
       <label className="block">
-        Short Title *
+        Short Title *<br />
+        <small>(e.g. target software or focus area)</small>
         <input
           type="text"
           className={inputClass}

--- a/components/grant-application/steps/RedResearch.tsx
+++ b/components/grant-application/steps/RedResearch.tsx
@@ -7,10 +7,7 @@ export default function RedResearch({ register, errors }: StepProps) {
       <h2>Research</h2>
 
       <label className="block">
-        Short Title *<br />
-        <small>
-          A brief label for this research (e.g. target software or focus area).
-        </small>
+        Short Title *
         <input
           type="text"
           className={inputClass}

--- a/components/grant-application/steps/TokenReimbursement.tsx
+++ b/components/grant-application/steps/TokenReimbursement.tsx
@@ -52,20 +52,6 @@ export default function TokenReimbursement({ register, errors }: StepProps) {
         </select>
         <FieldError errors={errors} name="duration" />
       </label>
-
-      <label className="block">
-        Requested Reimbursement (USD) *<br />
-        <small>
-          How much are you asking OpenSats to reimburse? Include a short
-          breakdown if useful.
-        </small>
-        <textarea
-          rows={4}
-          className={inputClass}
-          {...register('proposed_budget', { required: true })}
-        />
-        <FieldError errors={errors} name="proposed_budget" />
-      </label>
     </>
   )
 }

--- a/components/grant-application/steps/TokenReimbursement.tsx
+++ b/components/grant-application/steps/TokenReimbursement.tsx
@@ -27,7 +27,7 @@ export default function TokenReimbursement({ register, errors }: StepProps) {
       <label className="block">
         Expected Ongoing Burn *<br />
         <small>
-          Rough estimate of monthly or ongoing token spend while this research
+          Rough estimate of monthly or ongoing spend while this research
           continues.
         </small>
         <textarea

--- a/components/grant-application/steps/TokenReimbursement.tsx
+++ b/components/grant-application/steps/TokenReimbursement.tsx
@@ -14,8 +14,8 @@ export default function TokenReimbursement({ register, errors }: StepProps) {
         Token Spend So Far
         <br />
         <small>
-          Approximate usage to date (tokens, USD, or both). Include the tools or
-          providers if helpful.
+          Prefer USD; include approximate token spend too if you can. Mention
+          tools or providers if helpful.
         </small>
         <textarea
           rows={4}

--- a/components/grant-application/steps/TokenReimbursement.tsx
+++ b/components/grant-application/steps/TokenReimbursement.tsx
@@ -4,7 +4,7 @@ import { StepProps, inputClass } from '../types'
 export default function TokenReimbursement({ register, errors }: StepProps) {
   return (
     <>
-      <h2>Token Reimbursement</h2>
+      <h2>Budget</h2>
       <p>
         Security research often burns a lot of LLM tokens. Tell us what you have
         spent and what you need reimbursed.

--- a/components/grant-application/steps/TokenReimbursement.tsx
+++ b/components/grant-application/steps/TokenReimbursement.tsx
@@ -11,7 +11,8 @@ export default function TokenReimbursement({ register, errors }: StepProps) {
       </p>
 
       <label className="block">
-        Token Spend So Far *<br />
+        Token Spend So Far
+        <br />
         <small>
           Approximate usage to date (tokens, USD, or both). Include the tools or
           providers if helpful.
@@ -19,9 +20,8 @@ export default function TokenReimbursement({ register, errors }: StepProps) {
         <textarea
           rows={4}
           className={inputClass}
-          {...register('token_spend_so_far', { required: true })}
+          {...register('token_spend_so_far')}
         />
-        <FieldError errors={errors} name="token_spend_so_far" />
       </label>
 
       <label className="block">

--- a/components/grant-application/steps/TokenReimbursement.tsx
+++ b/components/grant-application/steps/TokenReimbursement.tsx
@@ -5,10 +5,6 @@ export default function TokenReimbursement({ register, errors }: StepProps) {
   return (
     <>
       <h2>Budget</h2>
-      <p>
-        Security research burns a lot of LLM tokens these days. Tell us what you
-        have spent and what you expect to spend.
-      </p>
 
       <label className="block">
         Token Spend So Far *

--- a/components/grant-application/steps/TokenReimbursement.tsx
+++ b/components/grant-application/steps/TokenReimbursement.tsx
@@ -1,0 +1,56 @@
+import FieldError from '../FieldError'
+import { StepProps, inputClass } from '../types'
+
+export default function TokenReimbursement({ register, errors }: StepProps) {
+  return (
+    <>
+      <h2>Token Reimbursement</h2>
+      <p>
+        Security research often burns a lot of LLM tokens. Tell us what you have
+        spent and what you need reimbursed.
+      </p>
+
+      <label className="block">
+        Token Spend So Far *<br />
+        <small>
+          Approximate usage to date (tokens, USD, or both). Include the tools or
+          providers if helpful.
+        </small>
+        <textarea
+          rows={4}
+          className={inputClass}
+          {...register('token_spend_so_far', { required: true })}
+        />
+        <FieldError errors={errors} name="token_spend_so_far" />
+      </label>
+
+      <label className="block">
+        Expected Ongoing Burn *<br />
+        <small>
+          Rough estimate of monthly or ongoing token spend while this research
+          continues.
+        </small>
+        <textarea
+          rows={4}
+          className={inputClass}
+          {...register('estimated_token_burn', { required: true })}
+        />
+        <FieldError errors={errors} name="estimated_token_burn" />
+      </label>
+
+      <label className="block">
+        Requested Reimbursement (USD) *<br />
+        <small>
+          How much are you asking OpenSats to reimburse? Include a short
+          breakdown if useful.
+        </small>
+        <textarea
+          rows={4}
+          className={inputClass}
+          {...register('proposed_budget', { required: true })}
+        />
+        <FieldError errors={errors} name="proposed_budget" />
+      </label>
+    </>
+  )
+}

--- a/components/grant-application/steps/TokenReimbursement.tsx
+++ b/components/grant-application/steps/TokenReimbursement.tsx
@@ -6,8 +6,8 @@ export default function TokenReimbursement({ register, errors }: StepProps) {
     <>
       <h2>Budget</h2>
       <p>
-        Security research often burns a lot of LLM tokens. Tell us what you have
-        spent and what you need reimbursed.
+        Security research burns a lot of LLM tokens these days. Tell us what you
+        have spent and what you need reimbursed.
       </p>
 
       <label className="block">

--- a/components/grant-application/steps/TokenReimbursement.tsx
+++ b/components/grant-application/steps/TokenReimbursement.tsx
@@ -11,6 +11,21 @@ export default function TokenReimbursement({ register, errors }: StepProps) {
       </p>
 
       <label className="block">
+        Duration *
+        <br />
+        <small>How long do you need support for?</small>
+        <select
+          className={inputClass}
+          {...register('duration', { required: true })}
+        >
+          <option value="1 month">1 month</option>
+          <option value="3 months">3 months</option>
+          <option value="6 months">6 months</option>
+        </select>
+        <FieldError errors={errors} name="duration" />
+      </label>
+
+      <label className="block">
         Token Spend So Far
         <br />
         <small>

--- a/components/grant-application/steps/TokenReimbursement.tsx
+++ b/components/grant-application/steps/TokenReimbursement.tsx
@@ -11,21 +11,6 @@ export default function TokenReimbursement({ register, errors }: StepProps) {
       </p>
 
       <label className="block">
-        Duration *
-        <br />
-        <small>How long do you need support for?</small>
-        <select
-          className={inputClass}
-          {...register('duration', { required: true })}
-        >
-          <option value="1 month">1 month</option>
-          <option value="3 months">3 months</option>
-          <option value="6 months">6 months</option>
-        </select>
-        <FieldError errors={errors} name="duration" />
-      </label>
-
-      <label className="block">
         Token Spend So Far
         <br />
         <small>
@@ -51,6 +36,21 @@ export default function TokenReimbursement({ register, errors }: StepProps) {
           {...register('estimated_token_burn', { required: true })}
         />
         <FieldError errors={errors} name="estimated_token_burn" />
+      </label>
+
+      <label className="block">
+        Duration *
+        <br />
+        <small>How long do you need support for?</small>
+        <select
+          className={inputClass}
+          {...register('duration', { required: true })}
+        >
+          <option value="1 month">1 month</option>
+          <option value="3 months">3 months</option>
+          <option value="6 months">6 months</option>
+        </select>
+        <FieldError errors={errors} name="duration" />
       </label>
 
       <label className="block">

--- a/components/grant-application/steps/TokenReimbursement.tsx
+++ b/components/grant-application/steps/TokenReimbursement.tsx
@@ -11,7 +11,7 @@ export default function TokenReimbursement({ register, errors }: StepProps) {
       </p>
 
       <label className="block">
-        Token Spend So Far
+        Token Spend So Far *
         <br />
         <small>
           Prefer USD; include approximate token spend too if you can. Mention
@@ -20,8 +20,9 @@ export default function TokenReimbursement({ register, errors }: StepProps) {
         <textarea
           rows={4}
           className={inputClass}
-          {...register('token_spend_so_far')}
+          {...register('token_spend_so_far', { required: true })}
         />
+        <FieldError errors={errors} name="token_spend_so_far" />
       </label>
 
       <label className="block">

--- a/components/grant-application/steps/TokenReimbursement.tsx
+++ b/components/grant-application/steps/TokenReimbursement.tsx
@@ -7,7 +7,7 @@ export default function TokenReimbursement({ register, errors }: StepProps) {
       <h2>Budget</h2>
       <p>
         Security research burns a lot of LLM tokens these days. Tell us what you
-        have spent and what you need reimbursed.
+        have spent and what you expect to spend.
       </p>
 
       <label className="block">

--- a/next.config.js
+++ b/next.config.js
@@ -160,6 +160,11 @@ module.exports = () => {
           destination: 'https://heartbeat.opensats.org/',
           permanent: false,
         },
+        {
+          source: '/red',
+          destination: '/apply/red',
+          permanent: false,
+        },
       ]
     },
     webpack: (config, options) => {

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -60,6 +60,8 @@ ${req.body.disclosure_links}
 }
 ### Budget
 
+**Duration:** ${req.body.duration || 'n/a'}
+
 **Spend so far:**
 ${req.body.token_spend_so_far || 'n/a'}
 

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -24,7 +24,7 @@ export default async function handler(
     console.log(`REPO: ${GH_ORG}/${GH_APP_REPO}`)
 
     const byOrFor = req.body.LTS ? 'for' : 'by'
-    const issueTitle = `${req.body.project_name} ${byOrFor} ${req.body.your_name}`
+    const issueTitle = `${req.body.RED ? 'RED: ' : ''}${req.body.project_name} ${byOrFor} ${req.body.your_name}`
 
     const contactFooter = `
 ---

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -67,9 +67,6 @@ ${req.body.token_spend_so_far || 'n/a'}
 ${req.body.estimated_token_burn || 'n/a'}
 
 **Duration:** ${req.body.duration || 'n/a'}
-
-**Requested reimbursement:**
-${req.body.proposed_budget || 'n/a'}
 ${contactFooter}`
       : `
 ### Description

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -60,13 +60,13 @@ ${req.body.disclosure_links}
 }
 ### Budget
 
-**Duration:** ${req.body.duration || 'n/a'}
-
 **Spend so far:**
 ${req.body.token_spend_so_far || 'n/a'}
 
 **Expected ongoing burn:**
 ${req.body.estimated_token_burn || 'n/a'}
+
+**Duration:** ${req.body.duration || 'n/a'}
 
 **Requested reimbursement:**
 ${req.body.proposed_budget || 'n/a'}

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -26,9 +26,38 @@ export default async function handler(
     const byOrFor = req.body.LTS ? 'for' : 'by'
     const issueTitle = `${req.body.project_name} ${byOrFor} ${req.body.your_name}`
 
-    const tokenSection =
-      req.body.token_spend_so_far || req.body.estimated_token_burn
-        ? `
+    const contactFooter = `
+---
+
+${req.body.website ? `Website: ${req.body.website}` : ''}
+${req.body.license ? `License: ${req.body.license}` : ''}
+${req.body.github ? `GitHub: ${req.body.github}` : ''}
+${
+  req.body.personal_github ? `Personal GitHub: ${req.body.personal_github}` : ''
+}
+${
+  req.body.other_contact
+    ? `Other contact details: ${req.body.other_contact}`
+    : ''
+}
+${req.body.other_lead ? `Project lead: ${req.body.other_lead}` : ''}
+`
+
+    // Condensed information for screening purposes, no PII
+    const issueBody = req.body.RED
+      ? `
+### Research
+
+${req.body.short_description}
+
+${
+  req.body.disclosure_links
+    ? `### Disclosure Links
+
+${req.body.disclosure_links}
+`
+    : ''
+}
 ### Budget
 
 **Spend so far:**
@@ -36,19 +65,11 @@ ${req.body.token_spend_so_far || 'n/a'}
 
 **Expected ongoing burn:**
 ${req.body.estimated_token_burn || 'n/a'}
-`
-        : ''
 
-    const disclosureSection = req.body.disclosure_links
-      ? `
-### Disclosure Links
-
-${req.body.disclosure_links}
-`
-      : ''
-
-    // Condensed information for screening purposes, no PII
-    const issueBody = `
+**Requested reimbursement:**
+${req.body.proposed_budget || 'n/a'}
+${contactFooter}`
+      : `
 ### Description
 
 ${req.body.short_description}
@@ -56,7 +77,7 @@ ${req.body.short_description}
 ### Potential Impact
 
 ${req.body.potential_impact}
-${disclosureSection}${tokenSection}
+
 ### Other Organizations Applied To
 
 ${
@@ -81,8 +102,8 @@ ${req.body.proposed_budget}
 ${req.body.what_funding ? req.body.what_funding : ''}
 
 **Additional funding sources:** ${
-      req.body.has_additional_funding === 'yes' ? 'Yes' : 'No'
-    }
+          req.body.has_additional_funding === 'yes' ? 'Yes' : 'No'
+        }
 
 ${req.body.additional_funding ? req.body.additional_funding : ''}
 
@@ -106,22 +127,7 @@ ${req.body.video_application ? req.body.video_application : 'None provided.'}
 ### Anything Else
 
 ${req.body.anything_else ? req.body.anything_else : 'No.'}
-
----
-
-${req.body.website ? `Website: ${req.body.website}` : ''}
-${req.body.license ? `License: ${req.body.license}` : ''}
-${req.body.github ? `GitHub: ${req.body.github}` : ''}
-${
-  req.body.personal_github ? `Personal GitHub: ${req.body.personal_github}` : ''
-}
-${
-  req.body.other_contact
-    ? `Other contact details: ${req.body.other_contact}`
-    : ''
-}
-${req.body.other_lead ? `Project lead: ${req.body.other_lead}` : ''}
-        `
+${contactFooter}`
 
     // Label set according to "main focus" (absent for RED applications)
     const mainFocus = req.body.main_focus

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -26,6 +26,27 @@ export default async function handler(
     const byOrFor = req.body.LTS ? 'for' : 'by'
     const issueTitle = `${req.body.project_name} ${byOrFor} ${req.body.your_name}`
 
+    const tokenSection =
+      req.body.token_spend_so_far || req.body.estimated_token_burn
+        ? `
+### Token Reimbursement
+
+**Spend so far:**
+${req.body.token_spend_so_far || 'n/a'}
+
+**Expected ongoing burn:**
+${req.body.estimated_token_burn || 'n/a'}
+`
+        : ''
+
+    const disclosureSection = req.body.disclosure_links
+      ? `
+### Disclosure Links
+
+${req.body.disclosure_links}
+`
+      : ''
+
     // Condensed information for screening purposes, no PII
     const issueBody = `
 ### Description
@@ -35,7 +56,7 @@ ${req.body.short_description}
 ### Potential Impact
 
 ${req.body.potential_impact}
-
+${disclosureSection}${tokenSection}
 ### Other Organizations Applied To
 
 ${
@@ -49,7 +70,7 @@ ${
 ${req.body.duration ? `Grant duration: ${req.body.duration}` : ''}
 ${req.body.commitment ? `Time commitment: ${req.body.commitment}` : ''}
 
-${req.body.timelines}
+${req.body.timelines || ''}
 
 ### Proposed Budget
 
@@ -67,7 +88,7 @@ ${req.body.additional_funding ? req.body.additional_funding : ''}
 
 ### References & Prior Contributions
 
-${req.body.references}
+${req.body.references || ''}
 
 ${req.body.bios ? req.body.bios : 'No prior contributions.'}
 
@@ -134,11 +155,14 @@ ${req.body.other_lead ? `Project lead: ${req.body.other_lead}` : ''}
 
     // Tag depending on request for grant and/or request for listing
     req.body.LTS && issueLabels.push('LTS')
+    req.body.RED && issueLabels.push('RED')
 
     // Additional tags based on yes/no answers
     req.body.has_received_funding === 'yes' && issueLabels.push('prior funding')
-    !req.body.free_open_source && issueLabels.push('not FLOSS')
-    !req.body.are_you_lead && issueLabels.push('surrogate')
+    if (!req.body.RED) {
+      !req.body.free_open_source && issueLabels.push('not FLOSS')
+      !req.body.are_you_lead && issueLabels.push('surrogate')
+    }
 
     try {
       await octokit.rest.issues.create({

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -56,14 +56,6 @@ ${req.body.short_description}
 
 ${req.body.prior_work || 'n/a'}
 
-${
-  req.body.disclosure_links
-    ? `### Disclosure Links
-
-${req.body.disclosure_links}
-`
-    : ''
-}
 ### Budget
 
 **Spend so far:**

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -155,7 +155,7 @@ ${req.body.other_lead ? `Project lead: ${req.body.other_lead}` : ''}
 
     // Tag depending on request for grant and/or request for listing
     req.body.LTS && issueLabels.push('LTS')
-    req.body.RED && issueLabels.push('red-team')
+    req.body.RED && issueLabels.push('RED')
 
     // Additional tags based on yes/no answers
     req.body.has_received_funding === 'yes' && issueLabels.push('prior funding')

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -52,6 +52,10 @@ ${req.body.other_lead ? `Project lead: ${req.body.other_lead}` : ''}
 
 ${req.body.short_description}
 
+### Prior Work
+
+${req.body.prior_work || 'n/a'}
+
 ${
   req.body.disclosure_links
     ? `### Disclosure Links

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -155,7 +155,7 @@ ${req.body.other_lead ? `Project lead: ${req.body.other_lead}` : ''}
 
     // Tag depending on request for grant and/or request for listing
     req.body.LTS && issueLabels.push('LTS')
-    req.body.RED && issueLabels.push('RED')
+    req.body.RED && issueLabels.push('red-team')
 
     // Additional tags based on yes/no answers
     req.body.has_received_funding === 'yes' && issueLabels.push('prior funding')

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -65,6 +65,20 @@ ${req.body.token_spend_so_far || 'n/a'}
 ${req.body.estimated_token_burn || 'n/a'}
 
 **Duration:** ${req.body.duration || 'n/a'}
+
+### Acknowledgments
+
+**Terms effective:** ${req.body.red_terms_effective || 'n/a'}
+
+- Not authorization: ${req.body.red_ack_not_authorization ? 'Yes' : 'No'}
+- Sanctions / export-control: ${req.body.red_ack_sanctions ? 'Yes' : 'No'}
+- Authorized LLM/compute accounts: ${
+          req.body.red_ack_llm_accounts ? 'Yes' : 'No'
+        }
+- Accurate info / responsible disclosure: ${
+          req.body.red_ack_accurate_responsible ? 'Yes' : 'No'
+        }
+- Terms & privacy: ${req.body.red_ack_terms ? 'Yes' : 'No'}
 ${contactFooter}`
       : `
 ### Description

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -123,9 +123,11 @@ ${
 ${req.body.other_lead ? `Project lead: ${req.body.other_lead}` : ''}
         `
 
-    // Label set according to "main focus"
-    const mainFocus = `${req.body.main_focus}`.toLowerCase()
-    const issueLabels = [mainFocus]
+    // Label set according to "main focus" (absent for RED applications)
+    const mainFocus = req.body.main_focus
+      ? `${req.body.main_focus}`.toLowerCase()
+      : ''
+    const issueLabels = mainFocus ? [mainFocus] : []
     if (mainFocus === 'layer1' || mainFocus === 'layer2') {
       issueLabels.push('bitcoin') // L1 & L2 = subset of Bitcoin
     }

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -24,7 +24,9 @@ export default async function handler(
     console.log(`REPO: ${GH_ORG}/${GH_APP_REPO}`)
 
     const byOrFor = req.body.LTS ? 'for' : 'by'
-    const issueTitle = `${req.body.RED ? 'RED: ' : ''}${req.body.project_name} ${byOrFor} ${req.body.your_name}`
+    const issueTitle = `${req.body.RED ? 'RED: ' : ''}${
+      req.body.project_name
+    } ${byOrFor} ${req.body.your_name}`
 
     const contactFooter = `
 ---

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -29,7 +29,7 @@ export default async function handler(
     const tokenSection =
       req.body.token_spend_so_far || req.body.estimated_token_burn
         ? `
-### Token Reimbursement
+### Budget
 
 **Spend so far:**
 ${req.body.token_spend_so_far || 'n/a'}

--- a/pages/api/sendgrid.ts
+++ b/pages/api/sendgrid.ts
@@ -268,7 +268,7 @@ export default async function handler(
 
     const thankYouMessage = req.body.RED
       ? `
-Thanks for your RED application. We've received it and are fast-tracking review. We'll follow up as soon as we can. Questions: applications@opensats.org
+Thanks for your RED application. We've received it and are fast-tracking review. We'll follow up as soon as we can. Questions: red@opensats.org
     `
       : `
 Thank you for applying to OpenSats! 

--- a/pages/api/sendgrid.ts
+++ b/pages/api/sendgrid.ts
@@ -266,7 +266,11 @@ export default async function handler(
       body += `<h3>${key}</h3><p>${value}</p>`
     }
 
-    const thankYouMessage = `
+    const thankYouMessage = req.body.RED
+      ? `
+Thanks for your RED application. We've received it and are fast-tracking review. We'll follow up as soon as we can. Questions: applications@opensats.org
+    `
+      : `
 Thank you for applying to OpenSats! 
 
 We have received your application and will evaluate it soon.
@@ -282,7 +286,9 @@ Thank you for your patience.
       const msg = {
         to: `${req.body.email}`, // Applicant
         from: FROM_ADDRESS, // Verified sender
-        subject: `Your Application to OpenSats`,
+        subject: req.body.RED
+          ? `Your OpenSats RED Application`
+          : `Your Application to OpenSats`,
         html: `${thankYouMessage}`,
         text: thankYouMessage,
       }

--- a/pages/api/sendgrid.ts
+++ b/pages/api/sendgrid.ts
@@ -298,7 +298,9 @@ Thank you for your patience.
           to: TO_ADDRESS, // OpenSats
           cc: CC_ADDRESS, // Processing & backup
           from: FROM_ADDRESS, // Verified sender
-          subject: `OpenSats Application for ${req.body.project_name}`,
+          subject: req.body.RED
+            ? `OpenSats RED: Application for ${req.body.project_name}`
+            : `OpenSats Application for ${req.body.project_name}`,
           html: `${body}`,
           text: body.replace(/<[^>]*>/g, ''), // Strip HTML for plain text version
         }

--- a/pages/apply/index.tsx
+++ b/pages/apply/index.tsx
@@ -120,10 +120,10 @@ export default function Apply({
           Red Teaming
         </h2>
         <p className="mb-8">
-          For people already finding issues in Bitcoin and related free and
-          open-source software. Highly selective; a demonstrable trail of prior
-          work is expected. Always open. In light of recent events, we are
-          fast-tracking these applications.
+          For security researchers red-teaming Bitcoin and related free and
+          open-source software. Short application focused on research context
+          and LLM token reimbursement. Always open. In light of recent events,
+          we are fast-tracking these applications.
         </p>
         <Link
           href="/apply/red"

--- a/pages/apply/index.tsx
+++ b/pages/apply/index.tsx
@@ -116,6 +116,20 @@ export default function Apply({
             </p>
           </>
         )}
+        <h2 className="mb-4 mt-12 text-xl font-bold leading-normal md:text-2xl">
+          Red Teaming
+        </h2>
+        <p className="mb-8">
+          For security researchers red-teaming Bitcoin and related free and
+          open-source software. Short application focused on research context
+          and LLM token reimbursement. Always open.
+        </p>
+        <Link
+          href="/apply/red"
+          className="rounded border border-orange-500 bg-transparent px-4 py-2 font-semibold text-orange-500 no-underline hover:text-black dark:hover:text-white"
+        >
+          Apply for Red Teaming Support
+        </Link>
       </PageSection>
     </>
   )

--- a/pages/apply/index.tsx
+++ b/pages/apply/index.tsx
@@ -122,7 +122,8 @@ export default function Apply({
         <p className="mb-8">
           For security researchers red-teaming Bitcoin and related free and
           open-source software. Short application focused on research context
-          and LLM token reimbursement. Always open.
+          and LLM token reimbursement. Always open. In light of recent events,
+          we are fast-tracking these applications.
         </p>
         <Link
           href="/apply/red"

--- a/pages/apply/index.tsx
+++ b/pages/apply/index.tsx
@@ -120,10 +120,10 @@ export default function Apply({
           Red Teaming
         </h2>
         <p className="mb-8">
-          For security researchers red-teaming Bitcoin and related free and
-          open-source software. Short application focused on research context
-          and LLM token reimbursement. Always open. In light of recent events,
-          we are fast-tracking these applications.
+          For people already finding issues in Bitcoin and related free and
+          open-source software. Highly selective; a demonstrable trail of prior
+          work is expected. Always open. In light of recent events, we are
+          fast-tracking these applications.
         </p>
         <Link
           href="/apply/red"

--- a/pages/apply/red.tsx
+++ b/pages/apply/red.tsx
@@ -26,8 +26,8 @@ export default function ApplyRed() {
           applications.
         </p>
         <p>
-          Tell us what you are researching and what token spend you need
-          reimbursed. If approved, we will follow up with any details needed for
+          Tell us what you are researching and your token spend so far and going
+          forward. If approved, we will follow up with any details needed for
           payouts. Prefer a full project grant instead? See{' '}
           <CustomLink href="/apply/grant">General Grant</CustomLink>.
         </p>

--- a/pages/apply/red.tsx
+++ b/pages/apply/red.tsx
@@ -1,0 +1,34 @@
+import dynamic from 'next/dynamic'
+import PageSection from '@/components/PageSection'
+import CustomLink from '@/components/Link'
+import { PageSEO } from '@/components/SEO'
+
+const RedApplicationForm = dynamic(
+  () => import('@/components/RedApplicationForm'),
+  { ssr: false }
+)
+
+export default function ApplyRed() {
+  return (
+    <>
+      <PageSEO
+        title="Apply for Red Teaming Support - OpenSats"
+        description="Apply for OpenSats red teaming support, including LLM token reimbursement for security research on Bitcoin software."
+      />
+      <PageSection title="Red Teaming" image="/static/images/avatar.png">
+        <p>
+          Finding exploits in Bitcoin and related free and open-source software
+          takes time, skill, and often a lot of LLM tokens. This short
+          application is for researchers doing that work.
+        </p>
+        <p>
+          Tell us what you are researching and what token spend you need
+          reimbursed. If approved, we will follow up with any details needed for
+          payouts. Prefer a full project grant instead? See{' '}
+          <CustomLink href="/apply/grant">General Grant</CustomLink>.
+        </p>
+        <RedApplicationForm />
+      </PageSection>
+    </>
+  )
+}

--- a/pages/apply/red.tsx
+++ b/pages/apply/red.tsx
@@ -22,6 +22,10 @@ export default function ApplyRed() {
           application is for researchers doing that work.
         </p>
         <p>
+          In light of recent events, we are fast-tracking these red team
+          applications.
+        </p>
+        <p>
           Tell us what you are researching and what token spend you need
           reimbursed. If approved, we will follow up with any details needed for
           payouts. Prefer a full project grant instead? See{' '}

--- a/pages/apply/red.tsx
+++ b/pages/apply/red.tsx
@@ -22,8 +22,9 @@ export default function ApplyRed() {
           harnesses or seeking token reimbursement alone.
         </p>
         <p>
-          We will be highly selective. A demonstrable trail of trust or prior
-          work in Bitcoin security (or a closely related space) is expected.
+          While there is urgency and we want to fund generously, we will be
+          forced to be selective. A demonstrable trail of trust or prior work in
+          Bitcoin security (or a closely related space) is expected.
         </p>
         <p>
           In light of recent events, we are fast-tracking these red team

--- a/pages/apply/red.tsx
+++ b/pages/apply/red.tsx
@@ -1,6 +1,7 @@
 import dynamic from 'next/dynamic'
 import PageSection from '@/components/PageSection'
 import CustomLink from '@/components/Link'
+import RedBeforeYouApply from '@/components/RedBeforeYouApply'
 import { PageSEO } from '@/components/SEO'
 
 const RedApplicationForm = dynamic(
@@ -32,6 +33,7 @@ export default function ApplyRed() {
           for payouts. Prefer a full project grant instead? See{' '}
           <CustomLink href="/apply/grant">General Grant</CustomLink>.
         </p>
+        <RedBeforeYouApply />
         <RedApplicationForm />
       </PageSection>
     </>

--- a/pages/apply/red.tsx
+++ b/pages/apply/red.tsx
@@ -17,18 +17,19 @@ export default function ApplyRed() {
       />
       <PageSection title="Red Teaming" image="/static/images/avatar.png">
         <p>
-          Finding exploits in Bitcoin and related free and open-source software
-          takes time, skill, and often a lot of LLM tokens. This short
-          application is for researchers doing that work.
+          This track is for people already finding issues in Bitcoin and related
+          free and open-source software, not for building generic LLM audit
+          harnesses or seeking token reimbursement alone.
+        </p>
+        <p>
+          We will be highly selective. A demonstrable trail of trust or prior
+          work in Bitcoin security (or a closely related space) is expected.
         </p>
         <p>
           In light of recent events, we are fast-tracking these red team
-          applications.
-        </p>
-        <p>
-          Tell us what you are researching and your token spend so far and going
-          forward. If approved, we will follow up with any details needed for
-          payouts. Prefer a full project grant instead? See{' '}
+          applications. Tell us what you are researching and your token spend so
+          far and going forward. If approved, we will follow up with any details
+          needed for payouts. Prefer a full project grant instead? See{' '}
           <CustomLink href="/apply/grant">General Grant</CustomLink>.
         </p>
         <RedApplicationForm />

--- a/pages/apply/red.tsx
+++ b/pages/apply/red.tsx
@@ -28,9 +28,8 @@ export default function ApplyRed() {
         </p>
         <p>
           In light of recent events, we are fast-tracking these red team
-          applications. Tell us what you are researching and your token spend so
-          far and going forward. If approved, we will follow up with any details
-          needed for payouts. Prefer a full project grant instead? See{' '}
+          applications. If approved, we will follow up with any details needed
+          for payouts. Prefer a full project grant instead? See{' '}
           <CustomLink href="/apply/grant">General Grant</CustomLink>.
         </p>
         <RedApplicationForm />

--- a/pages/apply/red.tsx
+++ b/pages/apply/red.tsx
@@ -17,9 +17,9 @@ export default function ApplyRed() {
       />
       <PageSection title="Red Teaming" image="/static/images/avatar.png">
         <p>
-          This track is for people already finding issues in Bitcoin and related
-          free and open-source software, not for building generic LLM audit
-          harnesses or seeking token reimbursement alone.
+          Finding exploits in Bitcoin and related free and open-source software
+          takes time, skill, and often a lot of LLM tokens. This short
+          application is for researchers doing that work.
         </p>
         <p>
           While there is urgency and we want to fund generously, we will be

--- a/scripts/generate-page-og.mjs
+++ b/scripts/generate-page-og.mjs
@@ -180,8 +180,16 @@ function renderTransparencySvg(stats) {
       const centerX = PADDING + colWidth * index + colWidth / 2
       const value = formatLifetimeStatDisplay(index, stat.value)
       return `
-        <text x="${centerX}" y="${numberY}" fill="${COLORS.accent}" font-size="56" font-weight="700" font-family="${INTER_FONT_FAMILY}" text-anchor="middle">${escapeXml(value)}</text>
-        <text x="${centerX}" y="${labelY}" fill="${COLORS.summary}" font-size="26" font-family="${INTER_FONT_FAMILY}" text-anchor="middle">${escapeXml(stat.label)}</text>
+        <text x="${centerX}" y="${numberY}" fill="${
+        COLORS.accent
+      }" font-size="56" font-weight="700" font-family="${INTER_FONT_FAMILY}" text-anchor="middle">${escapeXml(
+        value
+      )}</text>
+        <text x="${centerX}" y="${labelY}" fill="${
+        COLORS.summary
+      }" font-size="26" font-family="${INTER_FONT_FAMILY}" text-anchor="middle">${escapeXml(
+        stat.label
+      )}</text>
       `
     })
     .join('')
@@ -192,12 +200,20 @@ function renderTransparencySvg(stats) {
 
       <image href="${faviconDataUri}" x="${logoX}" y="${logoY}" width="${logoSize}" height="${logoSize}" />
 
-      <text x="${titleX}" y="${titleY}" fill="${COLORS.title}" font-size="56" font-weight="900" font-family="${INTER_FONT_FAMILY}" letter-spacing="-2">Transparency</text>
+      <text x="${titleX}" y="${titleY}" fill="${
+    COLORS.title
+  }" font-size="56" font-weight="900" font-family="${INTER_FONT_FAMILY}" letter-spacing="-2">Transparency</text>
 
       ${statColumns}
 
-      <rect x="${PADDING}" y="${separatorY}" width="${CONTENT_WIDTH}" height="1" fill="${COLORS.separator}" />
-      <text x="${PADDING}" y="${urlY}" fill="${COLORS.url}" font-size="22" font-family="${INTER_FONT_FAMILY}" letter-spacing="1">${escapeXml(pageUrl)}</text>
+      <rect x="${PADDING}" y="${separatorY}" width="${CONTENT_WIDTH}" height="1" fill="${
+    COLORS.separator
+  }" />
+      <text x="${PADDING}" y="${urlY}" fill="${
+    COLORS.url
+  }" font-size="22" font-family="${INTER_FONT_FAMILY}" letter-spacing="1">${escapeXml(
+    pageUrl
+  )}</text>
     </svg>
   `
 }
@@ -280,7 +296,11 @@ function advanceWidth(text, fontSize) {
 
 function tokenWidth(token, fontSize) {
   if (token.kind === 'highlight') {
-    return advanceWidth(token.text, fontSize) + HIGHLIGHT_PAD * 2 + AFTER_HIGHLIGHT_GAP
+    return (
+      advanceWidth(token.text, fontSize) +
+      HIGHLIGHT_PAD * 2 +
+      AFTER_HIGHLIGHT_GAP
+    )
   }
   if (token.atomic) {
     return measureTextWidthWithResvg(token.text, fontSize)
@@ -309,21 +329,13 @@ function layoutHighlightedSentence(segments, options) {
     const width = tokenWidth(token, fontSize)
     const isSpace = token.kind === 'plain' && /^\s+$/.test(token.text)
 
-    if (
-      currentLine.length &&
-      !isSpace &&
-      currentWidth + width > maxWidth
-    ) {
+    if (currentLine.length && !isSpace && currentWidth + width > maxWidth) {
       lines.push(currentLine)
       currentLine = []
       currentWidth = 0
     }
 
-    if (
-      token.atomic &&
-      currentWidth + width > maxWidth &&
-      currentLine.length
-    ) {
+    if (token.atomic && currentWidth + width > maxWidth && currentLine.length) {
       lines.push(currentLine)
       currentLine = []
       currentWidth = 0
@@ -436,7 +448,9 @@ function renderMapSvg(mapDataUri, stats) {
 
   return `
     <svg width="${OG_WIDTH}" height="${OG_HEIGHT}" viewBox="0 0 ${OG_WIDTH} ${OG_HEIGHT}" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect width="${OG_WIDTH}" height="${OG_HEIGHT}" fill="${COLORS.background}" />
+      <rect width="${OG_WIDTH}" height="${OG_HEIGHT}" fill="${
+    COLORS.background
+  }" />
       ${networkSvg}
 
       <image href="${faviconDataUri}" x="${logoX}" y="${logoY}" width="${logoSize}" height="${logoSize}" />
@@ -445,8 +459,14 @@ function renderMapSvg(mapDataUri, stats) {
 
       <image href="${mapDataUri}" x="${mapX}" y="${mapY}" width="${mapWidth}" height="${mapHeight}" />
 
-      <rect x="${PADDING}" y="${separatorY}" width="${CONTENT_WIDTH}" height="1" fill="${COLORS.separator}" />
-      <text x="${PADDING}" y="${urlY}" fill="${COLORS.url}" font-size="22" font-family="${INTER_FONT_FAMILY}" letter-spacing="1">${escapeXml(pageUrl)}</text>
+      <rect x="${PADDING}" y="${separatorY}" width="${CONTENT_WIDTH}" height="1" fill="${
+    COLORS.separator
+  }" />
+      <text x="${PADDING}" y="${urlY}" fill="${
+    COLORS.url
+  }" font-size="22" font-family="${INTER_FONT_FAMILY}" letter-spacing="1">${escapeXml(
+    pageUrl
+  )}</text>
     </svg>
   `
 }
@@ -497,7 +517,11 @@ async function main() {
   const skipped = pages.filter((page) => SKIP_SLUGS.has(page.slug)).length
 
   console.log(
-    `Generated ${written} page OG images (skipped ${skipped} utility page${skipped === 1 ? '' : 's'}, plus ${EXTRA_PAGES.length} TSX route${EXTRA_PAGES.length === 1 ? '' : 's'}).`
+    `Generated ${written} page OG images (skipped ${skipped} utility page${
+      skipped === 1 ? '' : 's'
+    }, plus ${EXTRA_PAGES.length} TSX route${
+      EXTRA_PAGES.length === 1 ? '' : 's'
+    }).`
   )
 }
 

--- a/scripts/lib/og-network.mjs
+++ b/scripts/lib/og-network.mjs
@@ -286,7 +286,9 @@ export function measureTextBBoxWithResvg(text, fontSize) {
 
   const svgHeight = Math.ceil(fontSize * 2)
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="${svgHeight}">
-    <text x="0" y="${fontSize}" font-size="${fontSize}" font-family="${INTER_FONT_FAMILY}">${escapeXml(text)}</text>
+    <text x="0" y="${fontSize}" font-size="${fontSize}" font-family="${INTER_FONT_FAMILY}">${escapeXml(
+    text
+  )}</text>
   </svg>`
   const resvg = new Resvg(svg, {
     font: {


### PR DESCRIPTION
Adds an always-open red teaming application at `/apply/red` (with `/red` redirect) for security researchers seeking LLM token support. Reuses the multi-step grant form shell with a slim flow: prerequisites, applicant, research, and budget (spend so far, ongoing burn, 1/3/6 month duration).

- Listed on `/apply` and noted as fast-tracked; interim legal stub under prerequisites pending counsel
- RED applicants get a fast-track receipt pointing questions to `red@opensats.org`

Build preview: 
- [/apply/red](https://os-website-git-red-team-opensats.vercel.app/apply/red)
- [/red](https://os-website-git-red-team-opensats.vercel.app/red)
