### PR TITLE
Clarify RED token reimbursement copy

### DIFF
--- a/components/RedApplicationForm.tsx
+++ b/components/RedApplicationForm.tsx
@@ -31,11 +31,11 @@ const REVIEW_SECTIONS: ReviewSection[] = [
     ],
   },
   {
-    title: 'Budget',
+    title: 'Token Reimbursement',
     fields: [
-      ['Token Spend So Far', 'token_spend_so_far'],
-      ['Expected Ongoing Burn', 'estimated_token_burn'],
-      ['Duration', 'duration'],
+      ['LLM Token Spend So Far', 'token_spend_so_far'],
+      ['Expected Ongoing Token Burn', 'estimated_token_burn'],
+      ['Reimbursement Window', 'duration'],
     ],
   },
 ]
@@ -66,7 +66,7 @@ const STEPS: StepConfig[] = [
   },
   {
     id: 'budget',
-    title: 'Budget',
+    title: 'Token Reimbursement',
     fields: ['token_spend_so_far', 'estimated_token_burn', 'duration'],
     render: (props) => <TokenReimbursement {...props} />,
   },
@@ -92,7 +92,7 @@ export default function RedApplicationForm() {
         red_terms_effective: RED_TERMS_EFFECTIVE,
       }}
       defaultValues={{ duration: '1 month' }}
-      submitLabel="Submit Red Application"
+      submitLabel="Submit RED Reimbursement Application"
       submitRequiresChecked={RED_ACK_FIELDS}
     />
   )

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -42,8 +42,8 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
             {...register('red_security_research', { required: true })}
           />
           <span>
-            I am applying for security research / red teaming support, not a
-            general project grant
+            I am applying for reimbursement of LLM token costs and related
+            compute costs tied to security research and red-teaming
           </span>
         </label>
 

