### PR TITLE
Add AI cost and a USD grand total to the grant budget

### DIFF
--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -63,6 +63,7 @@ const REVIEW_SECTIONS: ReviewSection[] = [
     fields: [
       ['Costs & Proposed Budget', 'proposed_budget'],
       ['AI / Compute Cost', 'ai_cost'],
+      ['Grand Total', 'grand_total'],
       ['Prior Funding', 'has_received_funding'],
       ['Prior Funding Details', 'what_funding'],
       ['Additional Funding Sources', 'has_additional_funding'],
@@ -126,6 +127,7 @@ const STEPS: StepConfig[] = [
     fields: [
       'proposed_budget',
       'ai_cost',
+      'grand_total',
       'has_received_funding',
       'what_funding',
       'has_additional_funding',

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -62,6 +62,7 @@ const REVIEW_SECTIONS: ReviewSection[] = [
     title: 'Budget',
     fields: [
       ['Costs & Proposed Budget', 'proposed_budget'],
+      ['AI / Compute Cost', 'ai_cost'],
       ['Prior Funding', 'has_received_funding'],
       ['Prior Funding Details', 'what_funding'],
       ['Additional Funding Sources', 'has_additional_funding'],
@@ -124,6 +125,7 @@ const STEPS: StepConfig[] = [
     title: 'Budget',
     fields: [
       'proposed_budget',
+      'ai_cost',
       'has_received_funding',
       'what_funding',
       'has_additional_funding',

--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -138,7 +138,12 @@ const STEPS: StepConfig[] = [
   {
     id: 'anything_else',
     title: 'Final',
-    fields: ['no_vibed_garbage', 'human_in_charge', 'discipline_and_agency'],
+    fields: [
+      'no_vibed_garbage',
+      'human_in_charge',
+      'discipline_and_agency',
+      'video_application',
+    ],
     render: (props) => <AnythingElse {...props} />,
   },
   {

--- a/components/grant-application/UsdAmountInput.tsx
+++ b/components/grant-application/UsdAmountInput.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react'
+import { FieldErrors, UseFormRegister } from 'react-hook-form'
+import { formatUsd, parseUsd } from '@/utils/usd'
+import FieldError from './FieldError'
+import { FormValues, inputClass } from './types'
+
+interface UsdAmountInputProps {
+  name: string
+  register: UseFormRegister<FormValues>
+  errors: FieldErrors<FormValues>
+  defaultAmount?: unknown
+}
+
+export default function UsdAmountInput({
+  name,
+  register,
+  errors,
+  defaultAmount,
+}: UsdAmountInputProps) {
+  const initial = parseUsd(defaultAmount)
+  const [text, setText] = useState(initial === undefined ? '' : formatUsd(initial))
+  const registration = register(name, {
+    required: 'Enter a dollar amount',
+    setValueAs: parseUsd,
+    validate: (value) =>
+      (typeof value === 'number' && Number.isFinite(value) && value >= 0) ||
+      'Enter a dollar amount',
+  })
+
+  return (
+    <>
+      <div className="relative mt-1 max-w-xs">
+        <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 font-mono text-black">
+          $
+        </span>
+        <input
+          {...registration}
+          type="text"
+          inputMode="decimal"
+          autoComplete="off"
+          className={`${inputClass} mt-0 pl-8`}
+          value={text}
+          onChange={(event) => {
+            setText(event.target.value)
+            void registration.onChange(event)
+          }}
+          onBlur={(event) => {
+            const amount = parseUsd(event.target.value)
+            setText(amount === undefined ? '' : formatUsd(amount))
+            void registration.onBlur(event)
+          }}
+        />
+      </div>
+      <FieldError errors={errors} name={name} />
+    </>
+  )
+}

--- a/components/grant-application/UsdAmountInput.tsx
+++ b/components/grant-application/UsdAmountInput.tsx
@@ -6,6 +6,8 @@ import { FormValues, inputClass } from './types'
 
 interface UsdAmountInputProps {
   name: string
+  label: string
+  hint?: string
   register: UseFormRegister<FormValues>
   errors: FieldErrors<FormValues>
   defaultAmount?: unknown
@@ -13,12 +15,16 @@ interface UsdAmountInputProps {
 
 export default function UsdAmountInput({
   name,
+  label,
+  hint,
   register,
   errors,
   defaultAmount,
 }: UsdAmountInputProps) {
   const initial = parseUsd(defaultAmount)
-  const [text, setText] = useState(initial === undefined ? '' : formatUsd(initial))
+  const [text, setText] = useState(
+    initial === undefined ? '' : formatUsd(initial)
+  )
   const registration = register(name, {
     required: 'Enter a dollar amount',
     setValueAs: parseUsd,
@@ -28,7 +34,14 @@ export default function UsdAmountInput({
   })
 
   return (
-    <>
+    <label className="block">
+      {label}
+      {hint ? (
+        <>
+          <br />
+          <small>{hint}</small>
+        </>
+      ) : null}
       <div className="relative mt-1 max-w-xs">
         <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 font-mono text-black">
           $
@@ -52,6 +65,6 @@ export default function UsdAmountInput({
         />
       </div>
       <FieldError errors={errors} name={name} />
-    </>
+    </label>
   )
 }

--- a/components/grant-application/steps/AnythingElse.tsx
+++ b/components/grant-application/steps/AnythingElse.tsx
@@ -1,5 +1,7 @@
 import CustomLink from '@/components/Link'
+import { isHttpUrl, isVideoRequired } from '@/utils/grantRules'
 import CheckboxGroupError from '../CheckboxGroupError'
+import FieldError from '../FieldError'
 import { StepProps, inputClass, checkboxClass } from '../types'
 
 const VIBE_CHECK_FIELDS = [
@@ -8,7 +10,12 @@ const VIBE_CHECK_FIELDS = [
   'discipline_and_agency',
 ] as const
 
-export default function AnythingElse({ register, errors }: StepProps) {
+export default function AnythingElse({ register, watch, errors }: StepProps) {
+  const videoRequired = isVideoRequired({
+    LTS: watch('LTS'),
+    RED: watch('RED'),
+    grand_total: watch('grand_total'),
+  })
   return (
     <>
       <h2>Vibe Check</h2>
@@ -60,17 +67,32 @@ export default function AnythingElse({ register, errors }: StepProps) {
       <h2>Video Application</h2>
 
       <label className="block">
+        Video Link {videoRequired ? '*' : ''}
+        <br />
         <small>
-          We strongly encourage you to record a short video (around 2 minutes)
-          explaining your project and why it matters. This is optional but can
-          make a real difference. Please provide a link to the video below.
+          {videoRequired ? '' : 'Optional. '}
+          The video must be <strong>exactly 2 minutes</strong> long. We explain
+          why in the{' '}
+          <CustomLink href="/faq/application#why-do-i-have-to-submit-a-video">
+            FAQ
+          </CustomLink>
+          .
         </small>
         <input
           type="text"
           placeholder="https://"
           className={inputClass}
-          {...register('video_application')}
+          {...register('video_application', {
+            validate: (value) => {
+              const trimmed = typeof value === 'string' ? value.trim() : ''
+              if (!trimmed) {
+                return videoRequired ? 'A video link is required' : true
+              }
+              return isHttpUrl(trimmed) || 'Enter a valid URL'
+            },
+          })}
         />
+        <FieldError errors={errors} name="video_application" />
       </label>
 
       <hr />

--- a/components/grant-application/steps/Budget.tsx
+++ b/components/grant-application/steps/Budget.tsx
@@ -11,7 +11,7 @@ export default function Budget({ register, watch, errors }: StepProps) {
         Costs & Proposed Budget *<br />
         <small>
           Please submit a proposed budget in USD, including a breakdown of how
-          the funds will be used. Enter the grand total in the field below.
+          the funds will be used. 
         </small>
         <textarea
           rows={5}

--- a/components/grant-application/steps/Budget.tsx
+++ b/components/grant-application/steps/Budget.tsx
@@ -25,8 +25,8 @@ export default function Budget({ register, watch, errors }: StepProps) {
           AI / Compute Cost *
           <br />
           <small>
-            LLM tokens, APIs, and hardware if you want to self-host models. None
-            or $0 is fine. We are happy to fund this when it helps the work.
+            LLM tokens, APIs, and similar cost items related to working with
+            coding agents. None or $0 is fine too.
           </small>
           <textarea
             rows={4}

--- a/components/grant-application/steps/Budget.tsx
+++ b/components/grant-application/steps/Budget.tsx
@@ -1,4 +1,5 @@
 import FieldError from '../FieldError'
+import UsdAmountInput from '../UsdAmountInput'
 import { StepProps, inputClass } from '../types'
 
 export default function Budget({ register, watch, errors }: StepProps) {
@@ -10,7 +11,7 @@ export default function Budget({ register, watch, errors }: StepProps) {
         Costs & Proposed Budget *<br />
         <small>
           Please submit a proposed budget in USD, including a breakdown of how
-          the funds will be used and the grand total.
+          the funds will be used. Enter the grand total in the field below.
         </small>
         <textarea
           rows={5}
@@ -21,20 +22,34 @@ export default function Budget({ register, watch, errors }: StepProps) {
       </label>
 
       {!watch('LTS') && (
-        <label className="block">
-          AI / Compute Cost *
-          <br />
-          <small>
-            LLM tokens, APIs, and similar cost items related to working with
-            coding agents. None or $0 is fine too.
-          </small>
-          <textarea
-            rows={4}
-            className={inputClass}
-            {...register('ai_cost', { required: true })}
-          />
-          <FieldError errors={errors} name="ai_cost" />
-        </label>
+        <>
+          <label className="block">
+            AI / Compute Cost *
+            <br />
+            <small>
+              LLM tokens, APIs, and similar cost items related to working with
+              coding agents. None or $0 is fine too.
+            </small>
+            <textarea
+              rows={4}
+              className={inputClass}
+              {...register('ai_cost', { required: true })}
+            />
+            <FieldError errors={errors} name="ai_cost" />
+          </label>
+
+          <label className="block">
+            Grand Total *
+            <br />
+            <small>Total amount requested, in USD.</small>
+            <UsdAmountInput
+              name="grand_total"
+              register={register}
+              errors={errors}
+              defaultAmount={watch('grand_total')}
+            />
+          </label>
+        </>
       )}
 
       <hr />

--- a/components/grant-application/steps/Budget.tsx
+++ b/components/grant-application/steps/Budget.tsx
@@ -38,17 +38,14 @@ export default function Budget({ register, watch, errors }: StepProps) {
             <FieldError errors={errors} name="ai_cost" />
           </label>
 
-          <label className="block">
-            Grand Total *
-            <br />
-            <small>Total amount requested, in USD.</small>
-            <UsdAmountInput
-              name="grand_total"
-              register={register}
-              errors={errors}
-              defaultAmount={watch('grand_total')}
-            />
-          </label>
+          <UsdAmountInput
+            name="grand_total"
+            label="Grand Total *"
+            hint="Total amount requested, in USD."
+            register={register}
+            errors={errors}
+            defaultAmount={watch('grand_total')}
+          />
         </>
       )}
 

--- a/components/grant-application/steps/Budget.tsx
+++ b/components/grant-application/steps/Budget.tsx
@@ -11,7 +11,7 @@ export default function Budget({ register, watch, errors }: StepProps) {
         Costs & Proposed Budget *<br />
         <small>
           Please submit a proposed budget in USD, including a breakdown of how
-          the funds will be used. 
+          the funds will be used.
         </small>
         <textarea
           rows={5}

--- a/components/grant-application/steps/Budget.tsx
+++ b/components/grant-application/steps/Budget.tsx
@@ -20,6 +20,23 @@ export default function Budget({ register, watch, errors }: StepProps) {
         <FieldError errors={errors} name="proposed_budget" />
       </label>
 
+      {!watch('LTS') && (
+        <label className="block">
+          AI / Compute Cost *
+          <br />
+          <small>
+            LLM tokens, APIs, and hardware if you want to self-host models. None
+            or $0 is fine. We are happy to fund this when it helps the work.
+          </small>
+          <textarea
+            rows={4}
+            className={inputClass}
+            {...register('ai_cost', { required: true })}
+          />
+          <FieldError errors={errors} name="ai_cost" />
+        </label>
+      )}
+
       <hr />
       <h2>Prior Funding</h2>
 

--- a/components/grant-application/steps/Budget.tsx
+++ b/components/grant-application/steps/Budget.tsx
@@ -28,7 +28,7 @@ export default function Budget({ register, watch, errors }: StepProps) {
             <br />
             <small>
               LLM tokens, APIs, and similar cost items related to working with
-              coding agents. None or $0 is fine too.
+              coding agents, if applicable. None or $0 is fine too.
             </small>
             <textarea
               rows={4}

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -118,7 +118,11 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
         />
         <span>
           I have read the{' '}
-          <CustomLink href="/faq/application">Application FAQ</CustomLink>
+          <CustomLink href="/faq/application">Application FAQ</CustomLink>,
+          including the{' '}
+          <CustomLink href="/faq/application#why-do-i-have-to-submit-a-video">
+            video section
+          </CustomLink>
         </span>
       </label>
 

--- a/components/grant-application/steps/Review.tsx
+++ b/components/grant-application/steps/Review.tsx
@@ -1,4 +1,5 @@
 import { UseFormWatch } from 'react-hook-form'
+import { formatUsdDisplay } from '@/utils/usd'
 import { FormValues } from '../types'
 
 export interface ReviewSection {
@@ -11,8 +12,10 @@ interface ReviewProps {
   sections: readonly ReviewSection[]
 }
 
-const formatValue = (value: unknown) => {
+const formatValue = (value: unknown, name?: string) => {
   if (typeof value === 'boolean') return value ? 'Yes' : 'No'
+  if (name === 'grand_total') return formatUsdDisplay(value)
+  if (typeof value === 'number') return String(value)
   if (typeof value === 'string') return value.trim()
   return ''
 }
@@ -34,7 +37,7 @@ export default function Review({ watch, sections }: ReviewProps) {
             <h3>{section.title}</h3>
             <dl className="space-y-3">
               {section.fields.map(([label, name]) => {
-                const value = formatValue(values[name])
+                const value = formatValue(values[name], name)
                 if (!value) return null
 
                 return (

--- a/data/pages/faq-application.mdx
+++ b/data/pages/faq-application.mdx
@@ -29,6 +29,7 @@ not covered below.
 - [Can grants be part-time or only full-time?](#can-grants-be-part-time-or-only-full-time)
 - [What is the minimum grant duration?](#what-is-the-minimum-grant-duration)
 - [What is the maximum grant duration?](#what-is-the-maximum-grant-duration)
+- [Why do I have to submit a video?](#why-do-i-have-to-submit-a-video)
 - [How can I increase my funding chances?](#how-can-i-increase-my-funding-chances)
 - [What are you looking for in terms of references?](#what-are-you-looking-for-in-terms-of-references)
 - [If my application is rejected, can I reapply?](#if-my-application-is-rejected-can-i-reapply)
@@ -140,6 +141,20 @@ shorter window.
 
 Regular grants have a maximum duration of 12 months. [LTS grants](/apply/lts)
 can be longer.
+
+### Why do I have to submit a video?
+
+The video is how we can tell that you read the form, that you are the one applying
+(not a bot or someone else), and that the application is not spam. It also
+shows us that you can produce a short video and talk about your project. If you
+cannot describe what you are doing in 2 minutes, then having more time will not help. That
+is why it has to be exactly 2 minutes. We do not care where the video is
+hosted, as long as the link is easily accessible.
+
+Hiding your face is fine. That said, we expect a human voice-over at least.
+
+Videos with the wrong duration, or videos that are fully AI-generated, will be
+discarded along with the application.
 
 ### How can I increase my funding chances?
 

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -120,6 +120,9 @@ ${req.body.timelines || ''}
 
 ${req.body.proposed_budget}
 
+**AI / compute cost:**
+${req.body.ai_cost || 'n/a'}
+
 **Prior funding:** ${req.body.has_received_funding === 'yes' ? 'Yes' : 'No'}
 
 ${req.body.what_funding ? req.body.what_funding : ''}

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next/types'
 import { sendApplicationEmails } from '@/utils/application-emails'
 import { assertTurnstile, TURNSTILE_FAILURE_MESSAGE } from '@/utils/turnstile'
 import { areApplicationsOpen } from '@/utils/applicationWindow'
+import { formatUsdDisplay } from '@/utils/usd'
 import {
   getApplicationIssueLabels,
   getApplicationRepo,
@@ -122,6 +123,8 @@ ${req.body.proposed_budget}
 
 **AI / compute cost:**
 ${req.body.ai_cost || 'n/a'}
+
+**Grand total:** ${formatUsdDisplay(req.body.grand_total) || 'n/a'}
 
 **Prior funding:** ${req.body.has_received_funding === 'yes' ? 'Yes' : 'No'}
 

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next/types'
 import { sendApplicationEmails } from '@/utils/application-emails'
 import { assertTurnstile, TURNSTILE_FAILURE_MESSAGE } from '@/utils/turnstile'
 import { areApplicationsOpen } from '@/utils/applicationWindow'
+import { isHttpUrl, isVideoRequired } from '@/utils/grantRules'
 import { formatUsdDisplay } from '@/utils/usd'
 import {
   getApplicationIssueLabels,
@@ -24,6 +25,21 @@ export default async function handler(
     if (!req.body.RED && !areApplicationsOpen()) {
       return res.status(403).json({
         message: 'Grant applications are currently closed.',
+      })
+    }
+
+    const videoLink =
+      typeof req.body.video_application === 'string'
+        ? req.body.video_application.trim()
+        : ''
+    if (isVideoRequired(req.body) && !videoLink) {
+      return res.status(400).json({
+        message: 'A video link is required.',
+      })
+    }
+    if (videoLink && !isHttpUrl(videoLink)) {
+      return res.status(400).json({
+        message: 'Enter a valid URL.',
       })
     }
 

--- a/public/static/opensats-grant-application-template.md
+++ b/public/static/opensats-grant-application-template.md
@@ -106,8 +106,8 @@ If yes, please describe the additional funding sources and amounts:
 
 ## Video Application
 
-We strongly encourage you to record a short video, around 2 minutes, explaining
-your project and why it matters.
+A video is required. It must be exactly 2 minutes long. Paste a public link.
+See the Application FAQ for why the length matters.
 
 **Video Link:**
 

--- a/public/static/opensats-grant-application-template.md
+++ b/public/static/opensats-grant-application-template.md
@@ -78,12 +78,16 @@ This will help us evaluate overall scope and potential grant duration.
 ### Costs & Proposed Budget
 
 Please submit a proposed budget in USD, including a breakdown of how the funds
-will be used and the grand total.
+will be used. Enter the grand total in the field below.
 
 ### AI / Compute Cost
 
 LLM tokens, APIs, and similar cost items related to working with coding
 agents. None or $0 is fine too.
+
+### Grand Total
+
+Total amount requested, in USD.
 
 ### Prior Funding
 

--- a/public/static/opensats-grant-application-template.md
+++ b/public/static/opensats-grant-application-template.md
@@ -80,6 +80,11 @@ This will help us evaluate overall scope and potential grant duration.
 Please submit a proposed budget in USD, including a breakdown of how the funds
 will be used and the grand total.
 
+### AI / Compute Cost
+
+LLM tokens, APIs, and hardware if you want to self-host models. None or $0 is
+fine. We are happy to fund this when it helps the work.
+
 ### Prior Funding
 
 Has this project received prior funding? (Yes / No)

--- a/public/static/opensats-grant-application-template.md
+++ b/public/static/opensats-grant-application-template.md
@@ -82,8 +82,8 @@ will be used and the grand total.
 
 ### AI / Compute Cost
 
-LLM tokens, APIs, and hardware if you want to self-host models. None or $0 is
-fine. We are happy to fund this when it helps the work.
+LLM tokens, APIs, and similar cost items related to working with coding
+agents. None or $0 is fine too.
 
 ### Prior Funding
 

--- a/utils/grantRules.ts
+++ b/utils/grantRules.ts
@@ -1,0 +1,24 @@
+import { parseUsd } from './usd'
+
+const VIDEO_REQUIRED_USD = 21_000
+
+/** Video is required on general grants of $21k or more. LTS and RED skip it. */
+export function isVideoRequired(application: {
+  LTS?: unknown
+  RED?: unknown
+  grand_total?: unknown
+}): boolean {
+  if (application.LTS || application.RED) return false
+  const amount = parseUsd(application.grand_total)
+  return amount !== undefined && amount >= VIDEO_REQUIRED_USD
+}
+
+export function isHttpUrl(value: unknown): boolean {
+  if (typeof value !== 'string') return false
+  try {
+    const url = new URL(value.trim())
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+}

--- a/utils/usd.ts
+++ b/utils/usd.ts
@@ -1,0 +1,29 @@
+export function parseUsd(value: unknown): number | undefined {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined
+  }
+  if (typeof value !== 'string') return undefined
+
+  const cleaned = value.replace(/[^0-9.]/g, '')
+  if (!cleaned || cleaned === '.') return undefined
+
+  const [whole, ...rest] = cleaned.split('.')
+  const normalized = rest.length
+    ? `${whole || '0'}.${rest.join('').slice(0, 2)}`
+    : whole
+  const amount = Number(normalized)
+  return Number.isFinite(amount) ? amount : undefined
+}
+
+export function formatUsd(amount: number): string {
+  return amount.toLocaleString('en-US', {
+    minimumFractionDigits: Number.isInteger(amount) ? 0 : 2,
+    maximumFractionDigits: 2,
+  })
+}
+
+export function formatUsdDisplay(value: unknown): string {
+  const amount = parseUsd(value)
+  if (amount === undefined) return ''
+  return `$${formatUsd(amount)}`
+}


### PR DESCRIPTION
Splits AI/compute cost and the grand total out of the general grant budget. `ai_cost` is a required textarea for tokens, APIs, and similar coding-agent spend (none or `$0` is fine). `grand_total` is a USD `$` input stored as a number so later review can do things like `grand_total > 21000`. Hidden on LTS. Fixes OpenSats/operations#648.

- Both fields sit under Costs & Proposed Budget
- Review step, GitHub issue body, and the offline template include them
- Grand total formats on blur (`21000` becomes `21,000`)

Build preview: 
- [/apply/grant](https://os-website-git-feat-ai-cost-budget-opensats.vercel.app/apply/grant)
