### PR TITLE
Add entropy topic page

### DIFF
--- a/data/topics/bip-85.mdx
+++ b/data/topics/bip-85.mdx
@@ -5,7 +5,7 @@ category: 'Bitcoin'
 aliases: ['BIP85', 'deterministic entropy', 'child mnemonics', 'derived seeds']
 ---
 
-BIP 85 defines a way to derive fresh wallet entropy from one master [BIP 32](/topics/bip-32) root key. One root seed can produce separate child secrets for different devices, apps, and use cases, while still giving the user one backup to keep safe.
+BIP 85 defines a way to derive fresh wallet [entropy](/topics/entropy) from one master [BIP 32](/topics/bip-32) root key. One root seed can produce separate child secrets for different devices, apps, and use cases, while still giving the user one backup to keep safe.
 
 The standard derives a hardened child key and runs it through HMAC-SHA512 to produce application-specific entropy. Wallets can turn that entropy into a 12-word, 18-word, or 24-word BIP 39 mnemonic, an HD seed, a [WIF](/topics/wif), or other formats covered by the spec. Each child output stays isolated from the others, so one exposed child mnemonic does not expose the parent seed or sibling children.
 

--- a/data/topics/entropy.mdx
+++ b/data/topics/entropy.mdx
@@ -18,7 +18,7 @@ Good entropy does not just mean that something looks random to a person. It mean
 
 For Bitcoin wallets, entropy is usually turned into a seed phrase, a master seed, or a private key. BIP 39 mnemonics are generated from 128 to 256 bits of initial entropy plus a checksum, and [BIP 85](/topics/bip-85) can derive independent child entropy from one master root key. If the original entropy is weak or exposed, every key derived from it can be at risk.
 
-Entropy also appears outside wallets: protocols need unpredictable nonces, test suites rely on controlled randomness, and secure systems have to gather randomness from sources an attacker cannot predict. In every case, the useful question is not whether data looks messy, but how much uncertainty remains for the person trying to guess it.
+Entropy also appears outside wallets: protocols need unpredictable nonces, test suites rely on controlled randomness, and secure systems have to gather randomness from sources an attacker cannot predict. In every case, the useful question is not whether data looks messy, but how much uncertainty remains for the attacker trying to guess it.
 
 ## References
 

--- a/data/topics/entropy.mdx
+++ b/data/topics/entropy.mdx
@@ -1,0 +1,28 @@
+---
+title: 'Entropy'
+summary: 'A measure of uncertainty that, in Bitcoin security, describes how hard it is to guess a private key, seed, nonce, or other secret.'
+category: 'Bitcoin'
+aliases:
+  [
+    'randomness',
+    'wallet entropy',
+    'seed entropy',
+    'private key entropy',
+    'cryptographic entropy',
+  ]
+---
+
+Entropy is a measure of uncertainty. In cryptography, people usually use the word to describe how unpredictable a secret is to an attacker. A Bitcoin private key, seed phrase, nonce, or recovery secret needs enough entropy that guessing it remains infeasible.
+
+Good entropy does not just mean that something looks random to a person. It means the value came from a process with a large enough search space and no practical bias, reuse, or outside knowledge that narrows the attack. Human choices, timestamps, weak random number generators, and flawed hardware can all reduce effective entropy even when the final string appears random.
+
+For Bitcoin wallets, entropy is usually turned into a seed phrase, a master seed, or a private key. BIP 39 mnemonics are generated from 128 to 256 bits of initial entropy plus a checksum, and [BIP 85](/topics/bip-85) can derive independent child entropy from one master root key. If the original entropy is weak or exposed, every key derived from it can be at risk.
+
+Entropy also appears outside wallets: protocols need unpredictable nonces, test suites rely on controlled randomness, and secure systems have to gather randomness from sources an attacker cannot predict. In every case, the useful question is not whether data looks messy, but how much uncertainty remains for the person trying to guess it.
+
+## References
+
+- [Wikipedia: Entropy](https://en.wikipedia.org/wiki/Entropy)
+- [MIT Unified Engineering: Entropy on the microscopic scale](https://web.mit.edu/16.unified/www/FALL/thermodynamics/notes/node56.html)
+- [BIP 39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
+- [Bitcoin Security: Entropy](https://bitcoinsecurity.org/learn/entropy/)

--- a/scripts/generate-page-og.mjs
+++ b/scripts/generate-page-og.mjs
@@ -155,7 +155,9 @@ function renderRedSvg(logoDataUri) {
 
       <image href="${logoDataUri}" x="${logoX}" y="${logoY}" width="${logoSize}" height="${logoSize}" />
 
-      <rect x="${PADDING}" y="${urlY - 36}" width="${CONTENT_WIDTH}" height="1" fill="#44403c" />
+      <rect x="${PADDING}" y="${
+    urlY - 36
+  }" width="${CONTENT_WIDTH}" height="1" fill="#44403c" />
       <text x="${PADDING}" y="${urlY}" fill="#a8a29e" font-size="22" font-family="${INTER_FONT_FAMILY}" letter-spacing="1">${escapeXml(
     pageUrl
   )}</text>
@@ -562,7 +564,9 @@ async function writeImage(slug, svg) {
 async function main() {
   await ensureCleanDir(outputDir)
   faviconDataUri = await loadFaviconDataUri()
-  const redLogoDataUri = await publicAssetToDataUri('/static/brand/logo-red.png')
+  const redLogoDataUri = await publicAssetToDataUri(
+    '/static/brand/logo-red.png'
+  )
   if (!redLogoDataUri) {
     throw new Error('Missing red logo at public/static/brand/logo-red.png')
   }


### PR DESCRIPTION
Adds a concise topic page explaining entropy as uncertainty in cryptography and Bitcoin wallet security.

- adds `/topics/entropy`
- links the existing BIP 85 topic to the new entropy page

Build preview:
- [x] [/topics/entropy](https://os-website-git-content-add-entropy-topic-page-294-opensats.vercel.app/topics/entropy)

Closes OpenSats/content#294