### PR TITLE
Improve grant progress report form and FAQ guidance

### DIFF
--- a/components/GrantReportForm.tsx
+++ b/components/GrantReportForm.tsx
@@ -176,6 +176,8 @@ export default function GrantReportForm({
             )}
           </div>
 
+          <h2>3 Questions</h2>
+
           {/* Project Updates */}
           <label className="block">
             How did you spend your time? *
@@ -354,6 +356,8 @@ export default function GrantReportForm({
             </small>
           )}
         </div>
+
+        <h2>3 Questions</h2>
 
         {/* Project Updates */}
         <label className="block">

--- a/components/GrantReportForm.tsx
+++ b/components/GrantReportForm.tsx
@@ -285,6 +285,8 @@ export default function GrantReportForm({
             )}
           </label>
 
+          <hr />
+
           {/* Support needed */}
           <label className="block">
             Is there anything we could help with?
@@ -494,6 +496,8 @@ export default function GrantReportForm({
             <small className="text-red-500">{errors.own_words.message}</small>
           )}
         </label>
+
+        <hr />
 
         {/* Support needed */}
         <label className="block">

--- a/components/GrantReportForm.tsx
+++ b/components/GrantReportForm.tsx
@@ -253,7 +253,7 @@ export default function GrantReportForm({
             )}
           </label>
 
-          <h2>one paragraph, in your own words</h2>
+          <h2>One Paragraph, In Your Own Words</h2>
 
           <label className="block">
             <small>
@@ -458,7 +458,7 @@ export default function GrantReportForm({
           )}
         </label>
 
-        <h2>one paragraph, in your own words</h2>
+        <h2>One Paragraph, In Your Own Words</h2>
 
         <label className="block">
           <small>

--- a/components/GrantReportForm.tsx
+++ b/components/GrantReportForm.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { useRouter } from 'next/router'
 import { STORAGE_KEYS } from '../utils/constants'
