### PR TITLE
Require a 2-minute video for grant applications

### DIFF
--- a/components/GrantApplicationForm.tsx
+++ b/components/GrantApplicationForm.tsx
@@ -138,7 +138,12 @@ const STEPS: StepConfig[] = [
   {
     id: 'anything_else',
     title: 'Final',
-    fields: ['no_vibed_garbage', 'human_in_charge', 'discipline_and_agency'],
+    fields: [
+      'no_vibed_garbage',
+      'human_in_charge',
+      'discipline_and_agency',
+      'video_application',
+    ],
     render: (props) => <AnythingElse {...props} />,
   },
   {

--- a/components/grant-application/steps/AnythingElse.tsx
+++ b/components/grant-application/steps/AnythingElse.tsx
@@ -14,6 +14,7 @@ export default function AnythingElse({ register, watch, errors }: StepProps) {
   const videoRequired = isVideoRequired({
     LTS: watch('LTS'),
     RED: watch('RED'),
+    grand_total: watch('grand_total'),
   })
   return (
     <>

--- a/components/grant-application/steps/AnythingElse.tsx
+++ b/components/grant-application/steps/AnythingElse.tsx
@@ -1,5 +1,5 @@
 import CustomLink from '@/components/Link'
-import { isVideoRequired } from '@/utils/grantRules'
+import { isHttpUrl, isVideoRequired } from '@/utils/grantRules'
 import CheckboxGroupError from '../CheckboxGroupError'
 import FieldError from '../FieldError'
 import { StepProps, inputClass, checkboxClass } from '../types'
@@ -83,10 +83,13 @@ export default function AnythingElse({ register, watch, errors }: StepProps) {
           placeholder="https://"
           className={inputClass}
           {...register('video_application', {
-            validate: (value) =>
-              !videoRequired ||
-              (typeof value === 'string' && value.trim().length > 0) ||
-              'A video link is required',
+            validate: (value) => {
+              const trimmed = typeof value === 'string' ? value.trim() : ''
+              if (!trimmed) {
+                return videoRequired ? 'A video link is required' : true
+              }
+              return isHttpUrl(trimmed) || 'Enter a valid URL'
+            },
           })}
         />
         <FieldError errors={errors} name="video_application" />

--- a/components/grant-application/steps/AnythingElse.tsx
+++ b/components/grant-application/steps/AnythingElse.tsx
@@ -69,7 +69,7 @@ export default function AnythingElse({ register, watch, errors }: StepProps) {
           {videoRequired ? '' : 'Optional. '}
           The video must be <strong>exactly 2 minutes</strong> long. We explain
           why in the{' '}
-          <CustomLink href="/faq/application#why-does-the-video-have-to-be-exactly-2-minutes">
+          <CustomLink href="/faq/application#why-do-i-have-to-submit-a-video">
             FAQ
           </CustomLink>
           .

--- a/components/grant-application/steps/AnythingElse.tsx
+++ b/components/grant-application/steps/AnythingElse.tsx
@@ -11,7 +11,10 @@ const VIBE_CHECK_FIELDS = [
 ] as const
 
 export default function AnythingElse({ register, watch, errors }: StepProps) {
-  const videoRequired = !watch('LTS') && isVideoRequired(watch('grand_total'))
+  const videoRequired = isVideoRequired({
+    LTS: watch('LTS'),
+    RED: watch('RED'),
+  })
   return (
     <>
       <h2>Vibe Check</h2>
@@ -78,7 +81,12 @@ export default function AnythingElse({ register, watch, errors }: StepProps) {
           type="text"
           placeholder="https://"
           className={inputClass}
-          {...register('video_application', { required: videoRequired })}
+          {...register('video_application', {
+            validate: (value) =>
+              !videoRequired ||
+              (typeof value === 'string' && value.trim().length > 0) ||
+              'A video link is required',
+          })}
         />
         <FieldError errors={errors} name="video_application" />
       </label>

--- a/components/grant-application/steps/AnythingElse.tsx
+++ b/components/grant-application/steps/AnythingElse.tsx
@@ -67,8 +67,12 @@ export default function AnythingElse({ register, watch, errors }: StepProps) {
         <br />
         <small>
           {videoRequired ? '' : 'Optional. '}
-          It must be exactly 2 minutes and 10 seconds (2:10). Paste a link
-          below.
+          The video must be <strong>exactly 2 minutes</strong> long. We explain
+          why in the{' '}
+          <CustomLink href="/faq/application#why-does-the-video-have-to-be-exactly-2-minutes">
+            FAQ
+          </CustomLink>
+          .
         </small>
         <input
           type="text"

--- a/components/grant-application/steps/AnythingElse.tsx
+++ b/components/grant-application/steps/AnythingElse.tsx
@@ -1,5 +1,5 @@
 import CustomLink from '@/components/Link'
-import { isVideoRequired, VIDEO_REQUIRED_LABEL } from '@/utils/grantRules'
+import { isVideoRequired } from '@/utils/grantRules'
 import CheckboxGroupError from '../CheckboxGroupError'
 import FieldError from '../FieldError'
 import { StepProps, inputClass, checkboxClass } from '../types'
@@ -11,13 +11,7 @@ const VIBE_CHECK_FIELDS = [
 ] as const
 
 export default function AnythingElse({ register, watch, errors }: StepProps) {
-  const isLts = Boolean(watch('LTS'))
-  const videoRequired = !isLts && isVideoRequired(watch('grand_total'))
-  const videoLead = isLts
-    ? 'We strongly encourage a short video explaining your project and why it matters. '
-    : videoRequired
-    ? `A video is required for requests of ${VIDEO_REQUIRED_LABEL} or more. `
-    : `A video is optional unless you are requesting ${VIDEO_REQUIRED_LABEL} or more. `
+  const videoRequired = !watch('LTS') && isVideoRequired(watch('grand_total'))
   return (
     <>
       <h2>Vibe Check</h2>
@@ -72,7 +66,7 @@ export default function AnythingElse({ register, watch, errors }: StepProps) {
         Video Link {videoRequired ? '*' : ''}
         <br />
         <small>
-          {videoLead}
+          {videoRequired ? '' : 'Optional. '}
           It must be exactly 2 minutes and 10 seconds (2:10). Paste a link
           below. We do not host uploads.
         </small>
@@ -80,11 +74,7 @@ export default function AnythingElse({ register, watch, errors }: StepProps) {
           type="text"
           placeholder="https://"
           className={inputClass}
-          {...register('video_application', {
-            required: videoRequired
-              ? `A video link is required for requests of ${VIDEO_REQUIRED_LABEL} or more`
-              : false,
-          })}
+          {...register('video_application', { required: videoRequired })}
         />
         <FieldError errors={errors} name="video_application" />
       </label>

--- a/components/grant-application/steps/AnythingElse.tsx
+++ b/components/grant-application/steps/AnythingElse.tsx
@@ -1,5 +1,7 @@
 import CustomLink from '@/components/Link'
+import { isVideoRequired, VIDEO_REQUIRED_LABEL } from '@/utils/grantRules'
 import CheckboxGroupError from '../CheckboxGroupError'
+import FieldError from '../FieldError'
 import { StepProps, inputClass, checkboxClass } from '../types'
 
 const VIBE_CHECK_FIELDS = [
@@ -8,7 +10,14 @@ const VIBE_CHECK_FIELDS = [
   'discipline_and_agency',
 ] as const
 
-export default function AnythingElse({ register, errors }: StepProps) {
+export default function AnythingElse({ register, watch, errors }: StepProps) {
+  const isLts = Boolean(watch('LTS'))
+  const videoRequired = !isLts && isVideoRequired(watch('grand_total'))
+  const videoLead = isLts
+    ? 'We strongly encourage a short video explaining your project and why it matters. '
+    : videoRequired
+    ? `A video is required for requests of ${VIDEO_REQUIRED_LABEL} or more. `
+    : `A video is optional unless you are requesting ${VIDEO_REQUIRED_LABEL} or more. `
   return (
     <>
       <h2>Vibe Check</h2>
@@ -60,17 +69,24 @@ export default function AnythingElse({ register, errors }: StepProps) {
       <h2>Video Application</h2>
 
       <label className="block">
+        Video Link {videoRequired ? '*' : ''}
+        <br />
         <small>
-          We strongly encourage you to record a short video (around 2 minutes)
-          explaining your project and why it matters. This is optional but can
-          make a real difference. Please provide a link to the video below.
+          {videoLead}
+          It must be exactly 2 minutes and 10 seconds (2:10). Paste a link
+          below. We do not host uploads.
         </small>
         <input
           type="text"
           placeholder="https://"
           className={inputClass}
-          {...register('video_application')}
+          {...register('video_application', {
+            required: videoRequired
+              ? `A video link is required for requests of ${VIDEO_REQUIRED_LABEL} or more`
+              : false,
+          })}
         />
+        <FieldError errors={errors} name="video_application" />
       </label>
 
       <hr />

--- a/components/grant-application/steps/AnythingElse.tsx
+++ b/components/grant-application/steps/AnythingElse.tsx
@@ -68,7 +68,7 @@ export default function AnythingElse({ register, watch, errors }: StepProps) {
         <small>
           {videoRequired ? '' : 'Optional. '}
           It must be exactly 2 minutes and 10 seconds (2:10). Paste a link
-          below. We do not host uploads.
+          below.
         </small>
         <input
           type="text"

--- a/components/grant-application/steps/Budget.tsx
+++ b/components/grant-application/steps/Budget.tsx
@@ -1,4 +1,3 @@
-import { VIDEO_REQUIRED_LABEL } from '@/utils/grantRules'
 import FieldError from '../FieldError'
 import UsdAmountInput from '../UsdAmountInput'
 import { StepProps, inputClass } from '../types'
@@ -42,7 +41,7 @@ export default function Budget({ register, watch, errors }: StepProps) {
           <UsdAmountInput
             name="grand_total"
             label="Grand Total *"
-            hint={`Total amount requested, in USD. Requests of ${VIDEO_REQUIRED_LABEL} or more require a 2:10 video.`}
+            hint="Total amount requested, in USD."
             register={register}
             errors={errors}
             defaultAmount={watch('grand_total')}

--- a/components/grant-application/steps/Budget.tsx
+++ b/components/grant-application/steps/Budget.tsx
@@ -1,3 +1,4 @@
+import { VIDEO_REQUIRED_LABEL } from '@/utils/grantRules'
 import FieldError from '../FieldError'
 import UsdAmountInput from '../UsdAmountInput'
 import { StepProps, inputClass } from '../types'
@@ -41,7 +42,7 @@ export default function Budget({ register, watch, errors }: StepProps) {
           <UsdAmountInput
             name="grand_total"
             label="Grand Total *"
-            hint="Total amount requested, in USD."
+            hint={`Total amount requested, in USD. Requests of ${VIDEO_REQUIRED_LABEL} or more require a 2:10 video.`}
             register={register}
             errors={errors}
             defaultAmount={watch('grand_total')}

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -118,7 +118,11 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
         />
         <span>
           I have read the{' '}
-          <CustomLink href="/faq/application">Application FAQ</CustomLink>
+          <CustomLink href="/faq/application">Application FAQ</CustomLink>,
+          including the{' '}
+          <CustomLink href="/faq/application#why-do-i-have-to-submit-a-video">
+            video section
+          </CustomLink>
         </span>
       </label>
 

--- a/data/pages/faq-application.mdx
+++ b/data/pages/faq-application.mdx
@@ -30,6 +30,7 @@ not covered below.
 - [What is the minimum grant duration?](#what-is-the-minimum-grant-duration)
 - [What is the maximum grant duration?](#what-is-the-maximum-grant-duration)
 - [Do I need to submit a video?](#do-i-need-to-submit-a-video)
+- [Why does the video have to be exactly 2 minutes?](#why-does-the-video-have-to-be-exactly-2-minutes)
 - [How can I increase my funding chances?](#how-can-i-increase-my-funding-chances)
 - [What are you looking for in terms of references?](#what-are-you-looking-for-in-terms-of-references)
 - [If my application is rejected, can I reapply?](#if-my-application-is-rejected-can-i-reapply)
@@ -145,8 +146,21 @@ can be longer.
 ### Do I need to submit a video?
 
 A video is required if you request $21,000 or more. It must be exactly 2
-minutes and 10 seconds (2:10). Paste a public link.
-Below that amount a video is optional, but still helpful.
+minutes long. Paste a public link. Below that amount a video is optional, but
+still helpful.
+
+### Why does the video have to be exactly 2 minutes?
+
+The exact length is how we tell that you read the form, that you are the one
+applying (not a bot or someone else), and that the application is not spam. It
+also shows that you can produce a short video and talk about your project in 2
+minutes. If you cannot describe what you are doing in 2 minutes, more time
+will not help.
+
+Hiding your face is fine. We expect a human voice-over at least.
+
+Videos with the wrong duration, or videos that are fully AI-generated, will be
+discarded along with the application.
 
 ### How can I increase my funding chances?
 

--- a/data/pages/faq-application.mdx
+++ b/data/pages/faq-application.mdx
@@ -145,7 +145,7 @@ can be longer.
 ### Do I need to submit a video?
 
 A video is required if you request $21,000 or more. It must be exactly 2
-minutes and 10 seconds (2:10). Paste a public link; we do not host uploads.
+minutes and 10 seconds (2:10). Paste a public link.
 Below that amount a video is optional, but still helpful.
 
 ### How can I increase my funding chances?

--- a/data/pages/faq-application.mdx
+++ b/data/pages/faq-application.mdx
@@ -29,6 +29,7 @@ not covered below.
 - [Can grants be part-time or only full-time?](#can-grants-be-part-time-or-only-full-time)
 - [What is the minimum grant duration?](#what-is-the-minimum-grant-duration)
 - [What is the maximum grant duration?](#what-is-the-maximum-grant-duration)
+- [Do I need to submit a video?](#do-i-need-to-submit-a-video)
 - [How can I increase my funding chances?](#how-can-i-increase-my-funding-chances)
 - [What are you looking for in terms of references?](#what-are-you-looking-for-in-terms-of-references)
 - [If my application is rejected, can I reapply?](#if-my-application-is-rejected-can-i-reapply)
@@ -140,6 +141,12 @@ shorter window.
 
 Regular grants have a maximum duration of 12 months. [LTS grants](/apply/lts)
 can be longer.
+
+### Do I need to submit a video?
+
+A video is required if you request $21,000 or more. It must be exactly 2
+minutes and 10 seconds (2:10). Paste a public link; we do not host uploads.
+Below that amount a video is optional, but still helpful.
 
 ### How can I increase my funding chances?
 

--- a/data/pages/faq-application.mdx
+++ b/data/pages/faq-application.mdx
@@ -144,10 +144,10 @@ can be longer.
 
 ### Why do I have to submit a video?
 
-The video is how we tell that you read the form, that you are the one applying
+The video is how we can tell that you read the form, that you are the one applying
 (not a bot or someone else), and that the application is not spam. It also
-shows that you can produce a short video and talk about your project. If you
-cannot describe what you are doing in 2 minutes, more time will not help. That
+shows us that you can produce a short video and talk about your project. If you
+cannot describe what you are doing in 2 minutes, then having more time will not help. That
 is why it has to be exactly 2 minutes. We do not care where the video is
 hosted, as long as the link is easily accessible.
 

--- a/data/pages/faq-application.mdx
+++ b/data/pages/faq-application.mdx
@@ -150,7 +150,7 @@ also shows that you can produce a short video and talk about your project in 2
 minutes. If you cannot describe what you are doing in 2 minutes, more time
 will not help.
 
-Hiding your face is fine. We expect a human voice-over at least.
+Hiding your face is fine. That said, we expect a human voice-over at least.
 
 Videos with the wrong duration, or videos that are fully AI-generated, will be
 discarded along with the application.

--- a/data/pages/faq-application.mdx
+++ b/data/pages/faq-application.mdx
@@ -148,12 +148,10 @@ The video is how we tell that you read the form, that you are the one applying
 (not a bot or someone else), and that the application is not spam. It also
 shows that you can produce a short video and talk about your project. If you
 cannot describe what you are doing in 2 minutes, more time will not help. That
-is why it has to be exactly 2 minutes.
+is why it has to be exactly 2 minutes. We do not care where the video is
+hosted, as long as the link is easily accessible.
 
 Hiding your face is fine. That said, we expect a human voice-over at least.
-
-We do not care where the video is hosted, as long as the link is easily
-accessible.
 
 Videos with the wrong duration, or videos that are fully AI-generated, will be
 discarded along with the application.

--- a/data/pages/faq-application.mdx
+++ b/data/pages/faq-application.mdx
@@ -29,7 +29,6 @@ not covered below.
 - [Can grants be part-time or only full-time?](#can-grants-be-part-time-or-only-full-time)
 - [What is the minimum grant duration?](#what-is-the-minimum-grant-duration)
 - [What is the maximum grant duration?](#what-is-the-maximum-grant-duration)
-- [Do I need to submit a video?](#do-i-need-to-submit-a-video)
 - [Why does the video have to be exactly 2 minutes?](#why-does-the-video-have-to-be-exactly-2-minutes)
 - [How can I increase my funding chances?](#how-can-i-increase-my-funding-chances)
 - [What are you looking for in terms of references?](#what-are-you-looking-for-in-terms-of-references)
@@ -142,12 +141,6 @@ shorter window.
 
 Regular grants have a maximum duration of 12 months. [LTS grants](/apply/lts)
 can be longer.
-
-### Do I need to submit a video?
-
-A video is required if you request $21,000 or more. It must be exactly 2
-minutes long. Paste a public link. Below that amount a video is optional, but
-still helpful.
 
 ### Why does the video have to be exactly 2 minutes?
 

--- a/data/pages/faq-application.mdx
+++ b/data/pages/faq-application.mdx
@@ -152,6 +152,9 @@ will not help.
 
 Hiding your face is fine. That said, we expect a human voice-over at least.
 
+We do not care where the video is hosted, as long as the link is easily
+accessible.
+
 Videos with the wrong duration, or videos that are fully AI-generated, will be
 discarded along with the application.
 

--- a/data/pages/faq-application.mdx
+++ b/data/pages/faq-application.mdx
@@ -144,11 +144,11 @@ can be longer.
 
 ### Why do I have to submit a video?
 
-The exact length is how we tell that you read the form, that you are the one
-applying (not a bot or someone else), and that the application is not spam. It
-also shows that you can produce a short video and talk about your project in 2
-minutes. If you cannot describe what you are doing in 2 minutes, more time
-will not help.
+The video is how we tell that you read the form, that you are the one applying
+(not a bot or someone else), and that the application is not spam. It also
+shows that you can produce a short video and talk about your project. If you
+cannot describe what you are doing in 2 minutes, more time will not help. That
+is why it has to be exactly 2 minutes.
 
 Hiding your face is fine. That said, we expect a human voice-over at least.
 

--- a/data/pages/faq-application.mdx
+++ b/data/pages/faq-application.mdx
@@ -29,7 +29,7 @@ not covered below.
 - [Can grants be part-time or only full-time?](#can-grants-be-part-time-or-only-full-time)
 - [What is the minimum grant duration?](#what-is-the-minimum-grant-duration)
 - [What is the maximum grant duration?](#what-is-the-maximum-grant-duration)
-- [Why does the video have to be exactly 2 minutes?](#why-does-the-video-have-to-be-exactly-2-minutes)
+- [Why do I have to submit a video?](#why-do-i-have-to-submit-a-video)
 - [How can I increase my funding chances?](#how-can-i-increase-my-funding-chances)
 - [What are you looking for in terms of references?](#what-are-you-looking-for-in-terms-of-references)
 - [If my application is rejected, can I reapply?](#if-my-application-is-rejected-can-i-reapply)
@@ -142,7 +142,7 @@ shorter window.
 Regular grants have a maximum duration of 12 months. [LTS grants](/apply/lts)
 can be longer.
 
-### Why does the video have to be exactly 2 minutes?
+### Why do I have to submit a video?
 
 The exact length is how we tell that you read the form, that you are the one
 applying (not a bot or someone else), and that the application is not spam. It

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next/types'
 import { sendApplicationEmails } from '@/utils/application-emails'
 import { assertTurnstile, TURNSTILE_FAILURE_MESSAGE } from '@/utils/turnstile'
 import { areApplicationsOpen } from '@/utils/applicationWindow'
-import { isVideoRequired, VIDEO_REQUIRED_LABEL } from '@/utils/grantRules'
+import { isVideoRequired } from '@/utils/grantRules'
 import { formatUsdDisplay } from '@/utils/usd'
 import {
   getApplicationIssueLabels,
@@ -28,18 +28,14 @@ export default async function handler(
       })
     }
 
-    if (
-      !req.body.RED &&
-      !req.body.LTS &&
-      isVideoRequired(req.body.grand_total)
-    ) {
+    if (isVideoRequired(req.body)) {
       const videoLink =
         typeof req.body.video_application === 'string'
           ? req.body.video_application.trim()
           : ''
       if (!videoLink) {
         return res.status(400).json({
-          message: `A video link is required for requests of ${VIDEO_REQUIRED_LABEL} or more.`,
+          message: 'A video link is required.',
         })
       }
     }

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next/types'
 import { sendApplicationEmails } from '@/utils/application-emails'
 import { assertTurnstile, TURNSTILE_FAILURE_MESSAGE } from '@/utils/turnstile'
 import { areApplicationsOpen } from '@/utils/applicationWindow'
-import { isVideoRequired } from '@/utils/grantRules'
+import { isHttpUrl, isVideoRequired } from '@/utils/grantRules'
 import { formatUsdDisplay } from '@/utils/usd'
 import {
   getApplicationIssueLabels,
@@ -28,16 +28,19 @@ export default async function handler(
       })
     }
 
-    if (isVideoRequired(req.body)) {
-      const videoLink =
-        typeof req.body.video_application === 'string'
-          ? req.body.video_application.trim()
-          : ''
-      if (!videoLink) {
-        return res.status(400).json({
-          message: 'A video link is required.',
-        })
-      }
+    const videoLink =
+      typeof req.body.video_application === 'string'
+        ? req.body.video_application.trim()
+        : ''
+    if (isVideoRequired(req.body) && !videoLink) {
+      return res.status(400).json({
+        message: 'A video link is required.',
+      })
+    }
+    if (videoLink && !isHttpUrl(videoLink)) {
+      return res.status(400).json({
+        message: 'Enter a valid URL.',
+      })
     }
 
     if (!(await assertTurnstile(req))) {

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next/types'
 import { sendApplicationEmails } from '@/utils/application-emails'
 import { assertTurnstile, TURNSTILE_FAILURE_MESSAGE } from '@/utils/turnstile'
 import { areApplicationsOpen } from '@/utils/applicationWindow'
+import { isVideoRequired, VIDEO_REQUIRED_LABEL } from '@/utils/grantRules'
 import { formatUsdDisplay } from '@/utils/usd'
 import {
   getApplicationIssueLabels,
@@ -25,6 +26,22 @@ export default async function handler(
       return res.status(403).json({
         message: 'Grant applications are currently closed.',
       })
+    }
+
+    if (
+      !req.body.RED &&
+      !req.body.LTS &&
+      isVideoRequired(req.body.grand_total)
+    ) {
+      const videoLink =
+        typeof req.body.video_application === 'string'
+          ? req.body.video_application.trim()
+          : ''
+      if (!videoLink) {
+        return res.status(400).json({
+          message: `A video link is required for requests of ${VIDEO_REQUIRED_LABEL} or more.`,
+        })
+      }
     }
 
     if (!(await assertTurnstile(req))) {

--- a/public/static/opensats-grant-application-template.md
+++ b/public/static/opensats-grant-application-template.md
@@ -106,9 +106,8 @@ If yes, please describe the additional funding sources and amounts:
 
 ## Video Application
 
-A video is required if you request $21,000 or more. It must be exactly 2
-minutes long. Paste a public link. See the Application FAQ for why the length
-matters.
+A video is required. It must be exactly 2 minutes long. Paste a public link.
+See the Application FAQ for why the length matters.
 
 **Video Link:**
 

--- a/public/static/opensats-grant-application-template.md
+++ b/public/static/opensats-grant-application-template.md
@@ -106,8 +106,8 @@ If yes, please describe the additional funding sources and amounts:
 
 ## Video Application
 
-We strongly encourage you to record a short video, around 2 minutes, explaining
-your project and why it matters.
+A video is required if you request $21,000 or more. It must be exactly 2 minutes
+and 10 seconds (2:10). Paste a public link; we do not host uploads.
 
 **Video Link:**
 

--- a/public/static/opensats-grant-application-template.md
+++ b/public/static/opensats-grant-application-template.md
@@ -106,8 +106,9 @@ If yes, please describe the additional funding sources and amounts:
 
 ## Video Application
 
-A video is required if you request $21,000 or more. It must be exactly 2 minutes
-and 10 seconds (2:10). Paste a public link.
+A video is required if you request $21,000 or more. It must be exactly 2
+minutes long. Paste a public link. See the Application FAQ for why the length
+matters.
 
 **Video Link:**
 

--- a/public/static/opensats-grant-application-template.md
+++ b/public/static/opensats-grant-application-template.md
@@ -107,7 +107,7 @@ If yes, please describe the additional funding sources and amounts:
 ## Video Application
 
 A video is required if you request $21,000 or more. It must be exactly 2 minutes
-and 10 seconds (2:10). Paste a public link; we do not host uploads.
+and 10 seconds (2:10). Paste a public link.
 
 **Video Link:**
 

--- a/utils/grantRules.ts
+++ b/utils/grantRules.ts
@@ -12,3 +12,13 @@ export function isVideoRequired(application: {
   const amount = parseUsd(application.grand_total)
   return amount !== undefined && amount >= VIDEO_REQUIRED_USD
 }
+
+export function isHttpUrl(value: unknown): boolean {
+  if (typeof value !== 'string') return false
+  try {
+    const url = new URL(value.trim())
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+}

--- a/utils/grantRules.ts
+++ b/utils/grantRules.ts
@@ -1,0 +1,9 @@
+import { formatUsdDisplay, parseUsd } from './usd'
+
+export const VIDEO_REQUIRED_USD = 21_000
+export const VIDEO_REQUIRED_LABEL = formatUsdDisplay(VIDEO_REQUIRED_USD)
+
+export function isVideoRequired(grandTotal: unknown): boolean {
+  const amount = parseUsd(grandTotal)
+  return amount !== undefined && amount >= VIDEO_REQUIRED_USD
+}

--- a/utils/grantRules.ts
+++ b/utils/grantRules.ts
@@ -1,9 +1,7 @@
-import { formatUsdDisplay, parseUsd } from './usd'
-
-export const VIDEO_REQUIRED_USD = 21_000
-export const VIDEO_REQUIRED_LABEL = formatUsdDisplay(VIDEO_REQUIRED_USD)
-
-export function isVideoRequired(grandTotal: unknown): boolean {
-  const amount = parseUsd(grandTotal)
-  return amount !== undefined && amount >= VIDEO_REQUIRED_USD
+/** Video is required on general grant applications. LTS and RED skip it. */
+export function isVideoRequired(application: {
+  LTS?: unknown
+  RED?: unknown
+}): boolean {
+  return !application.LTS && !application.RED
 }

--- a/utils/grantRules.ts
+++ b/utils/grantRules.ts
@@ -1,7 +1,14 @@
-/** Video is required on general grant applications. LTS and RED skip it. */
+import { parseUsd } from './usd'
+
+const VIDEO_REQUIRED_USD = 21_000
+
+/** Video is required on general grants of $21k or more. LTS and RED skip it. */
 export function isVideoRequired(application: {
   LTS?: unknown
   RED?: unknown
+  grand_total?: unknown
 }): boolean {
-  return !application.LTS && !application.RED
+  if (application.LTS || application.RED) return false
+  const amount = parseUsd(application.grand_total)
+  return amount !== undefined && amount >= VIDEO_REQUIRED_USD
 }


### PR DESCRIPTION
Requires a video link for general grant applications. The video must be exactly 2 minutes. Fixes OpenSats/operations#651.

- Form and `/api/github` both enforce it
- FAQ covers why, hosting, and what gets discarded
- Prerequisites checkbox now mentions the video FAQ

Build preview: 
- [/apply/grant](https://os-website-git-feat-require-video-high-value-opensats.vercel.app/apply/grant)
- [/faq/application](https://os-website-git-feat-require-video-high-value-opensats.vercel.app/faq/application#why-do-i-have-to-submit-a-video)
