### PR TITLE
Add BIPs project page

### DIFF
--- a/data/projects/bips.mdx
+++ b/data/projects/bips.mdx
@@ -30,7 +30,7 @@ than one implementation, wallet, library, or user workflow. BIPs help turn
 mailing list discussions and design sketches into specifications that can be
 reviewed, referenced, implemented, tested, and challenged over time.
 
-That work is mostly coordination and maintenance. Authors have to define scope,
+That work is mostly coordination, review, and maintenance. Authors have to define scope,
 write clear specifications, address objections, record rationale, and revise the
 proposal as review improves it. Editors keep the process moving by checking
 format, scope, soundness, metadata, licensing, status, and publication criteria.

--- a/data/projects/bips.mdx
+++ b/data/projects/bips.mdx
@@ -1,0 +1,60 @@
+---
+title: 'Bitcoin Improvement Proposals'
+dateAdded: '2026-08-08'
+summary: "Bitcoin's public specification process and proposal archive."
+nym: 'BIP Editors and Authors'
+website: 'https://bips.dev/'
+coverImage: '/static/images/projects/bips.svg'
+containCoverImage: true
+git: 'https://github.com/bitcoin/bips'
+tags: ['Bitcoin', 'Protocol', 'Documentation']
+fund: general
+announcementLink: '/blog/jon-atack-receives-lts-grant'
+---
+
+Bitcoin Improvement Proposals (BIPs) are the public specification process and
+archive for Bitcoin. They give authors a structured way to document protocol
+changes, peer-to-peer behavior, wallet standards, application conventions, and
+process updates so implementers can review the same technical proposal from the
+same source of truth.
+
+The [BIPs repository][repo] is the canonical publication medium. It stores each
+proposal as a versioned text file, tracks edits through Git history, and makes
+the latest accepted draft easy to retrieve. The rendered [bips.dev][bips-dev]
+site gives developers and reviewers a faster way to browse those specifications.
+
+## Why fund it?
+
+Bitcoin development relies on written specifications when changes touch more
+than one implementation, wallet, library, or user workflow. BIPs help turn
+mailing list discussions and design sketches into stable documents that can be
+reviewed, referenced, implemented, tested, and challenged over time.
+
+That work is mostly coordination and maintenance. Authors have to define scope,
+write clear specifications, address objections, record rationale, and revise the
+proposal as review improves it. Editors keep the process moving by checking
+format, scope, metadata, licensing, status, and publication criteria.
+
+OpenSats funds [Jon Atack][jon-announce], a Bitcoin Core contributor and BIP
+editor, through the Long-Term Support program. His grant includes work on BIP
+proposal review and maintenance, especially where proposals affect Bitcoin's
+consensus rules, decentralization, security, robustness, privacy, or user
+experience.
+
+## What's next?
+
+The BIP process was refreshed by [BIP 3][bip-3], which replaced the older BIP 2
+process and clarified the role of BIP authors, deputies, editors, proposal
+types, statuses, and publication criteria.
+
+The repository remains active because Bitcoin remains active. Current and future
+work includes new consensus proposals, peer-service changes, wallet
+interoperability standards, application-level conventions, and process
+improvements. Keeping the archive readable, reviewable, and current gives the
+ecosystem a durable place to debate technical changes without tying publication
+to adoption.
+
+[bip-3]: https://github.com/bitcoin/bips/blob/master/bip-0003.md
+[bips-dev]: https://bips.dev/
+[jon-announce]: /blog/jon-atack-receives-lts-grant
+[repo]: https://github.com/bitcoin/bips

--- a/data/projects/bips.mdx
+++ b/data/projects/bips.mdx
@@ -27,7 +27,7 @@ site gives developers and reviewers a faster way to browse those specifications.
 
 Bitcoin development relies on written specifications when changes touch more
 than one implementation, wallet, library, or user workflow. BIPs help turn
