### PR TITLE
Remove leftover common grant application fields

### DIFF
--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -101,14 +101,6 @@ ${req.body.short_description}
 
 ${req.body.potential_impact}
 
-### Other Organizations Applied To
-
-${
-  req.body.organizations
-    ? `This application was submitted to: ${req.body.organizations.join(', ')}`
-    : 'No organizations specified'
-}
-
 ### Timeline & Milestones
 
 ${req.body.duration ? `Grant duration: ${req.body.duration}` : ''}

--- a/utils/application-routing.ts
+++ b/utils/application-routing.ts
@@ -30,10 +30,6 @@ export function getApplicationIssueLabels(body: Record<string, unknown>) {
     issueLabels.push('bitcoin')
   }
 
-  if (body.source === 'common-grant-app') {
-    issueLabels.push('common-grant-app')
-  }
-
   if (body.LTS) issueLabels.push('LTS')
   if (body.RED) issueLabels.push('RED')
   if (body.has_received_funding === 'yes') issueLabels.push('prior funding')


### PR DESCRIPTION
Drops the leftover "other organizations applied to" block from grant GitHub issues and stops applying the `common-grant-app` label. The form already did not collect this. Fixes OpenSats/operations#660.

- Issue bodies no longer mention other organizations
- Incoming posts are no longer tagged `common-grant-app`

Build preview: 
- [/apply/grant](https://os-website-git-fix-remove-other-organizations-opensats.vercel.app/apply/grant)
