### PR TITLE
Make blog search full-text

### DIFF
--- a/components/PostList.tsx
+++ b/components/PostList.tsx
@@ -4,17 +4,34 @@ import type { Blog } from 'contentlayer/generated'
 import Link from '@/components/Link'
 import Tag from '@/components/Tag'
 import siteMetadata from '@/data/siteMetadata'
+import type { SearchExcerpt } from '@/utils/searchIndex'
 
 interface PostListProps {
   posts: CoreContent<Blog>[]
   rightAlignDate?: boolean
   useProjectLayout?: boolean
+  excerpts?: Record<string, SearchExcerpt>
+}
+
+function ExcerptText({ excerpt }: { excerpt: SearchExcerpt }) {
+  return (
+    <div className="prose max-w-none text-gray-500 dark:text-gray-400">
+      {excerpt.prefix && '...'}
+      {excerpt.before}
+      <mark className="bg-yellow-200 text-gray-900 dark:bg-yellow-700 dark:text-gray-100">
+        {excerpt.match}
+      </mark>
+      {excerpt.after}
+      {excerpt.suffix && '...'}
+    </div>
+  )
 }
 
 export default function PostList({
   posts,
   rightAlignDate = false,
   useProjectLayout = false,
+  excerpts,
 }: PostListProps) {
   if (posts.length === 0) {
     return null
@@ -23,7 +40,8 @@ export default function PostList({
   return (
     <ul>
       {posts.map((post) => {
-        const { path, date, title, summary, tags } = post
+        const { path, date, title, summary, tags, slug } = post
+        const excerpt = excerpts?.[slug]
         return (
           <li key={path} className="py-4">
             <article
@@ -67,10 +85,14 @@ export default function PostList({
                     </div>
                   )}
                 </div>
-                {summary && (
-                  <div className="prose max-w-none text-gray-500 dark:text-gray-400">
-                    {summary}
-                  </div>
+                {excerpt ? (
+                  <ExcerptText excerpt={excerpt} />
+                ) : (
+                  summary && (
+                    <div className="prose max-w-none text-gray-500 dark:text-gray-400">
+                      {summary}
+                    </div>
+                  )
                 )}
               </div>
             </article>

--- a/layouts/ListLayout.tsx
+++ b/layouts/ListLayout.tsx
@@ -5,6 +5,7 @@ import type { Blog } from 'contentlayer/generated'
 import Link from '@/components/Link'
 import PostList from '@/components/PostList'
 import {
+  excerptsForPosts,
   postMatchesSearch,
   searchStatusMessage,
   useSearchIndex,
@@ -125,7 +126,14 @@ export default function ListLayout({
           </div>
         </div>
         {statusMessage}
-        <PostList posts={displayPosts} />
+        <PostList
+          posts={displayPosts}
+          excerpts={
+            searchValue
+              ? excerptsForPosts(displayPosts, searchValue, index)
+              : undefined
+          }
+        />
       </div>
       {pagination && pagination.totalPages > 1 && !searchValue && (
         <Pagination

--- a/layouts/ListLayout.tsx
+++ b/layouts/ListLayout.tsx
@@ -4,6 +4,7 @@ import { CoreContent } from 'pliny/utils/contentlayer'
 import type { Blog } from 'contentlayer/generated'
 import Link from '@/components/Link'
 import PostList from '@/components/PostList'
+import { postMatchesSearch, useSearchIndex } from '@/utils/searchIndex'
 
 interface PaginationProps {
   totalPages: number
@@ -72,10 +73,10 @@ export default function ListLayout({
   pagination,
 }: ListLayoutProps) {
   const [searchValue, setSearchValue] = useState('')
-  const filteredBlogPosts = posts.filter((post) => {
-    const searchContent = post.title + post.summary + post.tags.join(' ')
-    return searchContent.toLowerCase().includes(searchValue.toLowerCase())
-  })
+  const { index, load } = useSearchIndex()
+  const filteredBlogPosts = posts.filter((post) =>
+    postMatchesSearch(post, searchValue, index)
+  )
 
   // If initialDisplayPosts exist, display it if no searchValue is specified
   const displayPosts =
@@ -93,6 +94,7 @@ export default function ListLayout({
               <input
                 aria-label="Search posts"
                 type="text"
+                onFocus={load}
                 onChange={(e) => setSearchValue(e.target.value)}
                 placeholder="Search posts"
                 className="block w-full rounded-md border border-gray-300 bg-white px-4 py-2 text-gray-900 focus:border-primary-500 focus:ring-primary-500 dark:border-gray-900 dark:bg-gray-800 dark:text-gray-100"

--- a/layouts/ListLayout.tsx
+++ b/layouts/ListLayout.tsx
@@ -4,7 +4,11 @@ import { CoreContent } from 'pliny/utils/contentlayer'
 import type { Blog } from 'contentlayer/generated'
 import Link from '@/components/Link'
 import PostList from '@/components/PostList'
-import { postMatchesSearch, useSearchIndex } from '@/utils/searchIndex'
+import {
+  postMatchesSearch,
+  searchStatusMessage,
+  useSearchIndex,
+} from '@/utils/searchIndex'
 
 interface PaginationProps {
   totalPages: number
@@ -73,9 +77,14 @@ export default function ListLayout({
   pagination,
 }: ListLayoutProps) {
   const [searchValue, setSearchValue] = useState('')
-  const { index, load } = useSearchIndex()
+  const { index, ready } = useSearchIndex()
   const filteredBlogPosts = posts.filter((post) =>
     postMatchesSearch(post, searchValue, index)
+  )
+  const statusMessage = searchStatusMessage(
+    searchValue,
+    ready,
+    filteredBlogPosts.length
   )
 
   // If initialDisplayPosts exist, display it if no searchValue is specified
@@ -94,11 +103,7 @@ export default function ListLayout({
               <input
                 aria-label="Search posts"
                 type="text"
-                onFocus={load}
-                onChange={(e) => {
-                  load()
-                  setSearchValue(e.target.value)
-                }}
+                onChange={(e) => setSearchValue(e.target.value)}
                 placeholder="Search posts"
                 className="block w-full rounded-md border border-gray-300 bg-white px-4 py-2 text-gray-900 focus:border-primary-500 focus:ring-primary-500 dark:border-gray-900 dark:bg-gray-800 dark:text-gray-100"
               />
@@ -119,7 +124,7 @@ export default function ListLayout({
             </svg>
           </div>
         </div>
-        {!filteredBlogPosts.length && 'No posts found.'}
+        {statusMessage}
         <PostList posts={displayPosts} />
       </div>
       {pagination && pagination.totalPages > 1 && !searchValue && (

--- a/layouts/ListLayout.tsx
+++ b/layouts/ListLayout.tsx
@@ -95,7 +95,10 @@ export default function ListLayout({
                 aria-label="Search posts"
                 type="text"
                 onFocus={load}
-                onChange={(e) => setSearchValue(e.target.value)}
+                onChange={(e) => {
+                  load()
+                  setSearchValue(e.target.value)
+                }}
                 placeholder="Search posts"
                 className="block w-full rounded-md border border-gray-300 bg-white px-4 py-2 text-gray-900 focus:border-primary-500 focus:ring-primary-500 dark:border-gray-900 dark:bg-gray-800 dark:text-gray-100"
               />

--- a/pages/year/[year].tsx
+++ b/pages/year/[year].tsx
@@ -185,7 +185,10 @@ export default function YearPage({
                   aria-label="Search posts"
                   type="text"
                   onFocus={load}
-                  onChange={(e) => setSearchValue(e.target.value)}
+                  onChange={(e) => {
+                    load()
+                    setSearchValue(e.target.value)
+                  }}
                   placeholder=""
                   className="block w-full rounded-md border border-gray-300 bg-white px-4 py-2 text-gray-900 focus:border-primary-500 focus:ring-primary-500 dark:border-gray-900 dark:bg-gray-800 dark:text-gray-100"
                 />

--- a/pages/year/[year].tsx
+++ b/pages/year/[year].tsx
@@ -10,6 +10,7 @@ import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from 'next'
 import { allBlogs } from 'contentlayer/generated'
 import type { Blog } from 'contentlayer/generated'
 import PostList from '@/components/PostList'
+import { postMatchesSearch, useSearchIndex } from '@/utils/searchIndex'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   faChevronLeft,
@@ -143,6 +144,7 @@ export default function YearPage({
     new Set(allTagsCombined)
   )
   const [searchValue, setSearchValue] = useState('')
+  const { index, load } = useSearchIndex()
 
   const handleTagToggle = (tag: string) => {
     setSelectedTags((prev) => {
@@ -161,11 +163,7 @@ export default function YearPage({
 
   const filteredPosts = (posts as CoreContent<Blog>[]).filter((post) => {
     const matchesTags = post.tags?.some((tag) => selectedTags.has(tag))
-    const searchContent = post.title + post.summary + post.tags?.join(' ')
-    const matchesSearch = searchContent
-      .toLowerCase()
-      .includes(searchValue.toLowerCase())
-    return matchesTags && matchesSearch
+    return matchesTags && postMatchesSearch(post, searchValue, index)
   })
 
   return (
@@ -186,6 +184,7 @@ export default function YearPage({
                 <input
                   aria-label="Search posts"
                   type="text"
+                  onFocus={load}
                   onChange={(e) => setSearchValue(e.target.value)}
                   placeholder=""
                   className="block w-full rounded-md border border-gray-300 bg-white px-4 py-2 text-gray-900 focus:border-primary-500 focus:ring-primary-500 dark:border-gray-900 dark:bg-gray-800 dark:text-gray-100"

--- a/pages/year/[year].tsx
+++ b/pages/year/[year].tsx
@@ -11,6 +11,7 @@ import { allBlogs } from 'contentlayer/generated'
 import type { Blog } from 'contentlayer/generated'
 import PostList from '@/components/PostList'
 import {
+  excerptsForPosts,
   postMatchesSearch,
   searchStatusMessage,
   useSearchIndex,
@@ -225,7 +226,14 @@ export default function YearPage({
           />
         </div>
         {statusMessage}
-        <PostList posts={filteredPosts} />
+        <PostList
+          posts={filteredPosts}
+          excerpts={
+            searchValue
+              ? excerptsForPosts(filteredPosts, searchValue, index)
+              : undefined
+          }
+        />
       </div>
     </>
   )

--- a/pages/year/[year].tsx
+++ b/pages/year/[year].tsx
@@ -10,7 +10,11 @@ import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from 'next'
 import { allBlogs } from 'contentlayer/generated'
 import type { Blog } from 'contentlayer/generated'
 import PostList from '@/components/PostList'
-import { postMatchesSearch, useSearchIndex } from '@/utils/searchIndex'
+import {
+  postMatchesSearch,
+  searchStatusMessage,
+  useSearchIndex,
+} from '@/utils/searchIndex'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   faChevronLeft,
@@ -144,7 +148,7 @@ export default function YearPage({
     new Set(allTagsCombined)
   )
   const [searchValue, setSearchValue] = useState('')
-  const { index, load } = useSearchIndex()
+  const { index, ready } = useSearchIndex()
 
   const handleTagToggle = (tag: string) => {
     setSelectedTags((prev) => {
@@ -165,6 +169,11 @@ export default function YearPage({
     const matchesTags = post.tags?.some((tag) => selectedTags.has(tag))
     return matchesTags && postMatchesSearch(post, searchValue, index)
   })
+  const statusMessage = searchStatusMessage(
+    searchValue,
+    ready,
+    filteredPosts.length
+  )
 
   return (
     <>
@@ -184,11 +193,7 @@ export default function YearPage({
                 <input
                   aria-label="Search posts"
                   type="text"
-                  onFocus={load}
-                  onChange={(e) => {
-                    load()
-                    setSearchValue(e.target.value)
-                  }}
+                  onChange={(e) => setSearchValue(e.target.value)}
                   placeholder=""
                   className="block w-full rounded-md border border-gray-300 bg-white px-4 py-2 text-gray-900 focus:border-primary-500 focus:ring-primary-500 dark:border-gray-900 dark:bg-gray-800 dark:text-gray-100"
                 />
@@ -219,7 +224,7 @@ export default function YearPage({
             onSelectNone={handleSelectNone}
           />
         </div>
-        {!filteredPosts.length && 'No posts found.'}
+        {statusMessage}
         <PostList posts={filteredPosts} />
       </div>
     </>

--- a/scripts/search.mjs
+++ b/scripts/search.mjs
@@ -1,27 +1,27 @@
 import { writeFileSync, readFileSync } from 'fs'
-import { allCoreContent } from 'pliny/utils/contentlayer.js'
-import siteMetadata from '../data/siteMetadata.js'
 import { fileURLToPath } from 'url'
 import { dirname, join } from 'path'
+import { stripMarkdownForSearch } from '../utils/relatedPosts.ts'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
 const search = async () => {
-  // Read the blog data directly from the JSON file
   const blogDataPath = join(
     __dirname,
     '../.contentlayer/generated/Blog/_index.json'
   )
   const allBlogs = JSON.parse(readFileSync(blogDataPath, 'utf8'))
 
-  if (siteMetadata?.search?.kbarConfig?.searchDocumentsPath) {
-    writeFileSync(
-      `public/${siteMetadata.search.kbarConfig.searchDocumentsPath}`,
-      JSON.stringify(allCoreContent(allBlogs))
-    )
-    console.log('Local search index generated...')
-  }
+  const index = Object.fromEntries(
+    allBlogs.map((post) => [
+      post.slug,
+      stripMarkdownForSearch(post.body?.raw || ''),
+    ])
+  )
+
+  writeFileSync('public/search.json', JSON.stringify(index))
+  console.log('Local search index generated...')
 }
 
 export default search

--- a/utils/relatedPosts.ts
+++ b/utils/relatedPosts.ts
@@ -4,7 +4,7 @@ function escapeRegExp(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
-function stripMarkdownForSearch(raw = ''): string {
+export function stripMarkdownForSearch(raw = ''): string {
   return raw
     .replace(/```[\s\S]*?```/g, ' ')
     .replace(/`[^`]*`/g, ' ')

--- a/utils/searchIndex.ts
+++ b/utils/searchIndex.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 export type SearchIndex = Record<string, string>
 
@@ -10,10 +10,12 @@ export type SearchablePost = {
 }
 
 let cache: SearchIndex | null = null
+let failed = false
 let inflight: Promise<SearchIndex | null> | null = null
 
 function fetchSearchIndex(): Promise<SearchIndex | null> {
   if (cache) return Promise.resolve(cache)
+  if (failed) return Promise.resolve(null)
   if (inflight) return inflight
 
   inflight = fetch('/search.json')
@@ -25,7 +27,10 @@ function fetchSearchIndex(): Promise<SearchIndex | null> {
       cache = data
       return data
     })
-    .catch(() => null)
+    .catch(() => {
+      failed = true
+      return null
+    })
     .finally(() => {
       inflight = null
     })
@@ -35,16 +40,22 @@ function fetchSearchIndex(): Promise<SearchIndex | null> {
 
 export function useSearchIndex() {
   const [index, setIndex] = useState<SearchIndex | null>(cache)
+  const [ready, setReady] = useState(cache !== null || failed)
 
-  const load = useCallback(() => {
-    if (cache) {
+  useEffect(() => {
+    if (cache !== null || failed) {
       setIndex(cache)
+      setReady(true)
       return
     }
-    fetchSearchIndex().then(setIndex)
+
+    fetchSearchIndex().then((data) => {
+      setIndex(data)
+      setReady(true)
+    })
   }, [])
 
-  return { index, load }
+  return { index, ready }
 }
 
 export function postMatchesSearch(
@@ -65,4 +76,15 @@ export function postMatchesSearch(
     .toLowerCase()
 
   return haystack.includes(q)
+}
+
+export function searchStatusMessage(
+  query: string,
+  ready: boolean,
+  matchCount: number
+): string | null {
+  if (!query) return null
+  if (!ready) return 'Searching…'
+  if (!matchCount) return 'No posts found.'
+  return null
 }

--- a/utils/searchIndex.ts
+++ b/utils/searchIndex.ts
@@ -1,0 +1,68 @@
+import { useCallback, useState } from 'react'
+
+export type SearchIndex = Record<string, string>
+
+export type SearchablePost = {
+  title?: string
+  summary?: string
+  tags?: string[]
+  slug: string
+}
+
+let cache: SearchIndex | null = null
+let inflight: Promise<SearchIndex | null> | null = null
+
+function fetchSearchIndex(): Promise<SearchIndex | null> {
+  if (cache) return Promise.resolve(cache)
+  if (inflight) return inflight
+
+  inflight = fetch('/search.json')
+    .then((res) => {
+      if (!res.ok) throw new Error('search index missing')
+      return res.json() as Promise<SearchIndex>
+    })
+    .then((data) => {
+      cache = data
+      return data
+    })
+    .catch(() => null)
+    .finally(() => {
+      inflight = null
+    })
+
+  return inflight
+}
+
+export function useSearchIndex() {
+  const [index, setIndex] = useState<SearchIndex | null>(cache)
+
+  const load = useCallback(() => {
+    if (cache) {
+      setIndex(cache)
+      return
+    }
+    fetchSearchIndex().then(setIndex)
+  }, [])
+
+  return { index, load }
+}
+
+export function postMatchesSearch(
+  post: SearchablePost,
+  query: string,
+  index: SearchIndex | null
+): boolean {
+  const q = query.trim().toLowerCase()
+  if (!q) return true
+
+  const haystack = [
+    post.title || '',
+    post.summary || '',
+    (post.tags || []).join(' '),
+    index?.[post.slug] || '',
+  ]
+    .join(' ')
+    .toLowerCase()
+
+  return haystack.includes(q)
+}

--- a/utils/searchIndex.ts
+++ b/utils/searchIndex.ts
@@ -88,3 +88,60 @@ export function searchStatusMessage(
   if (!matchCount) return 'No posts found.'
   return null
 }
+
+export type SearchExcerpt = {
+  prefix: boolean
+  before: string
+  match: string
+  after: string
+  suffix: boolean
+}
+
+const EXCERPT_RADIUS = 40
+
+export function getSearchExcerpt(
+  post: SearchablePost,
+  query: string,
+  index: SearchIndex | null
+): SearchExcerpt | null {
+  const q = query.trim()
+  if (!q) return null
+
+  const text = [post.summary || '', index?.[post.slug] || '']
+    .filter(Boolean)
+    .join(' ')
+  const hit = text.toLowerCase().indexOf(q.toLowerCase())
+  if (hit < 0) return null
+
+  let start = Math.max(0, hit - EXCERPT_RADIUS)
+  let end = Math.min(text.length, hit + q.length + EXCERPT_RADIUS)
+  if (start > 0) {
+    const space = text.indexOf(' ', start)
+    if (space !== -1 && space < hit) start = space + 1
+  }
+  if (end < text.length) {
+    const space = text.lastIndexOf(' ', end)
+    if (space > hit + q.length) end = space
+  }
+
+  return {
+    prefix: start > 0,
+    before: text.slice(start, hit),
+    match: text.slice(hit, hit + q.length),
+    after: text.slice(hit + q.length, end),
+    suffix: end < text.length,
+  }
+}
+
+export function excerptsForPosts(
+  posts: SearchablePost[],
+  query: string,
+  index: SearchIndex | null
+): Record<string, SearchExcerpt> {
+  const excerpts: Record<string, SearchExcerpt> = {}
+  for (const post of posts) {
+    const excerpt = getSearchExcerpt(post, query, index)
+    if (excerpt) excerpts[post.slug] = excerpt
+  }
+  return excerpts
+}


### PR DESCRIPTION
Blog search on `/blog` and year archives now matches post body text, not just title, summary, and tags. Postbuild writes a slug-to-plain-text map to `public/search.json`, and the search box loads it on first use. Tracked in OpenSats/operations#689.

- Reuses `stripMarkdownForSearch` so the index stays DRY with related-post matching
- Shared `postMatchesSearch` matcher; pagination still hides while you search
- Falls back to title/summary/tags if the index is missing (e.g. `next dev` before postbuild)

Build preview: 
- [/blog](https://os-website-git-fix-blog-search-opensats.vercel.app/blog)
