### PR TITLE
Require GitHub confirmation before application submitted

### DIFF
--- a/components/grant-application/MultiStepApplicationForm.tsx
+++ b/components/grant-application/MultiStepApplicationForm.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useRef, useState } from 'react'
 import { useRouter } from 'next/router'
 import { DefaultValues, useForm } from 'react-hook-form'
-import { fetchPostJSON } from '../../utils/api-helpers'
+import { submitApplication } from '../../utils/application-submission'
 import StepIndicator from './StepIndicator'
 import StepNavigation from './StepNavigation'
 import { FormValues, StepProps } from './types'
@@ -85,33 +85,17 @@ export default function MultiStepApplicationForm({
     if (currentStep !== steps.length - 1 || loading || submitDisabled) return
 
     setLoading(true)
+    setFailureReason(undefined)
 
     try {
-      const res = await fetchPostJSON('/api/github', data)
-      if (res.message === 'success') {
-        console.info('Application tracked')
-      } else {
-        // Fail silently
-      }
+      await submitApplication(data)
+      router.push('/submitted')
     } catch (e) {
       if (e instanceof Error) {
-        // Fail silently
+        setFailureReason(e.message)
       }
     } finally {
-      try {
-        const res = await fetchPostJSON('/api/sendgrid', data)
-        if (res.message === 'success') {
-          router.push('/submitted')
-        } else {
-          setFailureReason(res.message)
-        }
-      } catch (e) {
-        if (e instanceof Error) {
-          setFailureReason(e.message)
-        }
-      } finally {
-        setLoading(false)
-      }
+      setLoading(false)
     }
   }
 

--- a/components/grant-application/MultiStepApplicationForm.tsx
+++ b/components/grant-application/MultiStepApplicationForm.tsx
@@ -95,7 +95,7 @@ export default function MultiStepApplicationForm({
 
     try {
       await submitApplication(data)
-      router.push('/submitted')
+      await router.push('/submitted')
     } catch (e) {
       const nextFailures = failedAttempts + 1
       setFailedAttempts(nextFailures)

--- a/components/grant-application/MultiStepApplicationForm.tsx
+++ b/components/grant-application/MultiStepApplicationForm.tsx
@@ -1,7 +1,12 @@
 import { ReactNode, useRef, useState } from 'react'
 import { useRouter } from 'next/router'
 import { DefaultValues, useForm } from 'react-hook-form'
-import { submitApplication } from '../../utils/application-submission'
+import {
+  SUBMISSION_CONTACT,
+  SUBMISSION_CONTACT_AFTER_FAILURES,
+  SUBMISSION_ERROR,
+  submitApplication,
+} from '../../utils/application-submission'
 import StepIndicator from './StepIndicator'
 import StepNavigation from './StepNavigation'
 import { FormValues, StepProps } from './types'
@@ -32,6 +37,7 @@ export default function MultiStepApplicationForm({
   const [currentStep, setCurrentStep] = useState(0)
   const [loading, setLoading] = useState(false)
   const [failureReason, setFailureReason] = useState<string>()
+  const [failedAttempts, setFailedAttempts] = useState(0)
   const formRef = useRef<HTMLFormElement>(null)
   const router = useRouter()
 
@@ -91,9 +97,14 @@ export default function MultiStepApplicationForm({
       await submitApplication(data)
       router.push('/submitted')
     } catch (e) {
-      if (e instanceof Error) {
-        setFailureReason(e.message)
-      }
+      const nextFailures = failedAttempts + 1
+      setFailedAttempts(nextFailures)
+      const baseMessage = e instanceof Error ? e.message : SUBMISSION_ERROR
+      setFailureReason(
+        nextFailures >= SUBMISSION_CONTACT_AFTER_FAILURES
+          ? `${baseMessage} ${SUBMISSION_CONTACT}`
+          : baseMessage
+      )
     } finally {
       setLoading(false)
     }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,12 @@
-module.exports = {
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({ dir: './' })
+
+module.exports = createJestConfig({
   testEnvironment: 'jest-environment-jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/.next/'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
   },
-}
+})

--- a/pages/api/sendgrid.ts
+++ b/pages/api/sendgrid.ts
@@ -245,6 +245,15 @@ export async function sendReportConfirmationEmail(
   return sendEmailWithRetry(msg)
 }
 
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;')
+}
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
@@ -258,11 +267,11 @@ export default async function handler(
     throw new Error('Env misconfigured')
   }
 
-  let body = ''
-
-  for (const [key, value] of Object.entries(req.body)) {
-    body += `<h3>${key}</h3><p>${value}</p>`
-  }
+  const body = Object.entries(req.body)
+    .map(
+      ([key, value]) => `<h3>${escapeHtml(key)}</h3><p>${escapeHtml(value)}</p>`
+    )
+    .join('')
 
   const thankYouMessage = req.body.RED
     ? `

--- a/pages/api/sendgrid.ts
+++ b/pages/api/sendgrid.ts
@@ -249,22 +249,26 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  if (req.method === 'POST') {
-    if (!SENDGRID_API_KEY || !TO_ADDRESS || !FROM_ADDRESS) {
-      throw new Error('Env misconfigured')
-    }
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    return res.status(405).end('Method Not Allowed')
+  }
 
-    let body = ''
+  if (!SENDGRID_API_KEY || !TO_ADDRESS || !FROM_ADDRESS) {
+    throw new Error('Env misconfigured')
+  }
 
-    for (const [key, value] of Object.entries(req.body)) {
-      body += `<h3>${key}</h3><p>${value}</p>`
-    }
+  let body = ''
 
-    const thankYouMessage = req.body.RED
-      ? `
+  for (const [key, value] of Object.entries(req.body)) {
+    body += `<h3>${key}</h3><p>${value}</p>`
+  }
+
+  const thankYouMessage = req.body.RED
+    ? `
 Thanks for your RED application. We've received it and are fast-tracking review. We'll follow up as soon as we can. Questions: red@opensats.org
     `
-      : `
+    : `
 Thank you for applying to OpenSats! 
 
 We have received your application and will evaluate it soon.
@@ -275,47 +279,48 @@ We will reach out again once we've made a decision.
 Thank you for your patience.
     `
 
-    try {
-      // Mail 'application received' to applicant
-      const msg = {
-        to: `${req.body.email}`, // Applicant
-        from: FROM_ADDRESS, // Verified sender
-        subject: req.body.RED
-          ? `Your OpenSats RED Application`
-          : `Your Application to OpenSats`,
-        html: `${thankYouMessage}`,
-        text: thankYouMessage,
-      }
-
-      await sendEmailWithRetry(msg)
-      console.info('Application receipt sent')
-    } catch (err) {
-      console.error(err)
-    } finally {
-      // Mail application content to us
-      try {
-        const msg = {
-          to: TO_ADDRESS, // OpenSats
-          cc: CC_ADDRESS, // Processing & backup
-          from: FROM_ADDRESS, // Verified sender
-          subject: req.body.RED
-            ? `OpenSats RED: Application for ${req.body.project_name}`
-            : `OpenSats Application for ${req.body.project_name}`,
-          html: `${body}`,
-          text: body.replace(/<[^>]*>/g, ''), // Strip HTML for plain text version
-        }
-
-        await sendEmailWithRetry(msg)
-        console.info('Application copy sent to OpenSats')
-        res.status(200).json({ message: 'success' })
-      } catch (err) {
-        res
-          .status(500)
-          .json({ statusCode: 500, message: (err as Error).message })
-      }
-    }
-  } else {
-    res.setHeader('Allow', 'POST')
-    res.status(405).end('Method Not Allowed')
+  const internalMessage = {
+    to: TO_ADDRESS,
+    cc: CC_ADDRESS,
+    from: FROM_ADDRESS,
+    subject: req.body.RED
+      ? `OpenSats RED: Application for ${req.body.project_name}`
+      : `OpenSats Application for ${req.body.project_name}`,
+    html: `${body}`,
+    text: body.replace(/<[^>]*>/g, ''),
   }
+
+  const applicantMessage = {
+    to: `${req.body.email}`,
+    from: FROM_ADDRESS,
+    subject: req.body.RED
+      ? `Your OpenSats RED Application`
+      : `Your Application to OpenSats`,
+    html: `${thankYouMessage}`,
+    text: thankYouMessage,
+  }
+
+  const [internalSent, applicantSent] = await Promise.all([
+    sendEmailWithRetry(internalMessage),
+    sendEmailWithRetry(applicantMessage),
+  ])
+
+  if (!internalSent) {
+    console.error('Application copy was not accepted by SendGrid')
+    return res
+      .status(502)
+      .json({ message: 'Application email delivery failed' })
+  }
+
+  if (!applicantSent) {
+    console.warn('Application stored, but applicant confirmation was not sent')
+  } else {
+    console.info('Application receipt sent')
+  }
+
+  console.info('Application copy sent to OpenSats')
+  return res.status(200).json({
+    message: 'success',
+    applicantConfirmationSent: applicantSent,
+  })
 }

--- a/tests/api/sendgrid.test.js
+++ b/tests/api/sendgrid.test.js
@@ -1,0 +1,140 @@
+/** @jest-environment node */
+/* eslint-env jest, node */
+
+process.env.SENDGRID_API_KEY = 'test-key'
+process.env.SENDGRID_RECIPIENT = 'applications@opensats.test'
+process.env.SENDGRID_CC = 'backup@opensats.test'
+process.env.SENDGRID_VERIFIED_SENDER = 'sender@opensats.test'
+
+jest.mock('@sendgrid/mail', () => ({
+  __esModule: true,
+  default: {
+    setApiKey: jest.fn(),
+    send: jest.fn(),
+  },
+}))
+
+const sgMail = require('@sendgrid/mail').default
+const handler = require('../../pages/api/sendgrid.ts').default
+
+function responseMock() {
+  return {
+    statusCode: undefined,
+    payload: undefined,
+    headers: {},
+    status(code) {
+      this.statusCode = code
+      return this
+    },
+    json(payload) {
+      this.payload = payload
+      return this
+    },
+    setHeader(name, value) {
+      this.headers[name] = value
+    },
+    end(payload) {
+      this.payload = payload
+      return this
+    },
+  }
+}
+
+const validApplication = {
+  project_name: 'Test project',
+  email: 'applicant@example.org',
+  short_description: 'Description',
+}
+
+describe('/api/sendgrid', () => {
+  beforeEach(() => {
+    sgMail.send.mockReset()
+    jest.spyOn(console, 'log').mockImplementation(() => undefined)
+    jest.spyOn(console, 'info').mockImplementation(() => undefined)
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+    jest.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  it('confirms success only after the internal copy is accepted', async () => {
+    sgMail.send.mockResolvedValue([{}])
+    const response = responseMock()
+
+    await handler({ method: 'POST', body: validApplication }, response)
+
+    expect(response.statusCode).toBe(200)
+    expect(response.payload).toEqual({
+      message: 'success',
+      applicantConfirmationSent: true,
+    })
+    expect(sgMail.send).toHaveBeenCalledTimes(2)
+    expect(sgMail.send.mock.calls[0][0].to).toBe('applications@opensats.test')
+  })
+
+  it('returns a failure when SendGrid does not accept the internal copy', async () => {
+    jest.useFakeTimers()
+    sgMail.send.mockImplementation((message) => {
+      if (message.to === 'applications@opensats.test') {
+        return Promise.reject(new Error('SendGrid unavailable'))
+      }
+      return Promise.resolve([{}])
+    })
+    const response = responseMock()
+
+    const request = handler(
+      { method: 'POST', body: validApplication },
+      response
+    )
+    await jest.runAllTimersAsync()
+    await request
+
+    expect(response.statusCode).toBe(502)
+    expect(response.payload.message).not.toBe('success')
+  })
+
+  it('still confirms internal receipt if the applicant email fails', async () => {
+    jest.useFakeTimers()
+    sgMail.send.mockImplementation((message) => {
+      if (message.to === 'applicant@example.org') {
+        return Promise.reject(new Error('Applicant address rejected'))
+      }
+      return Promise.resolve([{}])
+    })
+    const response = responseMock()
+
+    const request = handler(
+      { method: 'POST', body: validApplication },
+      response
+    )
+    await jest.runAllTimersAsync()
+    await request
+
+    expect(response.statusCode).toBe(200)
+    expect(response.payload).toEqual({
+      message: 'success',
+      applicantConfirmationSent: false,
+    })
+  })
+
+  it('preserves RED internal and applicant subjects', async () => {
+    sgMail.send.mockResolvedValue([{}])
+    const response = responseMock()
+
+    await handler(
+      { method: 'POST', body: { ...validApplication, RED: true } },
+      response
+    )
+
+    expect(response.statusCode).toBe(200)
+    expect(sgMail.send.mock.calls[0][0].subject).toBe(
+      'OpenSats RED: Application for Test project'
+    )
+    expect(sgMail.send.mock.calls[1][0].subject).toBe(
+      'Your OpenSats RED Application'
+    )
+  })
+})

--- a/tests/api/sendgrid.test.js
+++ b/tests/api/sendgrid.test.js
@@ -137,4 +137,29 @@ describe('/api/sendgrid', () => {
       'Your OpenSats RED Application'
     )
   })
+
+  it('escapes applicant-controlled fields in the internal HTML email', async () => {
+    sgMail.send.mockResolvedValue([{}])
+    const response = responseMock()
+
+    await handler(
+      {
+        method: 'POST',
+        body: {
+          ...validApplication,
+          short_description: '<script>alert(1)</script>',
+        },
+      },
+      response
+    )
+
+    expect(response.statusCode).toBe(200)
+    expect(sgMail.send.mock.calls[0][0].html).toContain(
+      '&lt;script&gt;alert(1)&lt;/script&gt;'
+    )
+    expect(sgMail.send.mock.calls[0][0].html).not.toContain(
+      '<script>alert(1)</script>'
+    )
+  })
 })
+

--- a/utils/application-submission.test.js
+++ b/utils/application-submission.test.js
@@ -37,7 +37,7 @@ describe('submitApplication', () => {
     })
 
     await expect(submitApplication(submission, postJSON)).rejects.toThrow(
-      'create your application record on GitHub'
+      'Please try again.'
     )
     expect(postJSON).toHaveBeenCalledTimes(1)
     expect(postJSON).toHaveBeenCalledWith('/api/github', submission)
@@ -54,4 +54,14 @@ describe('submitApplication', () => {
     )
     expect(postJSON).toHaveBeenCalledTimes(1)
   })
+
+  it('does not mention applications@ in the base error', async () => {
+    const postJSON = jest.fn().mockRejectedValue(new Error('Network error'))
+
+    await expect(submitApplication(submission, postJSON)).rejects.toThrow(
+      "We couldn't create your application record on GitHub. It has not been marked as submitted. Please try again."
+    )
+  })
 })
+
+

--- a/utils/application-submission.test.js
+++ b/utils/application-submission.test.js
@@ -1,0 +1,61 @@
+/** @jest-environment node */
+/* eslint-env jest, node */
+
+const { submitApplication } = require('./application-submission.ts')
+
+describe('submitApplication', () => {
+  const submission = { project_name: 'Test project' }
+
+  it('attempts both destinations and reports full delivery', async () => {
+    const postJSON = jest.fn().mockResolvedValue({ message: 'success' })
+
+    await expect(submitApplication(submission, postJSON)).resolves.toEqual({
+      github: true,
+      email: true,
+    })
+    expect(postJSON).toHaveBeenCalledTimes(2)
+    expect(postJSON).toHaveBeenCalledWith('/api/github', submission)
+    expect(postJSON).toHaveBeenCalledWith('/api/sendgrid', submission)
+  })
+
+  it('succeeds when GitHub fails but the internal email is confirmed', async () => {
+    const postJSON = jest.fn(async (url) => {
+      if (url === '/api/github') throw new Error('GitHub unavailable')
+      return { message: 'success' }
+    })
+
+    await expect(submitApplication(submission, postJSON)).resolves.toEqual({
+      github: false,
+      email: true,
+    })
+  })
+
+  it('succeeds when email fails but the GitHub record is confirmed', async () => {
+    const postJSON = jest.fn(async (url) => ({
+      message: url === '/api/github' ? 'success' : 'Email delivery failed',
+    }))
+
+    await expect(submitApplication(submission, postJSON)).resolves.toEqual({
+      github: true,
+      email: false,
+    })
+  })
+
+  it('does not report success when neither destination confirms storage', async () => {
+    const postJSON = jest
+      .fn()
+      .mockResolvedValue({ message: 'Delivery unavailable' })
+
+    await expect(submitApplication(submission, postJSON)).rejects.toThrow(
+      'It has not been marked as submitted'
+    )
+  })
+
+  it('does not report success when both requests fail at the transport layer', async () => {
+    const postJSON = jest.fn().mockRejectedValue(new Error('Network error'))
+
+    await expect(submitApplication(submission, postJSON)).rejects.toThrow(
+      'It has not been marked as submitted'
+    )
+  })
+})

--- a/utils/application-submission.test.js
+++ b/utils/application-submission.test.js
@@ -18,19 +18,7 @@ describe('submitApplication', () => {
     expect(postJSON).toHaveBeenCalledWith('/api/sendgrid', submission)
   })
 
-  it('succeeds when GitHub fails but the internal email is confirmed', async () => {
-    const postJSON = jest.fn(async (url) => {
-      if (url === '/api/github') throw new Error('GitHub unavailable')
-      return { message: 'success' }
-    })
-
-    await expect(submitApplication(submission, postJSON)).resolves.toEqual({
-      github: false,
-      email: true,
-    })
-  })
-
-  it('succeeds when email fails but the GitHub record is confirmed', async () => {
+  it('succeeds when GitHub is confirmed even if email fails', async () => {
     const postJSON = jest.fn(async (url) => ({
       message: url === '/api/github' ? 'success' : 'Email delivery failed',
     }))
@@ -41,17 +29,29 @@ describe('submitApplication', () => {
     })
   })
 
-  it('does not report success when neither destination confirms storage', async () => {
-    const postJSON = jest
-      .fn()
-      .mockResolvedValue({ message: 'Delivery unavailable' })
+  it('forces a retry when GitHub fails even if email succeeds', async () => {
+    const postJSON = jest.fn(async (url) => {
+      if (url === '/api/github') throw new Error('GitHub unavailable')
+      return { message: 'success' }
+    })
+
+    await expect(submitApplication(submission, postJSON)).rejects.toThrow(
+      'create your application record on GitHub'
+    )
+  })
+
+  it('forces a retry when GitHub returns a non-success response', async () => {
+    const postJSON = jest.fn(async (url) => ({
+      message:
+        url === '/api/github' ? 'Application storage failed' : 'success',
+    }))
 
     await expect(submitApplication(submission, postJSON)).rejects.toThrow(
       'It has not been marked as submitted'
     )
   })
 
-  it('does not report success when both requests fail at the transport layer', async () => {
+  it('forces a retry when both destinations fail', async () => {
     const postJSON = jest.fn().mockRejectedValue(new Error('Network error'))
 
     await expect(submitApplication(submission, postJSON)).rejects.toThrow(

--- a/utils/application-submission.test.js
+++ b/utils/application-submission.test.js
@@ -6,16 +6,17 @@ const { submitApplication } = require('./application-submission.ts')
 describe('submitApplication', () => {
   const submission = { project_name: 'Test project' }
 
-  it('attempts both destinations and reports full delivery', async () => {
+  it('creates the GitHub record before sending email', async () => {
     const postJSON = jest.fn().mockResolvedValue({ message: 'success' })
 
     await expect(submitApplication(submission, postJSON)).resolves.toEqual({
       github: true,
       email: true,
     })
-    expect(postJSON).toHaveBeenCalledTimes(2)
-    expect(postJSON).toHaveBeenCalledWith('/api/github', submission)
-    expect(postJSON).toHaveBeenCalledWith('/api/sendgrid', submission)
+    expect(postJSON.mock.calls.map((call) => call[0])).toEqual([
+      '/api/github',
+      '/api/sendgrid',
+    ])
   })
 
   it('succeeds when GitHub is confirmed even if email fails', async () => {
@@ -29,7 +30,7 @@ describe('submitApplication', () => {
     })
   })
 
-  it('forces a retry when GitHub fails even if email succeeds', async () => {
+  it('forces a retry when GitHub fails and does not email anyone', async () => {
     const postJSON = jest.fn(async (url) => {
       if (url === '/api/github') throw new Error('GitHub unavailable')
       return { message: 'success' }
@@ -38,6 +39,8 @@ describe('submitApplication', () => {
     await expect(submitApplication(submission, postJSON)).rejects.toThrow(
       'create your application record on GitHub'
     )
+    expect(postJSON).toHaveBeenCalledTimes(1)
+    expect(postJSON).toHaveBeenCalledWith('/api/github', submission)
   })
 
   it('forces a retry when GitHub returns a non-success response', async () => {
@@ -49,13 +52,6 @@ describe('submitApplication', () => {
     await expect(submitApplication(submission, postJSON)).rejects.toThrow(
       'It has not been marked as submitted'
     )
-  })
-
-  it('forces a retry when both destinations fail', async () => {
-    const postJSON = jest.fn().mockRejectedValue(new Error('Network error'))
-
-    await expect(submitApplication(submission, postJSON)).rejects.toThrow(
-      'It has not been marked as submitted'
-    )
+    expect(postJSON).toHaveBeenCalledTimes(1)
   })
 })

--- a/utils/application-submission.ts
+++ b/utils/application-submission.ts
@@ -21,26 +21,30 @@ export interface ApplicationDeliveryResult {
 const SUBMISSION_ERROR =
   "We couldn't create your application record on GitHub. It has not been marked as submitted. Please try again or contact applications@opensats.org."
 
+async function postSucceeded(
+  postJSON: PostJSON,
+  url: string,
+  data: ApplicationSubmissionData
+): Promise<boolean> {
+  try {
+    const response = await postJSON(url, data)
+    return response.message === 'success'
+  } catch {
+    return false
+  }
+}
+
 export async function submitApplication(
   data: ApplicationSubmissionData,
   postJSON: PostJSON = fetchPostJSON
 ): Promise<ApplicationDeliveryResult> {
-  const destinations = ['/api/github', '/api/sendgrid'] as const
-  const results = await Promise.allSettled(
-    destinations.map(async (destination) => {
-      const response = await postJSON(destination, data)
-      return response.message === 'success'
-    })
-  )
-
-  const [github, email] = results.map(
-    (result) => result.status === 'fulfilled' && result.value
-  )
-
-  // GitHub is the durable screening record. Email alone is not enough.
+  // GitHub first: only email after the issue exists, so retries do not
+  // re-send the applicant receipt or internal copy on a failed create.
+  const github = await postSucceeded(postJSON, '/api/github', data)
   if (!github) {
     throw new Error(SUBMISSION_ERROR)
   }
 
+  const email = await postSucceeded(postJSON, '/api/sendgrid', data)
   return { github, email }
 }

--- a/utils/application-submission.ts
+++ b/utils/application-submission.ts
@@ -18,8 +18,14 @@ export interface ApplicationDeliveryResult {
   email: boolean
 }
 
-const SUBMISSION_ERROR =
-  "We couldn't create your application record on GitHub. It has not been marked as submitted. Please try again or contact applications@opensats.org."
+export const SUBMISSION_ERROR =
+  "We couldn't create your application record on GitHub. It has not been marked as submitted. Please try again."
+
+export const SUBMISSION_CONTACT =
+  'If this keeps happening, email applications@opensats.org.'
+
+/** Show the contact line after this many failed submit attempts. */
+export const SUBMISSION_CONTACT_AFTER_FAILURES = 3
 
 async function postSucceeded(
   postJSON: PostJSON,

--- a/utils/application-submission.ts
+++ b/utils/application-submission.ts
@@ -19,7 +19,7 @@ export interface ApplicationDeliveryResult {
 }
 
 const SUBMISSION_ERROR =
-  "We couldn't confirm that your application reached OpenSats. It has not been marked as submitted. Please try again or contact applications@opensats.org."
+  "We couldn't create your application record on GitHub. It has not been marked as submitted. Please try again or contact applications@opensats.org."
 
 export async function submitApplication(
   data: ApplicationSubmissionData,
@@ -37,7 +37,8 @@ export async function submitApplication(
     (result) => result.status === 'fulfilled' && result.value
   )
 
-  if (!github && !email) {
+  // GitHub is the durable screening record. Email alone is not enough.
+  if (!github) {
     throw new Error(SUBMISSION_ERROR)
   }
 

--- a/utils/application-submission.ts
+++ b/utils/application-submission.ts
@@ -1,0 +1,45 @@
+import { fetchPostJSON } from './api-helpers'
+
+export interface ApplicationSubmissionData {
+  [key: string]: unknown
+}
+
+interface DestinationResponse {
+  message?: string
+}
+
+type PostJSON = (
+  url: string,
+  data: ApplicationSubmissionData
+) => Promise<DestinationResponse>
+
+export interface ApplicationDeliveryResult {
+  github: boolean
+  email: boolean
+}
+
+const SUBMISSION_ERROR =
+  "We couldn't confirm that your application reached OpenSats. It has not been marked as submitted. Please try again or contact applications@opensats.org."
+
+export async function submitApplication(
+  data: ApplicationSubmissionData,
+  postJSON: PostJSON = fetchPostJSON
+): Promise<ApplicationDeliveryResult> {
+  const destinations = ['/api/github', '/api/sendgrid'] as const
+  const results = await Promise.allSettled(
+    destinations.map(async (destination) => {
+      const response = await postJSON(destination, data)
+      return response.message === 'success'
+    })
+  )
+
+  const [github, email] = results.map(
+    (result) => result.status === 'fulfilled' && result.value
+  )
+
+  if (!github && !email) {
+    throw new Error(SUBMISSION_ERROR)
+  }
+
+  return { github, email }
+}


### PR DESCRIPTION
In short:

- requires GitHub confirmation before `/submitted`
- emails only after the issue exists, so retries do not spam the applicant
- gates SendGrid success on the internal `sendEmailWithRetry` boolean

Refs OpenSats/operations#675

Build preview: 
- [/apply](https://os-website-git-fix-never-fail-silently-opensats.vercel.app/apply)
