### PR TITLE
Add npub topic reference

### DIFF
--- a/data/topics/nip-05.mdx
+++ b/data/topics/nip-05.mdx
@@ -2,14 +2,15 @@
 title: 'NIP-05'
 summary: 'A Nostr spec that maps human-readable identifiers like `name@domain.com` to public keys via a JSON file hosted on the domain.'
 category: 'Nostr'
-aliases: ['Nostr address', 'nostr.json', 'DNS-based identifier', 'verified identifier']
+aliases:
+  ['Nostr address', 'nostr.json', 'DNS-based identifier', 'verified identifier']
 ---
 
 NIP-05 maps human-readable identifiers like `alice@example.com` to [Nostr](/topics/nostr) public keys using a JSON file on the domain's server. A client that wants to verify the identifier fetches `https://example.com/.well-known/nostr.json?name=alice` and checks that the returned pubkey matches the one the user claims on their profile.
 
 The identifier is optional. The underlying identity is still the pubkey. NIP-05 only asserts that the user controls the domain where the identifier lives. Losing the domain means losing the NIP-05, but the Nostr account keeps working with the same keypair.
 
-Clients display the identifier as a handle next to the name or as a string the user can share instead of a raw `npub`. Hosting services like `nostrcheck.me`, `iris.to`, and `nostrplebs.com` offer NIP-05 addresses for users who do not run their own domain.
+Clients display the identifier as a handle next to the name or as a string the user can share instead of a raw [`npub`](/topics/npub). Hosting services like `nostrcheck.me`, `iris.to`, and `nostrplebs.com` offer NIP-05 addresses for users who do not run their own domain.
 
 ## References
 

--- a/data/topics/nostr.mdx
+++ b/data/topics/nostr.mdx
@@ -6,7 +6,7 @@ category: 'Nostr'
 aliases: ['Notes and Other Stuff Transmitted by Relays']
 ---
 
-Nostr is a simple protocol for publishing and reading signed messages. A user's identity is a public key, often shared in `npub` form. A user's content is a list of "events" signed by an [`nsec`](/topics/nsec), the matching private key. Events are stored and served by "relays", which are small servers that anyone can run.
+Nostr is a simple protocol for publishing and reading signed messages. A user's identity is a public key, often shared in [`npub`](/topics/npub) form. A user's content is a list of "events" signed by an [`nsec`](/topics/nsec), the matching private key. Events are stored and served by "relays", which are small servers that anyone can run.
 
 There is no central server and no account system. A client connects to several relays at once, publishes events to all of them, and reads events from all of them. If a relay disappears or starts censoring, the client switches to another. The same identity and the same content keep working.
 

--- a/data/topics/npub.mdx
+++ b/data/topics/npub.mdx
@@ -1,0 +1,18 @@
+---
+title: 'npub'
+summary: 'A Nostr public key encoded as a Bech32 string under NIP-19. It is the shareable identifier for a Nostr account.'
+category: 'Nostr'
+aliases: ['nostr public key', 'nostr pubkey', 'npub1']
+---
+
+`npub` is the standard human-readable encoding for a [Nostr](/topics/nostr) public key. [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) wraps the raw 32-byte key in a [Bech32](/topics/bech32) string that starts with the `npub1` prefix.
+
+An `npub` is safe to share. It identifies the account, lets other users find the profile, and gives clients the public key they need to verify signed events. The matching private key is usually stored as an [`nsec`](/topics/nsec), which should stay secret.
+
+Users often share a [NIP-05](/topics/nip-05) identifier such as `alice@example.com` because it is easier to read than a long `npub`. The underlying Nostr identity is still the public key, and clients resolve or display the friendlier name next to that key.
+
+## References
+
+- [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md)
+- [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md)
+- [nostr-protocol/nips](https://github.com/nostr-protocol/nips)

--- a/data/topics/nsec.mdx
+++ b/data/topics/nsec.mdx
@@ -5,7 +5,7 @@ category: 'Nostr'
 aliases: ['nostr private key', 'nostr secret key', 'nsec1']
 ---
 
-`nsec` is the standard human-readable encoding for a Nostr private key. [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) wraps the raw 32-byte secret in a [Bech32](/topics/bech32) string that starts with the `nsec1` prefix. The matching public identity is usually shared as an `npub` string.
+`nsec` is the standard human-readable encoding for a Nostr private key. [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) wraps the raw 32-byte secret in a [Bech32](/topics/bech32) string that starts with the `nsec1` prefix. The matching public identity is usually shared as an [`npub`](/topics/npub) string.
 
 Whoever has the `nsec` can sign events, publish notes, change profile metadata, authorize client connections, and decrypt content tied to the same keypair. In practice, the `nsec` is the account. Users should keep it in a dedicated signer such as [Amber](/projects/amber), hardware-backed storage, or a [remote-signing](/topics/remote-signing) setup instead of pasting it into every client.
 


### PR DESCRIPTION
Adds a concise topic page explaining Nostr `npub` identifiers and links nearby Nostr topics to it.

- adds `/topics/npub`
- links existing `npub` mentions from Nostr, `nsec`, and NIP-05 topics

Build preview:
- [/topics](https://os-website-git-fix-issue-808-npub-topic-opensats.vercel.app/topics)
- [/topics/npub](https://os-website-git-fix-issue-808-npub-topic-opensats.vercel.app/topics/npub)

Fixes #808
