### PR TITLE
Route Code RED applications to applications-red

### DIFF
--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -148,21 +148,19 @@ ${contactFooter}`
       issueLabels.push('common-grant-app')
     }
 
-    // Repo set according to "main focus"
+    // Repo set according to "main focus" (RED uses its own priority repo)
     let appRepo = GH_APP_REPO
-    if (mainFocus === 'nostr') {
+    if (req.body.RED) {
+      appRepo = `${GH_APP_REPO}-red`
+    } else if (mainFocus === 'nostr') {
       appRepo = `${GH_APP_REPO}-nostr`
-    }
-    if (mainFocus === 'layer1') {
+    } else if (mainFocus === 'layer1') {
       appRepo = `${GH_APP_REPO}-layer1`
-    }
-    if (mainFocus === 'layer2') {
+    } else if (mainFocus === 'layer2') {
       appRepo = `${GH_APP_REPO}-layer2`
-    }
-    if (mainFocus === 'core') {
+    } else if (mainFocus === 'core') {
       appRepo = `${GH_APP_REPO}-core`
-    }
-    if (mainFocus === 'ecash') {
+    } else if (mainFocus === 'ecash') {
       appRepo = `${GH_APP_REPO}-ecash`
     }
 


### PR DESCRIPTION
Routes Code RED form submissions from `/apply/red` into `applications-red` instead of the main `applications` repo, matching the other focus-area repos.

- Prefer `applications-red` when `RED` is set, before main-focus routing
- Keep the `RED` label on those issues

Build preview:
- [/apply/red](https://website-git-feat-applications-red-routing-opensats.vercel.app/apply/red)