-mailing list discussions and design sketches into stable documents that can be
+mailing list discussions and design sketches into specifications that can be
 reviewed, referenced, implemented, tested, and challenged over time.
 
 That work is mostly coordination and maintenance. Authors have to define scope,

--- a/data/projects/bips.mdx
+++ b/data/projects/bips.mdx
@@ -37,9 +37,9 @@ format, scope, metadata, licensing, status, and publication criteria.
 
 OpenSats funds [Jon Atack][jon-announce], a Bitcoin Core contributor and BIP
 editor, through the Long-Term Support program. His grant includes work on BIP
-proposal review and maintenance, especially where proposals affect Bitcoin's
-consensus rules, decentralization, security, robustness, privacy, or user
-experience.
+maintainership, technical and conceptual review, scope checks, moderation, and
+publication work, especially where proposals affect Bitcoin's consensus rules,
+decentralization, security, robustness, privacy, or user experience.
 
 ## What's next?
 
@@ -50,9 +50,9 @@ types, statuses, and publication criteria.
 The repository remains active because Bitcoin remains active. Current and future
 work includes new consensus proposals, peer-service changes, wallet
 interoperability standards, application-level conventions, and process
-improvements. Keeping the archive readable, reviewable, technically sound, in scope, and current gives the
-ecosystem a durable place to debate technical changes without tying publication
-to adoption.
+improvements. Keeping the archive readable, reviewable, technically sound, in
+scope, and current gives the ecosystem a durable place to debate technical
+changes without tying publication to adoption.
 
 [bip-3]: https://github.com/bitcoin/bips/blob/master/bip-0003.md
 [bips-dev]: https://bips.dev/

--- a/data/projects/bips.mdx
+++ b/data/projects/bips.mdx
@@ -47,7 +47,7 @@ The BIP process was refreshed by [BIP 3][bip-3], which replaced the older BIP 2
 process and clarified the role of BIP authors, deputies, editors, proposal
 types, statuses, and publication criteria.
 
-The repository remains active because Bitcoin remains active. Current and future
+The repository has been increasingly active over the past two years, with a plethora of new BIPs, as well as bug fixes and improvements. Current and future
 work includes new consensus proposals, peer-service changes, wallet
 interoperability standards, application-level conventions, and process
 improvements. Keeping the archive readable, reviewable, technically sound, in

--- a/data/projects/bips.mdx
+++ b/data/projects/bips.mdx
@@ -43,10 +43,6 @@ decentralization, security, robustness, privacy, or user experience.
 
 ## What's next?
 
-The BIP process was refreshed by [BIP 3][bip-3], which replaced the older BIP 2
-process and clarified the role of BIP authors, deputies, editors, proposal
-types, statuses, and publication criteria.
-
 The repository has been increasingly active over the past two years, with a plethora of new BIPs, as well as bug fixes and improvements. Current and future
 work includes new consensus proposals, peer-service changes, wallet
 interoperability standards, application-level conventions, and process
@@ -54,7 +50,6 @@ improvements. Keeping the archive readable, reviewable, technically sound, in
 scope, and current gives the ecosystem a durable place to debate technical
 changes without tying publication to adoption.
 
-[bip-3]: https://github.com/bitcoin/bips/blob/master/bip-0003.md
 [bips-dev]: https://bips.dev/
 [jon-announce]: /blog/jon-atack-receives-lts-grant
 [repo]: https://github.com/bitcoin/bips

--- a/data/projects/bips.mdx
+++ b/data/projects/bips.mdx
@@ -50,7 +50,7 @@ types, statuses, and publication criteria.
 The repository remains active because Bitcoin remains active. Current and future
 work includes new consensus proposals, peer-service changes, wallet
 interoperability standards, application-level conventions, and process
-improvements. Keeping the archive readable, reviewable, and current gives the
+improvements. Keeping the archive readable, reviewable, technically sound, in scope, and current gives the
 ecosystem a durable place to debate technical changes without tying publication
 to adoption.
 

