### PR TITLE
Fix ongoing exploits blog post nits

### DIFF
--- a/data/blog/ongoing-exploits-of-bitcoin-open-source-software.mdx
+++ b/data/blog/ongoing-exploits-of-bitcoin-open-source-software.mdx
@@ -9,7 +9,7 @@ summary: 'A critical BTCPay Server flaw affecting LND is under active exploit.'
 fundCard: red
 ---
 
-In the last 24h multiple critical security vulnerabilities were found and
+In the last 24 hours multiple critical security vulnerabilities were found and
 disclosed, most notably a [BTCPay Server vulnerability] that can lead to loss of
 funds when using an LND node. Refer to the [official statement] by the BTCPay
 Server team for a more detailed description and actionable steps.
@@ -26,7 +26,7 @@ days. Keep an eye out for updates via official channels, not only from the
 [projects we fund], but across the whole bitcoin open-source ecosystem.
 
 We would like to thank everyone who has donated to or otherwise supported the
-[red team], developers and security researchers who are responsibly disclosing
+[red team], the developers and security researchers who are responsibly disclosing
 any issues that are found, and the maintainers who are working around the clock
 to make sure that free and open-source software is as secure as it can be.
 


### PR DESCRIPTION
Applies the two review nits from #910 to the ongoing exploits blog post: expands `24h` in prose and adds `the` before `developers` in the acknowledgements paragraph.

- Build preview: [/blog/ongoing-exploits-of-bitcoin-open-source-software](https://os-website-git-fix-blog-ongoing-exploits-nits-opensats.vercel.app/blog/ongoing-exploits-of-bitcoin-open-source-software)
