### PR TITLE
Enforce 3-month minimum grant duration

### DIFF
--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -151,7 +151,7 @@ export default function GrantApplicationForm() {
     <MultiStepApplicationForm
       steps={STEPS}
       hiddenFields={{ general_fund: true }}
-      defaultValues={{ duration: '6 months' }}
+      defaultValues={{ duration: '3 months' }}
       submitLabel="Submit Grant Application"
     />
   )

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -1,3 +1,4 @@
+import { areApplicationsOpen } from '@/utils/applicationWindow'
 import MultiStepApplicationForm, {
   StepConfig,
 } from './grant-application/MultiStepApplicationForm'
@@ -153,6 +154,7 @@ export default function GrantApplicationForm() {
       hiddenFields={{ general_fund: true }}
       defaultValues={{ duration: '3 months' }}
       submitLabel="Submit Grant Application"
+      allowSubmit={areApplicationsOpen()}
     />
   )
 }

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -151,7 +151,7 @@ export default function GrantApplicationForm() {
     <MultiStepApplicationForm
       steps={STEPS}
       hiddenFields={{ general_fund: true }}
-      defaultValues={{ duration: '6 months' }}
+      defaultValues={{ duration: 6 }}
       submitLabel="Submit Grant Application"
     />
   )

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -151,7 +151,7 @@ export default function GrantApplicationForm() {
     <MultiStepApplicationForm
       steps={STEPS}
       hiddenFields={{ general_fund: true }}
-      defaultValues={{ duration: 6 }}
+      defaultValues={{ duration: '6 months' }}
       submitLabel="Submit Grant Application"
     />
   )

