### PR TITLE
fix(blog): link red team support to /funds/red

### DIFF
--- a/data/blog/code-red-supporting-first-responders.mdx
+++ b/data/blog/code-red-supporting-first-responders.mdx
@@ -17,7 +17,7 @@ revealed. A lot of people have been working 24/7 in the last few days, doing
 everything in their power to reduce the damage that is being done.
 
 We see it as our duty to allocate sats where they're needed most. And right now,
-support for the red team is duly needed. If you are red teaming critical Bitcoin
+[support for the red team](/funds/red) is duly needed. If you are red teaming critical Bitcoin
 software today, [opensats.org/red](/red) is a priority path to funding, including
 reimbursement of past LLM token costs.
 


### PR DESCRIPTION
Links "support for the red team" in the Code RED announcement to the Red Team Fund page.

- points the phrase to `/funds/red` in `data/blog/code-red-supporting-first-responders.mdx`

Build preview: 
- [/blog/code-red-supporting-first-responders](https://os-website-git-red-followup-opensats.vercel.app/blog/code-red-supporting-first-responders)
