### PR TITLE
Link urgency phrase on /apply/red to Code RED blog

### DIFF
--- a/pages/apply/red.tsx
+++ b/pages/apply/red.tsx
@@ -24,8 +24,9 @@ export default function ApplyRed() {
           application is for researchers doing that work.
         </p>
         <p>
+          While{' '}
           <CustomLink href="/blog/code-red-supporting-first-responders">
-            While there is urgency
+            there is urgency
           </CustomLink>{' '}
           and we want to fund generously, we will be forced to be selective. A
           demonstrable trail of trust or prior work in Bitcoin security (or a

--- a/pages/apply/red.tsx
+++ b/pages/apply/red.tsx
@@ -24,9 +24,12 @@ export default function ApplyRed() {
           application is for researchers doing that work.
         </p>
         <p>
-          While there is urgency and we want to fund generously, we will be
-          forced to be selective. A demonstrable trail of trust or prior work in
-          Bitcoin security (or a closely related space) is expected.
+          <CustomLink href="/blog/code-red-supporting-first-responders">
+            While there is urgency
+          </CustomLink>{' '}
+          and we want to fund generously, we will be forced to be selective. A
+          demonstrable trail of trust or prior work in Bitcoin security (or a
+          closely related space) is expected.
         </p>
         <p>
           In light of recent events, we are fast-tracking these red team


### PR DESCRIPTION
Links `there is urgency` on `/apply/red` to the Code RED blog post so applicants can read the announcement for context.

- wraps the phrase in `CustomLink` pointing at `/blog/code-red-supporting-first-responders`

Build preview: 
- [/apply/red](https://os-website-git-link-from-apply-to-blog-opensats.vercel.app/apply/red)