--- a/components/grant-application/MultiStepApplicationForm.tsx
+++ b/components/grant-application/MultiStepApplicationForm.tsx
@@ -26,6 +26,8 @@ interface MultiStepApplicationFormProps {
   submitLabel: string
   /** When set, submit stays disabled until every listed field is truthy. */
   submitRequiresChecked?: readonly string[]
+  /** Preview builds can show the form while applications are closed. */
+  allowSubmit?: boolean
 }
 
 export default function MultiStepApplicationForm({
@@ -34,6 +36,7 @@ export default function MultiStepApplicationForm({
   defaultValues,
   submitLabel,
   submitRequiresChecked,
+  allowSubmit = true,
 }: MultiStepApplicationFormProps) {
   const [currentStep, setCurrentStep] = useState(0)
   const [loading, setLoading] = useState(false)
@@ -98,12 +101,19 @@ export default function MultiStepApplicationForm({
   }, [isLastStep])
 
   const submitDisabled =
+    !allowSubmit ||
     !!submitRequiresChecked?.some((name) => !watch(name)) ||
-    (isLastStep && !turnstileReady)
+    (isLastStep && allowSubmit && !turnstileReady)
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const onSubmit = async (data: any) => {
-    if (currentStep !== steps.length - 1 || loading || submitDisabled) return
+    if (
+      !allowSubmit ||
+      currentStep !== steps.length - 1 ||
+      loading ||
+      submitDisabled
+    )
+      return
 
     setLoading(true)
     setFailureReason(undefined)
@@ -153,13 +163,20 @@ export default function MultiStepApplicationForm({
 
       {steps[currentStep].render(stepProps)}
 
-      {isLastStep && (
+      {isLastStep && allowSubmit && (
         <div className="my-8 flex flex-col items-center py-2">
           <TurnstileWidget
             ref={turnstileRef}
             onTokenChange={(token) => setTurnstileReady(!!token)}
           />
         </div>
+      )}
+
+      {isLastStep && !allowSubmit && (
+        <p className="rounded bg-yellow-100 p-4 text-yellow-900">
+          This preview is for review only. Applications are closed, so
+          submissions are disabled.
+        </p>
       )}
 
       <StepNavigation

--- a/components/grant-application/MultiStepApplicationForm.tsx
+++ b/components/grant-application/MultiStepApplicationForm.tsx
@@ -113,11 +113,7 @@ export default function MultiStepApplicationForm({
       if (!turnstile) {
         throw new Error('Please complete the bot verification challenge.')
       }
-      const payload =
-        typeof data.duration === 'number'
-          ? { ...data, duration: `${data.duration} months` }
-          : data
-      await submitApplication(payload, undefined, turnstile)
+      await submitApplication(data, undefined, turnstile)
       await router.push('/submitted')
     } catch (e) {
       const nextFailures = failedAttempts + 1

--- a/components/grant-application/MultiStepApplicationForm.tsx
+++ b/components/grant-application/MultiStepApplicationForm.tsx
@@ -113,7 +113,11 @@ export default function MultiStepApplicationForm({
       if (!turnstile) {
         throw new Error('Please complete the bot verification challenge.')
       }
-      await submitApplication(data, undefined, turnstile)
+      const payload =
+        typeof data.duration === 'number'
+          ? { ...data, duration: `${data.duration} months` }
+          : data
+      await submitApplication(payload, undefined, turnstile)
       await router.push('/submitted')
     } catch (e) {
       const nextFailures = failedAttempts + 1

--- a/components/grant-application/steps/Review.tsx
+++ b/components/grant-application/steps/Review.tsx
@@ -11,14 +11,8 @@ interface ReviewProps {
   sections: readonly ReviewSection[]
 }
 
-const formatValue = (value: unknown, name?: string) => {
+const formatValue = (value: unknown) => {
   if (typeof value === 'boolean') return value ? 'Yes' : 'No'
-  if (typeof value === 'number') {
-    if (name === 'duration') {
-      return value === 1 ? '1 month' : `${value} months`
-    }
-    return String(value)
-  }
   if (typeof value === 'string') return value.trim()
   return ''
 }
@@ -40,7 +34,7 @@ export default function Review({ watch, sections }: ReviewProps) {
             <h3>{section.title}</h3>
             <dl className="space-y-3">
               {section.fields.map(([label, name]) => {
-                const value = formatValue(values[name], name)
+                const value = formatValue(values[name])
                 if (!value) return null
 
                 return (

--- a/components/grant-application/steps/Review.tsx
+++ b/components/grant-application/steps/Review.tsx
@@ -11,8 +11,14 @@ interface ReviewProps {
   sections: readonly ReviewSection[]
 }
 
-const formatValue = (value: unknown) => {
+const formatValue = (value: unknown, name?: string) => {
   if (typeof value === 'boolean') return value ? 'Yes' : 'No'
+  if (typeof value === 'number') {
+    if (name === 'duration') {
+      return value === 1 ? '1 month' : `${value} months`
+    }
+    return String(value)
+  }
   if (typeof value === 'string') return value.trim()
   return ''
 }
@@ -34,7 +40,7 @@ export default function Review({ watch, sections }: ReviewProps) {
             <h3>{section.title}</h3>
             <dl className="space-y-3">
               {section.fields.map(([label, name]) => {
-                const value = formatValue(values[name])
+                const value = formatValue(values[name], name)
                 if (!value) return null
 
                 return (

--- a/components/grant-application/steps/Timeline.tsx
+++ b/components/grant-application/steps/Timeline.tsx
@@ -11,7 +11,7 @@ export default function Timeline({ register, errors }: StepProps) {
         Duration
         <br />
         <small>
-          How long are you applying for? General grants must be between 3 and 12
+          How long are you applying for? General grants are 3, 6, 9, or 12
           months.{' '}
           <CustomLink href="/faq/application#what-is-the-minimum-grant-duration">
             Why?
@@ -21,11 +21,10 @@ export default function Timeline({ register, errors }: StepProps) {
           className={inputClass}
           {...register('duration', { required: true })}
         >
-          {Array.from({ length: 10 }, (_, i) => i + 3).map((months) => (
-            <option key={months} value={`${months} months`}>
-              {months} months
-            </option>
-          ))}
+          <option value="12 months">12 months</option>
+          <option value="9 months">9 months</option>
+          <option value="6 months">6 months</option>
+          <option value="3 months">3 months</option>
         </select>
         <FieldError errors={errors} name="duration" />
       </label>

--- a/components/grant-application/steps/Timeline.tsx
+++ b/components/grant-application/steps/Timeline.tsx
@@ -11,10 +11,9 @@ export default function Timeline({ register, errors }: StepProps) {
         Duration
         <br />
         <small>
-          How long are you applying for? General grants are 3, 6, 9, or 12
-          months.{' '}
+          Duration of grant you are applying for.{' '}
           <CustomLink href="/faq/application#what-is-the-minimum-grant-duration">
-            Why?
+            Minimum is 3 months.
           </CustomLink>
         </small>
         <select

--- a/components/grant-application/steps/Timeline.tsx
+++ b/components/grant-application/steps/Timeline.tsx
@@ -11,10 +11,11 @@ export default function Timeline({ register, errors }: StepProps) {
         Duration
         <br />
         <small>
-          Duration of grant you are applying for.{' '}
+          Duration of grant you are applying for. More on grant duration in our{' '}
           <CustomLink href="/faq/application#what-is-the-minimum-grant-duration">
-            Minimum is 3 months.
+            FAQ
           </CustomLink>
+          .
         </small>
         <select
           className={inputClass}

--- a/components/grant-application/steps/Timeline.tsx
+++ b/components/grant-application/steps/Timeline.tsx
@@ -1,3 +1,4 @@
+import CustomLink from '@/components/Link'
 import FieldError from '../FieldError'
 import { StepProps, inputClass } from '../types'
 
@@ -7,19 +8,43 @@ export default function Timeline({ register, errors }: StepProps) {
       <h2>Project Timeline</h2>
 
       <label className="block">
-        Duration
+        Duration (months)
         <br />
-        <small>Duration of grant you are applying for</small>
-        <select
+        <small>
+          How many months are you applying for? General grants must be between 3
+          and 12 months. We do not accept shorter durations.{' '}
+          <CustomLink href="/faq/application#what-is-the-minimum-grant-duration">
+            Why?
+          </CustomLink>
+        </small>
+        <input
+          type="number"
+          min={3}
+          max={12}
+          step={1}
           className={inputClass}
-          {...register('duration', { required: true })}
-        >
-          <option value="12 months">12 months</option>
-          <option value="9 months">9 months</option>
-          <option value="6 months">6 months</option>
-          <option value="3 months">3 months</option>
-          <option value="Other">Other (please elaborate below)</option>
-        </select>
+          {...register('duration', {
+            required: true,
+            valueAsNumber: true,
+            min: {
+              value: 3,
+              message: 'Minimum grant duration is 3 months',
+            },
+            max: {
+              value: 12,
+              message: 'Maximum grant duration is 12 months',
+            },
+            validate: (value) => {
+              if (typeof value !== 'number' || Number.isNaN(value)) {
+                return 'This field is required'
+              }
+              if (!Number.isInteger(value)) {
+                return 'Enter a whole number of months'
+              }
+              return true
+            },
+          })}
+        />
         <FieldError errors={errors} name="duration" />
       </label>
 

--- a/components/grant-application/steps/Timeline.tsx
+++ b/components/grant-application/steps/Timeline.tsx
@@ -8,43 +8,25 @@ export default function Timeline({ register, errors }: StepProps) {
       <h2>Project Timeline</h2>
 
       <label className="block">
-        Duration (months)
+        Duration
         <br />
         <small>
-          How many months are you applying for? General grants must be between 3
-          and 12 months. We do not accept shorter durations.{' '}
+          How long are you applying for? General grants must be between 3 and 12
+          months.{' '}
           <CustomLink href="/faq/application#what-is-the-minimum-grant-duration">
             Why?
           </CustomLink>
         </small>
-        <input
-          type="number"
-          min={3}
-          max={12}
-          step={1}
+        <select
           className={inputClass}
-          {...register('duration', {
-            required: true,
-            valueAsNumber: true,
-            min: {
-              value: 3,
-              message: 'Minimum grant duration is 3 months',
-            },
-            max: {
-              value: 12,
-              message: 'Maximum grant duration is 12 months',
-            },
-            validate: (value) => {
-              if (typeof value !== 'number' || Number.isNaN(value)) {
-                return 'This field is required'
-              }
-              if (!Number.isInteger(value)) {
-                return 'Enter a whole number of months'
-              }
-              return true
-            },
-          })}
-        />
+          {...register('duration', { required: true })}
+        >
+          {Array.from({ length: 10 }, (_, i) => i + 3).map((months) => (
+            <option key={months} value={`${months} months`}>
+              {months} months
+            </option>
+          ))}
+        </select>
         <FieldError errors={errors} name="duration" />
       </label>
 

--- a/components/grant-application/steps/Timeline.tsx
+++ b/components/grant-application/steps/Timeline.tsx
@@ -21,10 +21,10 @@ export default function Timeline({ register, errors }: StepProps) {
           className={inputClass}
           {...register('duration', { required: true })}
         >
-          <option value="12 months">12 months</option>
-          <option value="9 months">9 months</option>
-          <option value="6 months">6 months</option>
           <option value="3 months">3 months</option>
+          <option value="6 months">6 months</option>
+          <option value="9 months">9 months</option>
+          <option value="12 months">12 months</option>
         </select>
         <FieldError errors={errors} name="duration" />
       </label>

--- a/data/pages/faq-application.mdx
+++ b/data/pages/faq-application.mdx
@@ -28,6 +28,7 @@ not covered below.
 - [What does it mean to produce work under a free and open-source license?](#what-does-it-mean-to-produce-work-under-a-free-and-open-source-license)
 - [Can grants be part-time or only full-time?](#can-grants-be-part-time-or-only-full-time)
 - [What is the minimum grant duration?](#what-is-the-minimum-grant-duration)
+- [What is the maximum grant duration?](#what-is-the-maximum-grant-duration)
 - [How can I increase my funding chances?](#how-can-i-increase-my-funding-chances)
 - [What are you looking for in terms of references?](#what-are-you-looking-for-in-terms-of-references)
 - [If my application is rejected, can I reapply?](#if-my-application-is-rejected-can-i-reapply)
@@ -134,6 +135,11 @@ shorter periods.
 
 [RED token reimbursements](/apply/red) are an exception and may request a
 shorter window.
+
+### What is the maximum grant duration?
+
+Regular grants have a maximum duration of 12 months. [LTS grants](/apply/lts)
+can be longer.
 
 ### How can I increase my funding chances?
 

--- a/data/pages/faq-application.mdx
+++ b/data/pages/faq-application.mdx
@@ -130,7 +130,7 @@ commitment with corresponding levels of financial support.
 ### What is the minimum grant duration?
 
 General grants are 3, 6, 9, or 12 months. We do not accept applications for
-shorter periods. If you are unsure, apply for 6 months.
+shorter periods.
 
 [RED token reimbursements](/apply/red) are an exception and may request a
 shorter window.

--- a/data/pages/faq-application.mdx
+++ b/data/pages/faq-application.mdx
@@ -27,6 +27,7 @@ not covered below.
 - [What are the requirements of OpenSats grants?](#what-are-the-requirements-of-opensats-grants)
 - [What does it mean to produce work under a free and open-source license?](#what-does-it-mean-to-produce-work-under-a-free-and-open-source-license)
 - [Can grants be part-time or only full-time?](#can-grants-be-part-time-or-only-full-time)
+- [What is the minimum grant duration?](#what-is-the-minimum-grant-duration)
 - [How can I increase my funding chances?](#how-can-i-increase-my-funding-chances)
 - [What are you looking for in terms of references?](#what-are-you-looking-for-in-terms-of-references)
 - [If my application is rejected, can I reapply?](#if-my-application-is-rejected-can-i-reapply)
@@ -125,6 +126,14 @@ publish them later, is not compliant with our grant agreement.
 
 Grants can be full-time or part-time. We can accommodate different levels of
 commitment with corresponding levels of financial support.
+
+### What is the minimum grant duration?
+
+General grants must be at least 3 months and at most 12 months. We do not
+accept applications for shorter periods. If you are unsure, apply for 6 months.
+
+[RED token reimbursements](/apply/red) are an exception and may request a
+shorter window.
 
 ### How can I increase my funding chances?
 

--- a/data/pages/faq-application.mdx
+++ b/data/pages/faq-application.mdx
@@ -130,8 +130,8 @@ commitment with corresponding levels of financial support.
 
 ### What is the minimum grant duration?
 
-General grants are 3, 6, 9, or 12 months. We do not accept applications for
-shorter periods.
+The minimum duration for a general grant is 3 months. We do not accept
+applications for shorter periods.
 
 [RED token reimbursements](/apply/red) are an exception and may request a
 shorter window.

--- a/data/pages/faq-application.mdx
+++ b/data/pages/faq-application.mdx
@@ -129,8 +129,8 @@ commitment with corresponding levels of financial support.
 
 ### What is the minimum grant duration?
 
-General grants must be at least 3 months and at most 12 months. We do not
-accept applications for shorter periods. If you are unsure, apply for 6 months.
+General grants are 3, 6, 9, or 12 months. We do not accept applications for
+shorter periods. If you are unsure, apply for 6 months.
 
 [RED token reimbursements](/apply/red) are an exception and may request a
 shorter window.

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next/types'
 import { sendApplicationEmails } from '@/utils/application-emails'
 import { assertTurnstile, TURNSTILE_FAILURE_MESSAGE } from '@/utils/turnstile'
+import { areApplicationsOpen } from '@/utils/applicationWindow'
 import {
   getApplicationIssueLabels,
   getApplicationRepo,
@@ -19,6 +20,12 @@ export default async function handler(
   res: NextApiResponse
 ) {
   if (req.method === 'POST') {
+    if (!req.body.RED && !areApplicationsOpen()) {
+      return res.status(403).json({
+        message: 'Grant applications are currently closed.',
+      })
+    }
+
     if (!(await assertTurnstile(req))) {
       return res.status(403).json({ message: TURNSTILE_FAILURE_MESSAGE })
     }

--- a/pages/apply/grant.tsx
+++ b/pages/apply/grant.tsx
@@ -2,7 +2,7 @@ import dynamic from 'next/dynamic'
 import PageSection from '@/components/PageSection'
 import { PageSEO } from '@/components/SEO'
 import ClosedNotice from '@/components/ClosedNotice'
-import { areApplicationsOpen } from '@/utils/applicationWindow'
+import { showGrantApplicationForm } from '@/utils/applicationWindow'
 
 const GrantApplicationForm = dynamic(
   () => import('@/components/GrantApplicationForm'),
@@ -31,7 +31,7 @@ export default function Apply() {
           from OpenSats.
         </p>
         <ClosedNotice />
-        {areApplicationsOpen() && <GrantApplicationForm />}
+        {showGrantApplicationForm() && <GrantApplicationForm />}
       </PageSection>
     </>
   )

--- a/public/static/opensats-grant-application-template.md
+++ b/public/static/opensats-grant-application-template.md
@@ -63,7 +63,7 @@ visual materials that showcase your project.
 
 ## Timeline
 
-**Duration:** (3 months / 6 months / 9 months / 12 months / Other)
+**Duration:** (3-12 months)
 
 **Time Commitment:** (25% - Side Project / 50% - Part Time / 75% - Part Time / 100% - Full Time)
 

--- a/public/static/opensats-grant-application-template.md
+++ b/public/static/opensats-grant-application-template.md
@@ -63,7 +63,7 @@ visual materials that showcase your project.
 
 ## Timeline
 
-**Duration:** (3-12 months)
+**Duration:** (3 months to 12 months)
 
 **Time Commitment:** (25% - Side Project / 50% - Part Time / 75% - Part Time / 100% - Full Time)
 

--- a/public/static/opensats-grant-application-template.md
+++ b/public/static/opensats-grant-application-template.md
@@ -63,7 +63,7 @@ visual materials that showcase your project.
 
 ## Timeline
 
-**Duration:** (3 months to 12 months)
+**Duration:** (3 months / 6 months / 9 months / 12 months)
 
 **Time Commitment:** (25% - Side Project / 50% - Part Time / 75% - Part Time / 100% - Full Time)
 

--- a/utils/applicationWindow.ts
+++ b/utils/applicationWindow.ts
@@ -2,3 +2,14 @@
 export function areApplicationsOpen(date = new Date()): boolean {
   return date.getMonth() % 3 !== 2
 }
+
+export function isVercelPreview(): boolean {
+  return (
+    process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview' ||
+    process.env.VERCEL_ENV === 'preview'
+  )
+}
+
+export function showGrantApplicationForm(): boolean {
+  return areApplicationsOpen() || isVercelPreview()
+}


### PR DESCRIPTION
Removes `Other` from the grant duration dropdown so applicants pick 3, 6, 9, or 12 months, defaulting to 3 months. Adds application FAQ entries for the 3-month minimum and 12-month maximum. Fixes OpenSats/operations#650.

- Duration options are sorted shortest to longest
- Form helper links to the duration FAQ
- RED can be shorter; LTS can be longer than 12 months
- Vercel previews show the form for review; regular submissions stay closed

Build preview: 
- [/apply/grant](https://os-website-git-fix-minimum-grant-duration-opensats.vercel.app/apply/grant)
- [/faq/application](https://os-website-git-fix-minimum-grant-duration-opensats.vercel.app/faq/application)
