### PR TITLE
Show Red Team Fund card on the Code RED announcement

### DIFF
--- a/components/FundCard.tsx
+++ b/components/FundCard.tsx
@@ -168,7 +168,7 @@ export function FundCardEmbed({ slug }: FundCardEmbedProps) {
   if (!fund) return null
 
   return (
-    <div className="not-prose w-full">
+    <div className="not-prose mx-auto w-full max-w-[480px]">
       <FundCard
         fund={fund}
         blurb={FUND_CARD_BLURBS[slug]}

--- a/components/FundCard.tsx
+++ b/components/FundCard.tsx
@@ -1,0 +1,185 @@
+import { useState } from 'react'
+import Link from '@/components/Link'
+import Image from '@/components/Image'
+import { PageActionButton, PageActionLink } from '@/components/PageAction'
+import PaymentModal from '@/components/PaymentModal'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faBitcoin } from '@fortawesome/free-brands-svg-icons'
+import { faArrowRight, faRepeat } from '@fortawesome/free-solid-svg-icons'
+import { allFunds } from 'contentlayer/generated'
+import type { Fund } from 'contentlayer/generated'
+import { getFundDonationUrl } from '@/utils/funds'
+
+export type FundCardDesignation = 'nostr' | 'ops' | 'red'
+
+export type FundCardProps = {
+  fund: Fund
+  blurb?: string
+  designation?: FundCardDesignation
+  /**
+   * Secondary fund cards use compact square donate actions.
+   * The primary General Fund card on /funds uses text labels on desktop.
+   */
+  compactActions?: boolean
+  onDonate: () => void
+  className?: string
+}
+
+type FundActionRowProps = {
+  fund: Fund
+  designation?: FundCardDesignation
+  compactActions?: boolean
+  onDonate: () => void
+}
+
+export function FundActionRow({
+  fund,
+  designation,
+  compactActions = true,
+  onDonate,
+}: FundActionRowProps) {
+  const monthlyHref = getFundDonationUrl(designation ?? fund.slug)
+
+  return (
+    <div className="flex flex-wrap items-center justify-end gap-3 pt-6">
+      <PageActionButton
+        variant="outlineMuted"
+        onClick={onDonate}
+        layout={compactActions ? 'square' : 'mobileSquareDesktopText'}
+        aria-label={`Donate sats directly to ${fund.title}`}
+        title="Donate sats"
+      >
+        <FontAwesomeIcon
+          icon={faBitcoin}
+          className="h-6 w-6"
+          aria-hidden="true"
+        />
+        {!compactActions && (
+          <span className="hidden sm:inline">Donate sats directly</span>
+        )}
+      </PageActionButton>
+      <PageActionLink
+        variant="outlineMuted"
+        href={monthlyHref}
+        layout={compactActions ? 'square' : 'mobileSquareDesktopText'}
+        aria-label={`Donate monthly to ${fund.title}`}
+        title="Donate monthly"
+      >
+        <FontAwesomeIcon
+          icon={faRepeat}
+          className="h-4 w-4"
+          aria-hidden="true"
+        />
+        {!compactActions && (
+          <span className="hidden sm:inline">Donate monthly</span>
+        )}
+      </PageActionLink>
+      <PageActionLink
+        variant="outlineMuted"
+        href={`/funds/${fund.slug}`}
+        layout="mobileSquareDesktopText"
+        aria-label={`Learn more about ${fund.title}`}
+        title={`Learn more about ${fund.title}`}
+      >
+        <FontAwesomeIcon
+          icon={faArrowRight}
+          className="h-4 w-4 sm:hidden"
+          aria-hidden="true"
+        />
+        <span className="hidden sm:inline">Learn more</span>
+      </PageActionLink>
+    </div>
+  )
+}
+
+export function FundCard({
+  fund,
+  blurb,
+  designation,
+  compactActions = true,
+  onDonate,
+  className,
+}: FundCardProps) {
+  return (
+    <article
+      className={[
+        'flex flex-col gap-3 rounded-xl bg-stone-100 p-4 dark:bg-stone-900',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <div className="flex gap-4">
+        <Link
+          href={`/funds/${fund.slug}`}
+          aria-label={`View ${fund.title}`}
+          className="shrink-0 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-stone-900"
+        >
+          <Image
+            src={fund.coverImage}
+            alt={fund.title}
+            width={64}
+            height={64}
+            className="h-16 w-16 shrink-0 rounded-lg"
+          />
+        </Link>
+        <Link
+          href={`/funds/${fund.slug}`}
+          className="flex flex-1 flex-col gap-1 rounded-lg transition-colors duration-150 hover:text-primary-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:hover:text-primary-400 dark:focus-visible:ring-offset-stone-900"
+        >
+          <h3 className="text-lg font-bold text-gray-900 dark:text-gray-100">
+            {fund.title}
+          </h3>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {blurb ?? fund.summary}
+          </p>
+        </Link>
+      </div>
+      <div className="mt-auto">
+        <FundActionRow
+          fund={fund}
+          designation={designation}
+          compactActions={compactActions}
+          onDonate={onDonate}
+        />
+      </div>
+    </article>
+  )
+}
+
+export const FUND_CARD_BLURBS: Partial<Record<string, string>> = {
+  red: 'Funding for people red teaming critical Bitcoin software, including reimbursement of past LLM token costs.',
+  nostr:
+    'Pays grants to relay operators, client developers, library maintainers, designers, and protocol-level contributors working on nostr.',
+  ops: 'Contributions to the OpenSats Operations Budget are used to cover our operating expenses as we continue to facilitate frictionless, tax-deductible donations from the community to the Bitcoin & FOSS ecosystems at a pass-through rate of 100%.',
+}
+
+type FundCardEmbedProps = {
+  slug: FundCardDesignation
+}
+
+/**
+ * Self-contained fund card for MDX embeds (includes PaymentModal).
+ */
+export default function FundCardEmbed({ slug }: FundCardEmbedProps) {
+  const fund = allFunds.find((f) => f.slug === slug)
+  const [modalOpen, setModalOpen] = useState(false)
+
+  if (!fund) return null
+
+  return (
+    <div className="not-prose my-10 w-full max-w-md sm:max-w-lg">
+      <FundCard
+        fund={fund}
+        blurb={FUND_CARD_BLURBS[slug]}
+        designation={slug}
+        onDonate={() => setModalOpen(true)}
+      />
+      <PaymentModal
+        isOpen={modalOpen}
+        onRequestClose={() => setModalOpen(false)}
+        fund={fund}
+      />
+    </div>
+  )
+}

--- a/components/FundCard.tsx
+++ b/components/FundCard.tsx
@@ -159,16 +159,16 @@ type FundCardEmbedProps = {
 }
 
 /**
- * Self-contained fund card for MDX embeds (includes PaymentModal).
+ * Self-contained fund card for post footers and embeds (includes PaymentModal).
  */
-export default function FundCardEmbed({ slug }: FundCardEmbedProps) {
+export function FundCardEmbed({ slug }: FundCardEmbedProps) {
   const fund = allFunds.find((f) => f.slug === slug)
   const [modalOpen, setModalOpen] = useState(false)
 
   if (!fund) return null
 
   return (
-    <div className="not-prose my-10 w-full max-w-md sm:max-w-lg">
+    <div className="not-prose w-full max-w-md sm:max-w-lg">
       <FundCard
         fund={fund}
         blurb={FUND_CARD_BLURBS[slug]}

--- a/components/FundCard.tsx
+++ b/components/FundCard.tsx
@@ -168,7 +168,7 @@ export function FundCardEmbed({ slug }: FundCardEmbedProps) {
   if (!fund) return null
 
   return (
-    <div className="not-prose w-full max-w-md sm:max-w-lg">
+    <div className="not-prose w-full">
       <FundCard
         fund={fund}
         blurb={FUND_CARD_BLURBS[slug]}

--- a/components/MDXComponents.tsx
+++ b/components/MDXComponents.tsx
@@ -18,6 +18,7 @@ import DonateToRedFundButton from './DonateToRedFundButton'
 import DonateRecurringButton from './DonateRecurringButton'
 import DonateRecurringButtonV2 from './DonateRecurringButtonV2'
 import ApplyButton from './ApplyButton'
+import FundCard from './FundCard'
 import DesignTeam from './DesignTeam'
 import Credits from './Supporters'
 import YouTubeEmbed from './YouTubeEmbed'
@@ -52,6 +53,7 @@ export const MDXComponents: ComponentMap = {
   DonateRecurringButton,
   DonateRecurringButtonV2,
   ApplyButton,
+  FundCard,
   DesignTeam,
   YouTubeEmbed,
   Credits,

--- a/components/MDXComponents.tsx
+++ b/components/MDXComponents.tsx
@@ -18,7 +18,6 @@ import DonateToRedFundButton from './DonateToRedFundButton'
 import DonateRecurringButton from './DonateRecurringButton'
 import DonateRecurringButtonV2 from './DonateRecurringButtonV2'
 import ApplyButton from './ApplyButton'
-import FundCard from './FundCard'
 import DesignTeam from './DesignTeam'
 import Credits from './Supporters'
 import YouTubeEmbed from './YouTubeEmbed'
@@ -53,7 +52,6 @@ export const MDXComponents: ComponentMap = {
   DonateRecurringButton,
   DonateRecurringButtonV2,
   ApplyButton,
-  FundCard,
   DesignTeam,
   YouTubeEmbed,
   Credits,

--- a/components/post/PostArticleBody.tsx
+++ b/components/post/PostArticleBody.tsx
@@ -10,9 +10,11 @@ import siteMetadata from '@/data/siteMetadata'
 import { discussUrl, editUrl } from '@/components/post/postShared'
 import SpotlightPullQuotes from '@/components/post/SpotlightPullQuotes'
 
-// Dynamic import avoids a circular dep with pliny's layout `require()` in MDXComponents.
-const FundCardEmbed = dynamic(() =>
-  import('@/components/FundCard').then((mod) => mod.FundCardEmbed)
+// Client-only to avoid hydration mismatch with next/dynamic, and to avoid a
+// circular dep with pliny's layout `require()` in MDXComponents.
+const FundCardEmbed = dynamic(
+  () => import('@/components/FundCard').then((mod) => mod.FundCardEmbed),
+  { ssr: false }
 )
 
 interface Props {

--- a/components/post/PostArticleBody.tsx
+++ b/components/post/PostArticleBody.tsx
@@ -1,4 +1,5 @@
 import { useState, ReactNode } from 'react'
+import dynamic from 'next/dynamic'
 import { Comments } from 'pliny/comments'
 import { CoreContent } from 'pliny/utils/contentlayer'
 import type { Blog, Authors } from 'contentlayer/generated'
@@ -8,6 +9,11 @@ import Tag from '@/components/Tag'
 import siteMetadata from '@/data/siteMetadata'
 import { discussUrl, editUrl } from '@/components/post/postShared'
 import SpotlightPullQuotes from '@/components/post/SpotlightPullQuotes'
+
+// Dynamic import avoids a circular dep with pliny's layout `require()` in MDXComponents.
+const FundCardEmbed = dynamic(() =>
+  import('@/components/FundCard').then((mod) => mod.FundCardEmbed)
+)
 
 interface Props {
   content: CoreContent<Blog>
@@ -62,7 +68,7 @@ export default function PostArticleBody({
   children,
   spotlight = false,
 }: Props) {
-  const { filePath, path, slug, tags, pullQuotes } = content
+  const { filePath, path, slug, tags, pullQuotes, fundCard } = content
   const basePath = path.split('/')[0]
   const [loadComments, setLoadComments] = useState(false)
   const classes = spotlight
@@ -175,6 +181,11 @@ export default function PostArticleBody({
         {` • `}
         <Link href={editUrl(filePath)}>View on GitHub</Link>
       </div>
+      {fundCard && (
+        <div className="pb-8">
+          <FundCardEmbed slug={fundCard} />
+        </div>
+      )}
       {siteMetadata.comments && (
         <div
           className="pb-6 pt-6 text-center text-gray-700 dark:text-gray-300"

--- a/components/post/PostArticleBody.tsx
+++ b/components/post/PostArticleBody.tsx
@@ -184,7 +184,7 @@ export default function PostArticleBody({
         <Link href={editUrl(filePath)}>View on GitHub</Link>
       </div>
       {fundCard && (
-        <div className="pb-8">
+        <div className="pb-8 pt-8">
           <FundCardEmbed slug={fundCard} />
         </div>
       )}

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -58,6 +58,14 @@ export const Blog = defineDocumentType(() => ({
     bibliography: { type: 'string' },
     canonicalUrl: { type: 'string' },
     pullQuotes: { type: 'list', of: { type: 'string' } },
+    /**
+     * Optional fund card shown below the post body (after discuss/GitHub links).
+     * Values match secondary fund designations on /funds.
+     */
+    fundCard: {
+      type: 'enum',
+      options: ['red', 'nostr', 'ops'],
+    },
   },
   computedFields,
 }))

--- a/data/blog/code-red-supporting-first-responders.mdx
+++ b/data/blog/code-red-supporting-first-responders.mdx
@@ -6,6 +6,7 @@ draft: false
 authors: ['dergigi', 'default']
 images: ['/static/images/blog/111-code-red.jpg']
 summary: 'OpenSats is launching a new grant track to support people red teaming Bitcoin software.'
+fundCard: red
 ---
 
 The [COLDCARD vulnerability] that is currently being exploited shows that
@@ -33,8 +34,6 @@ reimbursement of past LLM token costs.
 We will prioritize any red team applications for the foreseeable future.
 
 Thank you for your work and support.
-
-<FundCard slug="red" />
 
 [COLDCARD vulnerability]: https://www.nobsbitcoin.com/coldcard-disaster-weak-entropy-bug-enables-drain-of-funds-from-cold-storage-wallets/
 [red teaming]: https://en.wikipedia.org/wiki/Red_team

--- a/data/blog/code-red-supporting-first-responders.mdx
+++ b/data/blog/code-red-supporting-first-responders.mdx
@@ -34,5 +34,7 @@ We will prioritize any red team applications for the foreseeable future.
 
 Thank you for your work and support.
 
+<FundCard slug="red" />
+
 [COLDCARD vulnerability]: https://www.nobsbitcoin.com/coldcard-disaster-weak-entropy-bug-enables-drain-of-funds-from-cold-storage-wallets/
 [red teaming]: https://en.wikipedia.org/wiki/Red_team

--- a/pages/funds/index.tsx
+++ b/pages/funds/index.tsx
@@ -3,16 +3,13 @@ import { useState } from 'react'
 import Link from '@/components/Link'
 import Image from '@/components/Image'
 import { PageSEO } from '@/components/SEO'
-import { PageActionButton, PageActionLink } from '@/components/PageAction'
 import StatsSentence from '@/components/StatsSentence'
 import DonateRecurringButtonV2 from '@/components/DonateRecurringButtonV2'
 import PaymentModal from '@/components/PaymentModal'
+import { FundActionRow, FundCard, FUND_CARD_BLURBS } from '@/components/FundCard'
+import type { FundCardDesignation } from '@/components/FundCard'
 import { allFunds } from 'contentlayer/generated'
 import type { Fund } from 'contentlayer/generated'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faBitcoin } from '@fortawesome/free-brands-svg-icons'
-import { faArrowRight, faRepeat } from '@fortawesome/free-solid-svg-icons'
-import { getFundDonationUrl } from '@/utils/funds'
 import { getLifetimeStats, type LifetimeStat } from '@/utils/lifetimeStats'
 
 type FundsIndexProps = {
@@ -22,7 +19,7 @@ type FundsIndexProps = {
 
 type FundConfig = {
   slug: 'general' | 'nostr' | 'ops' | 'red'
-  designation?: 'nostr' | 'ops' | 'red'
+  designation?: FundCardDesignation
   variant?: 'orange' | 'purple' | 'red'
   preTagline: string
   tagline: string
@@ -60,8 +57,7 @@ const SECONDARY_FUND_CONFIGS: FundConfig[] = [
     variant: 'red',
     preTagline: 'Help us cover',
     tagline: 'ongoing LLM costs',
-    blurb:
-      'Funding for people red teaming critical Bitcoin software, including reimbursement of past LLM token costs.',
+    blurb: FUND_CARD_BLURBS.red,
   },
   {
     slug: 'nostr',
@@ -69,83 +65,16 @@ const SECONDARY_FUND_CONFIGS: FundConfig[] = [
     variant: 'purple',
     preTagline: 'Help us support',
     tagline: 'Nostr development',
-    blurb:
-      'Pays grants to relay operators, client developers, library maintainers, designers, and protocol-level contributors working on nostr.',
+    blurb: FUND_CARD_BLURBS.nostr,
   },
   {
     slug: 'ops',
     designation: 'ops',
     preTagline: 'Help us keep',
     tagline: 'OpenSats running',
-    blurb:
-      'Contributions to the OpenSats Operations Budget are used to cover our operating expenses as we continue to facilitate frictionless, tax-deductible donations from the community to the Bitcoin & FOSS ecosystems at a pass-through rate of 100%.',
+    blurb: FUND_CARD_BLURBS.ops,
   },
 ]
-
-type FundActionRowProps = {
-  fund: Fund
-  cfg: FundConfig
-  onDonate: () => void
-}
-
-function FundActionRow({ fund, cfg, onDonate }: FundActionRowProps) {
-  const useCompactDonateActions = cfg.slug !== 'general'
-
-  return (
-    <div className="flex flex-wrap items-center justify-end gap-3 pt-6">
-      <PageActionButton
-        variant="outlineMuted"
-        onClick={onDonate}
-        layout={useCompactDonateActions ? 'square' : 'mobileSquareDesktopText'}
-        aria-label={`Donate sats directly to ${fund.title}`}
-        title="Donate sats"
-      >
-        <FontAwesomeIcon
-          icon={faBitcoin}
-          className="h-6 w-6"
-          aria-hidden="true"
-        />
-        {!useCompactDonateActions && (
-          <span className="hidden sm:inline">Donate sats directly</span>
-        )}
-      </PageActionButton>
-      <PageActionLink
-        variant="outlineMuted"
-        href={getMonthlyDonationUrl(cfg)}
-        layout={useCompactDonateActions ? 'square' : 'mobileSquareDesktopText'}
-        aria-label={`Donate monthly to ${fund.title}`}
-        title="Donate monthly"
-      >
-        <FontAwesomeIcon
-          icon={faRepeat}
-          className="h-4 w-4"
-          aria-hidden="true"
-        />
-        {!useCompactDonateActions && (
-          <span className="hidden sm:inline">Donate monthly</span>
-        )}
-      </PageActionLink>
-      <PageActionLink
-        variant="outlineMuted"
-        href={`/funds/${fund.slug}`}
-        layout="mobileSquareDesktopText"
-        aria-label={`Learn more about ${fund.title}`}
-        title={`Learn more about ${fund.title}`}
-      >
-        <FontAwesomeIcon
-          icon={faArrowRight}
-          className="h-4 w-4 sm:hidden"
-          aria-hidden="true"
-        />
-        <span className="hidden sm:inline">Learn more</span>
-      </PageActionLink>
-    </div>
-  )
-}
-
-function getMonthlyDonationUrl(cfg: FundConfig): string {
-  return getFundDonationUrl(cfg.designation ?? cfg.slug)
-}
 
 const FundsIndex: NextPage<FundsIndexProps> = ({ funds, lifetimeStats }) => {
   const [modalFund, setModalFund] = useState<Fund | undefined>(undefined)
@@ -249,7 +178,7 @@ const FundsIndex: NextPage<FundsIndexProps> = ({ funds, lifetimeStats }) => {
             </div>
             <FundActionRow
               fund={primaryFund}
-              cfg={PRIMARY_FUND_CONFIG}
+              compactActions={false}
               onDonate={() => setModalFund(primaryFund)}
             />
           </div>
@@ -271,44 +200,13 @@ const FundsIndex: NextPage<FundsIndexProps> = ({ funds, lifetimeStats }) => {
           </p>
           <div className="grid grid-cols-1 gap-6 pt-6 sm:grid-cols-2 lg:grid-cols-3">
             {secondaryFunds.map(({ cfg, fund }) => (
-              <article
+              <FundCard
                 key={fund.slug}
-                className="flex flex-col gap-3 rounded-xl bg-stone-100 p-4 dark:bg-stone-900"
-              >
-                <div className="flex gap-4">
-                  <Link
-                    href={`/funds/${fund.slug}`}
-                    aria-label={`View ${fund.title}`}
-                    className="shrink-0 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-stone-900"
-                  >
-                    <Image
-                      src={fund.coverImage}
-                      alt={fund.title}
-                      width={64}
-                      height={64}
-                      className="h-16 w-16 shrink-0 rounded-lg"
-                    />
-                  </Link>
-                  <Link
-                    href={`/funds/${fund.slug}`}
-                    className="flex flex-1 flex-col gap-1 rounded-lg transition-colors duration-150 hover:text-primary-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:hover:text-primary-400 dark:focus-visible:ring-offset-stone-900"
-                  >
-                    <h3 className="text-lg font-bold text-gray-900 dark:text-gray-100">
-                      {fund.title}
-                    </h3>
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
-                      {cfg.blurb ?? fund.summary}
-                    </p>
-                  </Link>
-                </div>
-                <div className="mt-auto">
-                  <FundActionRow
-                    fund={fund}
-                    cfg={cfg}
-                    onDonate={() => setModalFund(fund)}
-                  />
-                </div>
-              </article>
+                fund={fund}
+                blurb={cfg.blurb}
+                designation={cfg.designation}
+                onDonate={() => setModalFund(fund)}
+              />
             ))}
           </div>
         </section>

--- a/pages/funds/index.tsx
+++ b/pages/funds/index.tsx
@@ -6,7 +6,11 @@ import { PageSEO } from '@/components/SEO'
 import StatsSentence from '@/components/StatsSentence'
 import DonateRecurringButtonV2 from '@/components/DonateRecurringButtonV2'
 import PaymentModal from '@/components/PaymentModal'
-import { FundActionRow, FundCard, FUND_CARD_BLURBS } from '@/components/FundCard'
+import {
+  FundActionRow,
+  FundCard,
+  FUND_CARD_BLURBS,
+} from '@/components/FundCard'
 import type { FundCardDesignation } from '@/components/FundCard'
 import { allFunds } from 'contentlayer/generated'
 import type { Fund } from 'contentlayer/generated'


### PR DESCRIPTION
Adds the Red Team Fund card to the bottom of the Code RED announcement, below the discuss/GitHub links, so readers can donate or learn more without leaving the post. Pulls the secondary fund card out of `/funds` into a reusable `FundCard` component and drives post placement with a `fundCard` frontmatter field.

- Reuses the same donate sats, monthly, and learn more actions as `/funds`
- Renders full width in the post column with spacing above the card
- Loads client-side to avoid a hydration mismatch with the MDX layout wrapper

Build preview: 
- [/blog/code-red-supporting-first-responders](https://os-website-git-show-red-team-fund-in-blog-opensats.vercel.app/blog/code-red-supporting-first-responders)
- [/funds](https://os-website-git-show-red-team-fund-in-blog-opensats.vercel.app/funds)