--- a/data/projects/bips.mdx
+++ b/data/projects/bips.mdx
@@ -33,7 +33,7 @@ reviewed, referenced, implemented, tested, and challenged over time.
 That work is mostly coordination and maintenance. Authors have to define scope,
 write clear specifications, address objections, record rationale, and revise the
 proposal as review improves it. Editors keep the process moving by checking
-format, scope, metadata, licensing, status, and publication criteria.
+format, scope, soundness, metadata, licensing, status, and publication criteria.
 
 OpenSats funds [Jon Atack][jon-announce], a Bitcoin Core contributor and BIP
 editor, through the Long-Term Support program. His grant includes work on BIP

--- a/public/static/images/projects/bips.svg
+++ b/public/static/images/projects/bips.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Bitcoin Improvement Proposals</title>
+  <desc id="desc">A document mark with BIP text and a Bitcoin-orange accent.</desc>
+  <rect width="512" height="512" rx="96" fill="#f8fafc"/>
+  <path d="M160 72h144l88 88v280H160z" fill="#ffffff" stroke="#1f2937" stroke-width="18" stroke-linejoin="round"/>
+  <path d="M304 72v88h88" fill="none" stroke="#1f2937" stroke-width="18" stroke-linejoin="round"/>
+  <path d="M190 188h132M190 232h132M190 276h92" stroke="#94a3b8" stroke-width="18" stroke-linecap="round"/>
+  <rect x="120" y="318" width="272" height="82" rx="24" fill="#f7931a"/>
+  <g fill="none" stroke="#111827" stroke-width="12" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M168 344v30h25a15 15 0 0 0 0-30h-25zM168 374h29a14 14 0 0 1 0 28h-29"/>
+    <path d="M236 344h38M255 344v58M236 402h38"/>
+    <path d="M306 402v-58h27a18 18 0 0 1 0 36h-27"/>
+    <path d="M378 346h-22a15 15 0 0 0 0 30h8a13 13 0 0 1 0 26h-24"/>
+  </g>
+</svg>

--- a/public/static/images/projects/bips.svg
+++ b/public/static/images/projects/bips.svg
@@ -1,15 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
-  <title id="title">Bitcoin Improvement Proposals</title>
-  <desc id="desc">A document mark with BIP text and a Bitcoin-orange accent.</desc>
-  <rect width="512" height="512" rx="96" fill="#f8fafc"/>
-  <path d="M160 72h144l88 88v280H160z" fill="#ffffff" stroke="#1f2937" stroke-width="18" stroke-linejoin="round"/>
-  <path d="M304 72v88h88" fill="none" stroke="#1f2937" stroke-width="18" stroke-linejoin="round"/>
-  <path d="M190 188h132M190 232h132M190 276h92" stroke="#94a3b8" stroke-width="18" stroke-linecap="round"/>
-  <rect x="120" y="318" width="272" height="82" rx="24" fill="#f7931a"/>
-  <g fill="none" stroke="#111827" stroke-width="12" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M168 344v30h25a15 15 0 0 0 0-30h-25zM168 374h29a14 14 0 0 1 0 28h-29"/>
-    <path d="M236 344h38M255 344v58M236 402h38"/>
-    <path d="M306 402v-58h27a18 18 0 0 1 0 36h-27"/>
-    <path d="M378 346h-22a15 15 0 0 0 0 30h8a13 13 0 0 1 0 26h-24"/>
-  </g>
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Bitcoin Improvement Proposal icon</title>
+  <desc id="desc">A clean proposal document with a folded corner, specification lines, and an orange BIP badge.</desc>
+  <path d="M66 34H145L192 81V198C192 212.36 180.36 224 166 224H90C75.64 224 64 212.36 64 198V36C64 34.895 64.895 34 66 34Z" fill="#fff" stroke="#202A36" stroke-width="10" stroke-linejoin="round"/>
+  <path d="M145 34V75C145 78.314 147.686 81 151 81H192" stroke="#202A36" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="82" y="101" width="10" height="54" rx="5" fill="#F7931A"/>
+  <path d="M108 106H166" stroke="#7B8AA0" stroke-width="8" stroke-linecap="round"/>
+  <path d="M108 128H157" stroke="#A1AEC0" stroke-width="8" stroke-linecap="round"/>
+  <path d="M108 150H145" stroke="#A1AEC0" stroke-width="8" stroke-linecap="round"/>
+  <rect x="77" y="176" width="102" height="35" rx="11" fill="#F7931A"/>
+  <text x="128" y="200" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="27.5" font-weight="800" letter-spacing="1.1" fill="#151A20">BIPs</text>
 </svg>

