### PR TITLE
Add mutation testing topic page

### DIFF
--- a/data/topics/fuzzing.mdx
+++ b/data/topics/fuzzing.mdx
@@ -18,7 +18,7 @@ Modern fuzzers usually mutate a seed corpus, keep inputs that reach new code pat
 
 Some fuzzers focus on one implementation at a time. **Differential fuzzing** compares two or more implementations with the same input and flags mismatches in parsing, validation, or serialization. That matters in Bitcoin and Lightning, where consensus and interoperability depend on separate codebases agreeing on the same rules.
 
-OpenSats funds projects that use fuzzing to harden critical freedom tech. [bitcoinfuzz](/projects/bitcoinfuzz) focuses on cross-implementation testing in the Bitcoin stack, and other grantees use fuzzing to improve protocol libraries, node software, and security tooling.
+OpenSats funds projects that use fuzzing to harden critical freedom tech. [bitcoinfuzz](/projects/bitcoinfuzz) focuses on cross-implementation testing in the Bitcoin stack, and other grantees use fuzzing, [mutation testing](/topics/mutation-testing), and related techniques to improve protocol libraries, node software, and security tooling.
 
 ## References
 

--- a/data/topics/mutation-testing.mdx
+++ b/data/topics/mutation-testing.mdx
@@ -1,0 +1,42 @@
+---
+title: 'Mutation testing'
+summary: 'A testing technique that deliberately changes small pieces of code to check whether the existing test suite catches the behavior change.'
+ogSummary: 'Deliberately changes code in small ways to measure whether a test suite catches real behavior changes.'
+category: 'Open Source'
+aliases:
+  [
+    'mutation analysis',
+    'mutant testing',
+    'mutation score',
+    'incremental mutation testing',
+  ]
+---
+
+Mutation testing measures the strength of a test suite by making small, deliberate
+changes to the code under test and then running the tests against each changed
+version. Each changed version is called a mutant. If the tests fail, the mutant
+is killed. If the tests still pass, the mutant survived and points to behavior
+the test suite may not actually verify.
+
+Common mutations include flipping comparison operators, changing boolean
+conditions, removing method calls, or replacing constants. These changes are
+simple on purpose: a useful mutation should be small enough that a good test
+would notice it, while still close to the kinds of mistakes developers can make
+when editing real code.
+
+Mutation testing complements ordinary unit tests and [fuzzing](/topics/fuzzing).
+Unit tests check known examples. Fuzzing explores large input spaces. Mutation
+testing asks a different question: if the implementation changed in a plausible
+way, would the current tests protect the behavior users and maintainers care
+about?
+
+For large projects, running every mutation against every test can be expensive.
+Incremental mutation testing reduces that cost by focusing on recently changed
+code, affected tests, and mutants that provide the most useful signal. That makes
+the technique more practical for security-sensitive open-source projects where
+small regressions can have outsized consequences.
+
+## References
+
+- [Wikipedia: Mutation testing](https://en.wikipedia.org/wiki/Mutation_testing)
+- [Delving Bitcoin: Incremental Mutation Testing in the Bitcoin Core](https://delvingbitcoin.org/t/incremental-mutation-testing-in-the-bitcoin-core/2197)


### PR DESCRIPTION
Adds a concise topic page explaining mutation testing as a way to measure whether a test suite catches small behavior changes.

- adds /topics/mutation-testing
- links the existing fuzzing topic to the new page

Build preview:
- [x] [/topics/mutation-testing](https://os-website-git-content-add-mutation-testing-topic-298-opensats.vercel.app/topics/mutation-testing)

Evidence:
- npx contentlayer build
- npm run generate:topic-og
- verified added external links with curl --head --location --fail
- verified the path-specific preview returned HTTP 200

Closes OpenSats/content#298