--- a/components/grant-application/steps/TokenReimbursement.tsx
+++ b/components/grant-application/steps/TokenReimbursement.tsx
@@ -42,7 +42,7 @@ export default function TokenReimbursement({ register, errors }: StepProps) {
       <label className="block">
         Reimbursement Window *
         <br />
-        <small>How long do you expect the reimbursement need to last?</small>
+        <small>Expected duration of reimbursement</small>
         <select
           className={inputClass}
           {...register('duration', { required: true })}

--- a/components/grant-application/steps/TokenReimbursement.tsx
+++ b/components/grant-application/steps/TokenReimbursement.tsx
@@ -4,14 +4,18 @@ import { StepProps, inputClass } from '../types'
 export default function TokenReimbursement({ register, errors }: StepProps) {
   return (
     <>
-      <h2>Budget</h2>
+      <h2>Token Reimbursement</h2>
+      <p>
+        Keep this focused on direct LLM token and related compute costs for the
+        security research described above.
+      </p>
 
       <label className="block">
-        Token Spend So Far *
+        LLM Token Spend So Far *
         <br />
         <small>
-          Prefer USD; include approximate token spend too if you can. Mention
-          tools or providers if helpful.
+          List the providers or tools, the approximate token usage if useful,
+          and the USD amount you have already spent.
         </small>
         <textarea
           rows={4}
@@ -22,10 +26,10 @@ export default function TokenReimbursement({ register, errors }: StepProps) {
       </label>
 
       <label className="block">
-        Expected Ongoing Burn *<br />
+        Expected Ongoing Token Burn *<br />
         <small>
-          Rough estimate of monthly or ongoing spend while this research
-          continues.
+          Estimate the monthly or remaining spend needed to continue this
+          specific research.
         </small>
         <textarea
           rows={4}
@@ -36,9 +40,9 @@ export default function TokenReimbursement({ register, errors }: StepProps) {
       </label>
 
       <label className="block">
-        Duration *
+        Reimbursement Window *
         <br />
-        <small>How long do you need support for?</small>
+        <small>How long do you expect the reimbursement need to last?</small>
         <select
           className={inputClass}
           {...register('duration', { required: true })}

--- a/pages/apply/index.tsx
+++ b/pages/apply/index.tsx
@@ -117,19 +117,20 @@ export default function Apply({
           </>
         )}
         <h2 className="mb-4 mt-12 text-xl font-bold leading-normal md:text-2xl">
-          Red Teaming
+          RED Token Reimbursement
         </h2>
         <p className="mb-8">
           For security researchers red-teaming Bitcoin and related free and
-          open-source software. Short application focused on research context
-          and LLM token reimbursement. Always open. In light of recent events,
-          we are fast-tracking these applications.
+          open-source software. Short application focused on LLM token and
+          related compute reimbursement, with enough research context to assess
+          the work. Always open. In light of recent events, we are fast-tracking
+          these applications.
         </p>
         <Link
           href="/apply/red"
           className="rounded border border-orange-500 bg-transparent px-4 py-2 font-semibold text-orange-500 no-underline hover:text-black dark:hover:text-white"
         >
-          Apply for Red Teaming Support
+          Apply for RED Token Reimbursement
         </Link>
       </PageSection>
     </>

--- a/pages/apply/red.tsx
+++ b/pages/apply/red.tsx
@@ -25,27 +25,24 @@ export default function ApplyRed() {
           RED grants reimburse LLM token costs and closely related compute costs
           for researchers actively red-teaming Bitcoin and related free and
           open-source software. The application is short because the request
-          should be narrow: show the research context, the total spent up to
-          the date of this application, and the expected token burn.
+          should be narrow: show the research context, the total spent up to the
+          date of this application, and the expected token burn.
         </p>
         <p>
           OpenSats reviews RED requests as expense reimbursement tied to
           concrete security work. RED grants are not salary support, maintenance
-          funding, or broader project budgets. Use the{' '} <CustomLink
-          href="/apply/grant">General Grant</CustomLink> path for project
-          applications and funding.
+          funding, or broader project budgets. Use the{' '}
+          <CustomLink href="/apply/grant">General Grant</CustomLink> path for
+          project applications and funding.
         </p>
         <p>
           While{' '}
           <CustomLink href="/blog/code-red-supporting-first-responders">
             there is urgency
-          </CustomLink>{' '}
-          and we want to fund generously, we will be forced to be selective. A
-          demonstrable trail of trust or prior work in Bitcoin security (or a
-While {' '} <CustomLink href="/blog/code-red-supporting-first-responders">
-there is urgency </CustomLink>{' '}, we must be selective. A demonstrable
-trail of trust or prior work in Bitcoin security (or a closely related space)
-is expected.
+          </CustomLink>
+          {', '}
+          we must be selective. A demonstrable trail of trust or prior work in
+          Bitcoin security (or a closely related space) is expected.
         </p>
         <p>
           In light of recent events, we are fast-tracking these red team

--- a/pages/apply/red.tsx
+++ b/pages/apply/red.tsx
@@ -25,14 +25,15 @@ export default function ApplyRed() {
           RED grants reimburse LLM token costs and closely related compute costs
           for researchers actively red-teaming Bitcoin and related free and
           open-source software. The application is short because the request
-          should be narrow: show the research context, the spend so far, and the
-          expected token burn.
+          should be narrow: show the research context, the total spent up to
+          the date of this application, and the expected token burn.
         </p>
         <p>
           OpenSats reviews RED requests as expense reimbursement tied to
           concrete security work. RED grants are not salary support, maintenance
-          funding, or broader project budgets. Use the{' '}
-          <CustomLink href="/apply/grant">General Grant</CustomLink> path.
+          funding, or broader project budgets. Use the{' '} <CustomLink
+          href="/apply/grant">General Grant</CustomLink> path for project
+          applications and funding.
         </p>
         <p>
           While{' '}
@@ -41,7 +42,10 @@ export default function ApplyRed() {
           </CustomLink>{' '}
           and we want to fund generously, we will be forced to be selective. A
           demonstrable trail of trust or prior work in Bitcoin security (or a
-          closely related space) is expected.
+While {' '} <CustomLink href="/blog/code-red-supporting-first-responders">
+there is urgency </CustomLink>{' '}, we must be selective. A demonstrable
+trail of trust or prior work in Bitcoin security (or a closely related space)
+is expected.
         </p>
         <p>
           In light of recent events, we are fast-tracking these red team

--- a/pages/apply/red.tsx
+++ b/pages/apply/red.tsx
@@ -13,15 +13,26 @@ export default function ApplyRed() {
   return (
     <>
       <PageSEO
-        title="Apply for Red Teaming Support - OpenSats"
-        description="Apply for OpenSats red teaming support, including LLM token reimbursement for security research on Bitcoin software."
+        title="Apply for RED Token Reimbursement - OpenSats"
+        description="Apply for OpenSats RED grants: reimbursement for LLM token and related compute costs used in good-faith security research on Bitcoin software."
         slug="apply-red"
       />
-      <PageSection title="Red Teaming" image="/static/brand/logo-red.png">
+      <PageSection
+        title="RED Token Reimbursement"
+        image="/static/brand/logo-red.png"
+      >
         <p>
-          Finding exploits in Bitcoin and related free and open-source software
-          takes time, skill, and often a lot of LLM tokens. This short
-          application is for researchers doing that work.
+          RED grants reimburse LLM token costs and closely related compute costs
+          for researchers actively red-teaming Bitcoin and related free and
+          open-source software. The application is short because the request
+          should be narrow: show the research context, the spend so far, and the
+          expected token burn.
+        </p>
+        <p>
+          OpenSats reviews RED requests as expense reimbursement tied to
+          concrete security work. RED grants are not salary support, maintenance
+          funding, or broader project budgets. Use the{' '}
+          <CustomLink href="/apply/grant">General Grant</CustomLink> path.
         </p>
         <p>
           While{' '}
@@ -35,8 +46,7 @@ export default function ApplyRed() {
         <p>
           In light of recent events, we are fast-tracking these red team
           applications. If approved, we will follow up with any details needed
-          for payouts. Prefer a full project grant instead? See{' '}
-          <CustomLink href="/apply/grant">General Grant</CustomLink>.
+          for reimbursement.
         </p>
         <hr />
         <RedBeforeYouApply />

--- a/scripts/generate-page-og.mjs
+++ b/scripts/generate-page-og.mjs
@@ -155,7 +155,9 @@ function renderRedSvg(logoDataUri) {
 
       <image href="${logoDataUri}" x="${logoX}" y="${logoY}" width="${logoSize}" height="${logoSize}" />
 
-      <rect x="${PADDING}" y="${urlY - 36}" width="${CONTENT_WIDTH}" height="1" fill="#44403c" />
+      <rect x="${PADDING}" y="${
+    urlY - 36
+  }" width="${CONTENT_WIDTH}" height="1" fill="#44403c" />
       <text x="${PADDING}" y="${urlY}" fill="#a8a29e" font-size="22" font-family="${INTER_FONT_FAMILY}" letter-spacing="1">${escapeXml(
     pageUrl
   )}</text>
@@ -562,7 +564,9 @@ async function writeImage(slug, svg) {
 async function main() {
   await ensureCleanDir(outputDir)
   faviconDataUri = await loadFaviconDataUri()
-  const redLogoDataUri = await publicAssetToDataUri('/static/brand/logo-red.png')
+  const redLogoDataUri = await publicAssetToDataUri(
+    '/static/brand/logo-red.png'
+  )
   if (!redLogoDataUri) {
     throw new Error('Missing red logo at public/static/brand/logo-red.png')
   }


### PR DESCRIPTION
Clarifies the RED application flow so applicants understand that these grants reimburse LLM token and related compute costs tied to concrete security work.

- Updates `/apply/red` to frame RED grants as narrow expense reimbursement, not salary support or broad project funding
- Renames nearby application labels from generic budget/support language to token reimbursement language

---

Build preview:
- [/apply/red](https://os-website-git-content-red-llm-reimbursement-opensats.vercel.app/apply/red)