--- a/public/static/images/projects/bips.svg
+++ b/public/static/images/projects/bips.svg
@@ -1,4 +1,4 @@
-<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+<svg width="256" height="256" viewBox="20 20 216 216" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
   <title id="title">Bitcoin Improvement Proposal icon</title>
   <desc id="desc">A clean proposal document with a folded corner, specification lines, and an orange BIP badge.</desc>
   <path d="M66 34H145L192 81V198C192 212.36 180.36 224 166 224H90C75.64 224 64 212.36 64 198V36C64 34.895 64.895 34 66 34Z" fill="#fff" stroke="#202A36" stroke-width="10" stroke-linejoin="round"/>

--- a/scripts/generate-page-og.mjs
+++ b/scripts/generate-page-og.mjs
@@ -155,7 +155,9 @@ function renderRedSvg(logoDataUri) {
 
       <image href="${logoDataUri}" x="${logoX}" y="${logoY}" width="${logoSize}" height="${logoSize}" />
 
-      <rect x="${PADDING}" y="${urlY - 36}" width="${CONTENT_WIDTH}" height="1" fill="#44403c" />
+      <rect x="${PADDING}" y="${
+    urlY - 36
+  }" width="${CONTENT_WIDTH}" height="1" fill="#44403c" />
       <text x="${PADDING}" y="${urlY}" fill="#a8a29e" font-size="22" font-family="${INTER_FONT_FAMILY}" letter-spacing="1">${escapeXml(
     pageUrl
   )}</text>
@@ -562,7 +564,9 @@ async function writeImage(slug, svg) {
 async function main() {
   await ensureCleanDir(outputDir)
   faviconDataUri = await loadFaviconDataUri()
-  const redLogoDataUri = await publicAssetToDataUri('/static/brand/logo-red.png')
+  const redLogoDataUri = await publicAssetToDataUri(
+    '/static/brand/logo-red.png'
+  )
   if (!redLogoDataUri) {
     throw new Error('Missing red logo at public/static/brand/logo-red.png')
   }

--- a/utils/projectClusters.ts
+++ b/utils/projectClusters.ts
@@ -22,7 +22,14 @@ export const CLUSTERS: Cluster[] = [
     id: 'core',
     title: 'Protocol Maintenance & Development',
     blurb: 'Full nodes, validation, and core protocol work.',
-    slugs: ['bitcoin-core', 'libbitcoin', 'floresta', 'utreexod', 'asmap'],
+    slugs: [
+      'bitcoin-core',
+      'bips',
+      'libbitcoin',
+      'floresta',
+      'utreexod',
+      'asmap',
+    ],
   },
   {
     id: 'education',


### PR DESCRIPTION
Adds Bitcoin Improvement Proposals to the public project directory with a concise overview of the BIP process, the BIP 3 process refresh, and OpenSats support for Jon Atack's BIP review and maintenance work. I left `totalSatsSent` unset because the project page does not map cleanly to a single public payout stream.

- adds a new `/projects/bips` MDX page
- adds a lightweight project cover asset
- links to the canonical BIPs repository, `bips.dev`, BIP 3, and the Jon Atack LTS announcement

Build preview:
- [/projects](https://os-website-git-content-add-bips-project-opensats.vercel.app/projects)
- [/projects/bips](https://os-website-git-content-add-bips-project-opensats.vercel.app/projects/bips)

Fixes OpenSats/content#297