+import CustomLink from './Link'
 
 interface GrantReportFormProps {
   grantDetails: {
@@ -289,8 +290,11 @@ export default function GrantReportForm({
             <br />
             <small>
               Let us know if you need any technical assistance, introductions,
-              or have any other questions that aren't covered by the Grantee
-              FAQ.
+              or have any other questions that aren't covered by the{' '}
+              <CustomLink href="/faq/grantee" className="font-bold">
+                Grantee FAQ
+              </CustomLink>
+              .
             </small>
             <textarea
               {...register('help_needed')}
@@ -495,7 +499,11 @@ export default function GrantReportForm({
           <br />
           <small>
             Let us know if you need any technical assistance, introductions, or
-            have any other questions that aren't covered by the Grantee FAQ.
+            have any other questions that aren't covered by the{' '}
+            <CustomLink href="/faq/grantee" className="font-bold">
+              Grantee FAQ
+            </CustomLink>
+            .
           </small>
           <textarea
             {...register('help_needed')}

--- a/components/GrantReportForm.tsx
+++ b/components/GrantReportForm.tsx
@@ -257,8 +257,10 @@ export default function GrantReportForm({
 
           <label className="block">
             <small>
-              Write one paragraph about what happened this period. Use your own
-              words. Do not use an LLM or any other AI. *
+              Write one paragraph about what happened this period. What was
+              most important to you, what did you accomplish? Use your own
+              words. Do not use an LLM or any other AI to write this. We want
+              to hear from <em>you</em>, not from your slop-slinging clanker. *
             </small>
             <textarea
               {...register('own_words', {
@@ -462,8 +464,10 @@ export default function GrantReportForm({
 
         <label className="block">
           <small>
-            Write one paragraph about what happened this period. Use your own
-            words. Do not use an LLM or any other AI. *
+            Write one paragraph about what happened this period. What was most
+            important to you, what did you accomplish? Use your own words. Do
+            not use an LLM or any other AI to write this. We want to hear from{' '}
+            <em>you</em>, not from your slop-slinging clanker. *
           </small>
           <textarea
             {...register('own_words', {

--- a/components/GrantReportForm.tsx
+++ b/components/GrantReportForm.tsx
@@ -288,8 +288,9 @@ export default function GrantReportForm({
             Is there anything we could help with?
             <br />
             <small>
-              We're here to help! Let us know if you need any technical
-              assistance, introductions, or have other questions.
+              Let us know if you need any technical assistance, introductions,
+              or have any other questions that aren't covered by the Grantee
+              FAQ.
             </small>
             <textarea
               {...register('help_needed')}
@@ -493,8 +494,8 @@ export default function GrantReportForm({
           Is there anything we could help with?
           <br />
           <small>
-            We're here to help! Let us know if you need any technical
-            assistance, introductions, or have other questions.
+            Let us know if you need any technical assistance, introductions, or
+            have any other questions that aren't covered by the Grantee FAQ.
           </small>
           <textarea
             {...register('help_needed')}

--- a/components/GrantReportForm.tsx
+++ b/components/GrantReportForm.tsx
@@ -253,7 +253,7 @@ export default function GrantReportForm({
             )}
           </label>
 
-          <h2>One Paragraph, In Your Own Words</h2>
+          <h2>tl;dr - In Your Own Words</h2>
 
           <label className="block">
             <small>
@@ -458,7 +458,7 @@ export default function GrantReportForm({
           )}
         </label>
 
-        <h2>One Paragraph, In Your Own Words</h2>
+        <h2>tl;dr - In Your Own Words</h2>
 
         <label className="block">
           <small>

--- a/components/GrantReportForm.tsx
+++ b/components/GrantReportForm.tsx
@@ -254,6 +254,7 @@ export default function GrantReportForm({
             )}
           </label>
 
+          <hr />
           <h2>tl;dr - In Your Own Words</h2>
 
           <label className="block">
@@ -465,6 +466,7 @@ export default function GrantReportForm({
           )}
         </label>
 
+        <hr />
         <h2>tl;dr - In Your Own Words</h2>
 
         <label className="block">

--- a/components/GrantReportForm.tsx
+++ b/components/GrantReportForm.tsx
@@ -17,6 +17,7 @@ interface GrantReportFormData {
   time_spent: string
   next_quarter: string
   money_usage: string
+  own_words: string
   help_needed?: string
 }
 
@@ -43,6 +44,7 @@ export default function GrantReportForm({
       time_spent: '',
       next_quarter: '',
       money_usage: '',
+      own_words: '',
       help_needed: '',
     },
     mode: 'onBlur',
@@ -112,7 +114,8 @@ export default function GrantReportForm({
       !data.project_name ||
       !data.time_spent ||
       !data.next_quarter ||
-      !data.money_usage
+      !data.money_usage ||
+      !data.own_words
     ) {
       setError('Please fill in all required fields before previewing')
       return
@@ -131,6 +134,7 @@ export default function GrantReportForm({
           time_spent: data.time_spent,
           next_quarter: data.next_quarter,
           money_usage: data.money_usage,
+          own_words: data.own_words,
           help_needed: data.help_needed || '',
         })
       )
@@ -245,6 +249,34 @@ export default function GrantReportForm({
             {errors.money_usage && (
               <small className="text-red-500">
                 {errors.money_usage.message}
+              </small>
+            )}
+          </label>
+
+          <h2>one paragraph, in your own words</h2>
+
+          <label className="block">
+            <small>
+              Write one paragraph about what happened this period. Use your own
+              words. Do not use an LLM or any other AI. *
+            </small>
+            <textarea
+              {...register('own_words', {
+                required: 'Please write one paragraph in your own words',
+                validate: (value) => {
+                  const trimmed = value.trim()
+                  if (/\n\s*\n/.test(trimmed)) {
+                    return 'Please keep this to a single paragraph'
+                  }
+                  return true
+                },
+              })}
+              rows={4}
+              className="mt-1 block w-full rounded-md border-gray-300 font-mono text-sm text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+            />
+            {errors.own_words && (
+              <small className="text-red-500">
+                {errors.own_words.message}
               </small>
             )}
           </label>
@@ -423,6 +455,32 @@ export default function GrantReportForm({
           />
           {errors.money_usage && (
             <small className="text-red-500">{errors.money_usage.message}</small>
+          )}
+        </label>
+
+        <h2>one paragraph, in your own words</h2>
+
+        <label className="block">
+          <small>
+            Write one paragraph about what happened this period. Use your own
+            words. Do not use an LLM or any other AI. *
+          </small>
+          <textarea
+            {...register('own_words', {
+              required: 'Please write one paragraph in your own words',
+              validate: (value) => {
+                const trimmed = value.trim()
+                if (/\n\s*\n/.test(trimmed)) {
+                  return 'Please keep this to a single paragraph'
+                }
+                return true
+              },
+            })}
+            rows={4}
+            className="mt-1 block w-full rounded-md border-gray-300 font-mono text-sm text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+          />
+          {errors.own_words && (
+            <small className="text-red-500">{errors.own_words.message}</small>
           )}
         </label>
 

--- a/components/GrantReportForm.tsx
+++ b/components/GrantReportForm.tsx
@@ -259,10 +259,10 @@ export default function GrantReportForm({
 
           <label className="block">
             <small>
-              Write one paragraph about what happened this period. What was
-              most important to you, what did you accomplish? Use your own
-              words. Do not use an LLM or any other AI to write this. We want
-              to hear from <em>you</em>, not from your slop-slinging clanker. *
+              Write one paragraph about what happened this period. What was most
+              important to you, what did you accomplish? Use your own words. Do
+              not use an LLM or any other AI to write this. We want to hear from{' '}
+              <em>you</em>, not from your slop-slinging clanker. *
             </small>
             <textarea
               {...register('own_words', {
@@ -279,9 +279,7 @@ export default function GrantReportForm({
               className="mt-1 block w-full rounded-md border-gray-300 font-mono text-sm text-black shadow-sm focus:border-orange-300 focus:ring focus:ring-orange-200 focus:ring-opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
             />
             {errors.own_words && (
-              <small className="text-red-500">
-                {errors.own_words.message}
-              </small>
+              <small className="text-red-500">{errors.own_words.message}</small>
             )}
           </label>
 

--- a/data/pages/faq-grantees.mdx
+++ b/data/pages/faq-grantees.mdx
@@ -197,6 +197,10 @@ A poor progress report is:
 - Has no links to pull requests or similar work output
 - Missing context, summaries, and explanations, i.e. is only a long list of changes or bullet points without anything else
 
+Please put some effort into your report. We expect you to write at least one
+coherent and thoughtful paragraph that you wrote yourself, with sufficient
+thought and care. If all you send is LLM slop we're gonna have a bad time.
+
 Refer to the question above for what a [good progress
 report](#what-does-an-ideal-progress-report-look-like) looks like.
 

--- a/data/pages/faq-grantees.mdx
+++ b/data/pages/faq-grantees.mdx
@@ -194,7 +194,7 @@ A poor progress report is:
 - Hard to understand
 - An incredibly long wall of text
 - Not showing any of the actual work done
-- Has no links to pull requests or similar
+- Has no links to pull requests or similar work output
 - Missing context, summaries, and explanations, i.e. is only a long list of links to pull requests and commits without anything else
 
 Refer to the question above for what a [good progress

--- a/data/pages/faq-grantees.mdx
+++ b/data/pages/faq-grantees.mdx
@@ -197,8 +197,8 @@ A poor progress report is:
 - Devoid of links to pull requests or similar work output
 - Missing context, summaries, and explanations, i.e. is only a long list of changes or bullet points without anything else
 
-Please put some effort into your report. We expect you to write at least one
-coherent and thoughtful paragraph that you wrote yourself, with sufficient
+Please put some effort into your report. **We expect you to write at least one
+coherent and thoughtful paragraph that you wrote yourself**, with sufficient
 thought and care. If all you send is LLM slop we're gonna have a bad time.
 
 Refer to the question above for what a [good progress

--- a/data/pages/faq-grantees.mdx
+++ b/data/pages/faq-grantees.mdx
@@ -195,7 +195,7 @@ A poor progress report is:
 - Hard to understand
 - An incredibly long wall of text
 - Not showing any of the actual work done
-- Missing links to pull requests and commits
+- Has no links to pull requests or similar
 - Missing context, summaries, and explanations, i.e. is only a long list of links to pull requests and commits without anything else
 
 Refer to the question above for what a [good progress

--- a/data/pages/faq-grantees.mdx
+++ b/data/pages/faq-grantees.mdx
@@ -179,8 +179,8 @@ In the best case, each progress report:
 - Describes challenges, and how you overcame them
 - Includes if you are happy or unhappy with the progress you made
 
-Every progress report should show clearly the connection between what was
-planned in the application or previous report(s) and the work done since.
+In the best case, a progress report shows what was achieved and how it
+relates to the milestones outlined in the application.
 
 We encourage you to openly discuss any obstacles that may have prevented you
 from reaching previously established milestones, and/or why your previously

--- a/data/pages/faq-grantees.mdx
+++ b/data/pages/faq-grantees.mdx
@@ -179,8 +179,8 @@ In the best case, each progress report:
 - Describes challenges, and how you overcame them
 - Includes if you are happy or unhappy with the progress you made
 
-A good progress report shows what was achieved since the last report and how it
-relates to the milestones outlined in the application.
+A good progress report shows **what was achieved since the last report and how it
+relates to the milestones** outlined in the application.
 
 We encourage you to openly discuss any obstacles that may have prevented you
 from reaching previously established milestones, and/or why your previously

--- a/data/pages/faq-grantees.mdx
+++ b/data/pages/faq-grantees.mdx
@@ -179,7 +179,7 @@ In the best case, each progress report:
 - Describes challenges, and how you overcame them
 - Includes if you are happy or unhappy with the progress you made
 
-In the best case, a progress report shows what was achieved and how it
+A good progress report shows what was achieved since the last report and how it
 relates to the milestones outlined in the application.
 
 We encourage you to openly discuss any obstacles that may have prevented you

--- a/data/pages/faq-grantees.mdx
+++ b/data/pages/faq-grantees.mdx
@@ -171,7 +171,7 @@ An ideal progress report is:
 
 - Written in markdown
 - Easy to read and understand by a peer of yours
-- Enriched with the most relevant links to pull requests, commits, and other work produced
+- Coherent and has links to pull requests and similar
 
 In the best case, each progress report:
 

--- a/data/pages/faq-grantees.mdx
+++ b/data/pages/faq-grantees.mdx
@@ -194,7 +194,7 @@ A poor progress report is:
 - Hard to understand
 - An incredibly long wall of text
 - Not showing any of the actual work done
-- Has no links to pull requests or similar work output
+- Devoid of links to pull requests or similar work output
 - Missing context, summaries, and explanations, i.e. is only a long list of changes or bullet points without anything else
 
 Please put some effort into your report. We expect you to write at least one

--- a/data/pages/faq-grantees.mdx
+++ b/data/pages/faq-grantees.mdx
@@ -175,7 +175,6 @@ An ideal progress report is:
 
 In the best case, each progress report:
 
-- Has a brief summary in each section before providing additional details
 - Tells us if you are on track
 - Describes challenges, and how you overcame them
 - Includes if you are pleased or displeased with the progress you made

--- a/data/pages/faq-grantees.mdx
+++ b/data/pages/faq-grantees.mdx
@@ -171,7 +171,7 @@ An ideal progress report is:
 
 - Written in markdown
 - Easy to read and understand by a peer of yours
-- Coherent and has links to pull requests and similar
+- Accurate, coherent, and has links to pull requests and similar
 
 In the best case, each progress report:
 

--- a/data/pages/faq-grantees.mdx
+++ b/data/pages/faq-grantees.mdx
@@ -170,7 +170,7 @@ grantee performance.
 An ideal progress report is:
 
 - Written in Markdown format
-- Between 1 and 3 pages
+- Easy to read and understand by a peer of yours
 - Enriched with the most relevant links to pull requests, commits, and other work produced
 
 In the best case, each progress report:

--- a/data/pages/faq-grantees.mdx
+++ b/data/pages/faq-grantees.mdx
@@ -177,7 +177,7 @@ In the best case, each progress report:
 
 - Tells us if you are on track
 - Describes challenges, and how you overcame them
-- Includes if you are pleased or displeased with the progress you made
+- Includes if you are happy or unhappy with the progress you made
 
 Every progress report should show clearly the connection between what was
 planned in the application or previous report(s) and the work done since.

--- a/data/pages/faq-grantees.mdx
+++ b/data/pages/faq-grantees.mdx
@@ -169,7 +169,7 @@ grantee performance.
 
 An ideal progress report is:
 
-- Written in Markdown format
+- Written in markdown
 - Easy to read and understand by a peer of yours
 - Enriched with the most relevant links to pull requests, commits, and other work produced
 

--- a/data/pages/faq-grantees.mdx
+++ b/data/pages/faq-grantees.mdx
@@ -195,7 +195,7 @@ A poor progress report is:
 - An incredibly long wall of text
 - Not showing any of the actual work done
 - Has no links to pull requests or similar work output
-- Missing context, summaries, and explanations, i.e. is only a long list of links to pull requests and commits without anything else
+- Missing context, summaries, and explanations, i.e. is only a long list of changes or bullet points without anything else
 
 Refer to the question above for what a [good progress
 report](#what-does-an-ideal-progress-report-look-like) looks like.

--- a/pages/api/report.ts
+++ b/pages/api/report.ts
@@ -10,6 +10,7 @@ const GH_REPORTS_REPO = process.env.GH_REPORTS_REPO
 interface ReportBotRequest extends NextApiRequest {
   body: {
     project_name: string
+    own_words: string
     time_spent: string
     next_quarter: string
     money_usage: string
@@ -72,6 +73,7 @@ export default async function handler(
   try {
     const {
       project_name: original_project_name,
+      own_words,
       time_spent,
       next_quarter,
       money_usage,
@@ -83,6 +85,7 @@ export default async function handler(
     // Input validation
     if (
       !original_project_name ||
+      !own_words ||
       !time_spent ||
       !next_quarter ||
       !money_usage ||
@@ -103,6 +106,7 @@ export default async function handler(
     // Create report content in markdown format using the shared function
     const reportContent = generateReportContent({
       project_name,
+      own_words,
       time_spent,
       next_quarter,
       money_usage,

--- a/utils/api-helpers.ts
+++ b/utils/api-helpers.ts
@@ -95,7 +95,7 @@ export function generateReportContent(reportData: {
 
   return `# ${project_name} - Progress Report
 
-## In your own words
+## tl;dr - In Your Own Words
 ${own_words}
 
 ## Time Spent

--- a/utils/api-helpers.ts
+++ b/utils/api-helpers.ts
@@ -68,18 +68,25 @@ export async function fetchPostJSONAuthed(
 
 /**
  * Generates the markdown content for a grant report
- * @param reportData Object containing report data (project_name, time_spent, next_quarter, money_usage, help_needed)
+ * @param reportData Object containing report data (project_name, own_words, time_spent, next_quarter, money_usage, help_needed)
  * @returns Formatted markdown string for the report
  */
 export function generateReportContent(reportData: {
   project_name: string
+  own_words: string
   time_spent: string
   next_quarter: string
   money_usage: string
   help_needed?: string
 }): string {
-  const { project_name, time_spent, next_quarter, money_usage, help_needed } =
-    reportData
+  const {
+    project_name,
+    own_words,
+    time_spent,
+    next_quarter,
+    money_usage,
+    help_needed,
+  } = reportData
 
   // Format the help needed section if it exists
   const helpNeededSection = help_needed
@@ -87,6 +94,9 @@ export function generateReportContent(reportData: {
     : ''
 
   return `# ${project_name} - Progress Report
+
+## In your own words
+${own_words}
 
 ## Time Spent
 ${time_spent}

--- a/utils/api-helpers.ts
+++ b/utils/api-helpers.ts
@@ -95,8 +95,7 @@ export function generateReportContent(reportData: {
 
   return `# ${project_name} - Progress Report
 
-## tl;dr - In Your Own Words
-${own_words}
+**TLDR:** ${own_words}
 
 ## Time Spent
 ${time_spent}


### PR DESCRIPTION
Progress reports were producing unreadable commit dumps because the FAQ and form steered grantees toward long link lists instead of a short human-written overview.

- adds a required `tl;dr - In Your Own Words` field and `3 Questions` section on `/reports/write`
- posts the tl;dr as `**TLDR:**` at the top of the GitHub report comment
- updates ideal/poor progress report guidance in `faq-grantees.mdx`

**Build preview:**
- [/faq/grantee#what-does-an-ideal-progress-report-look-like](https://os-website-git-fix-report-form-guidance-opensats.vercel.app/faq/grantee#what-does-an-ideal-progress-report-look-like)
- [/faq/grantee#what-does-a-poor-progress-report-look-like](https://os-website-git-fix-report-form-guidance-opensats.vercel.app/faq/grantee#what-does-a-poor-progress-report-look-like)
- [/reports/submit](https://os-website-git-fix-report-form-guidance-opensats.vercel.app/reports/submit)

Fixes OpenSats/operations#687
