### PR TITLE
Add Zap.stream project page

### DIFF
--- a/data/projects/zapstream.mdx
+++ b/data/projects/zapstream.mdx
@@ -1,0 +1,69 @@
+---
+title: 'Zap.stream'
+dateAdded: '2023-10-18'
+summary: 'A nostr-native live-streaming client that lets creators broadcast video, chat with viewers, and receive Lightning zaps.'
+nym: 'Kieran Harkin'
+website: 'https://zap.stream/'
+coverImage: '/static/images/projects/nostr/zapstream.png'
+git: 'https://github.com/v0l/zap.stream'
+nostr: 'npub1v0lxxxxutpvrelsksy8cdhgfux9l6a42hsj2qzquu2zk7vc9qnkszrqj49'
+tags: ['Nostr', 'Streaming', 'Media']
+showcase: true
+fund: nostr
+announcementLink: '/blog/nostr-grants-october-2023#zapstream'
+---
+
+[Zap.stream](https://zap.stream/) is a live-streaming client built on
+[nostr] and Bitcoin. Creators can broadcast video, host a live chat, receive
+Lightning [zaps], and keep their streaming identity tied to their nostr key
+instead of a platform account. The web app is a [NIP-53] client and works with
+externally hosted HLS streams, giving streamers an open alternative to
+closed-platform live video.
+
+The project has grown beyond the browser client. Kieran also maintains the
+mobile [Flutter] apps for iOS and Android, which let creators go live from a
+phone camera, receive notifications, open stream links, and connect a Lightning
+wallet through Nostr Wallet Connect. The broader stack includes a self-hostable
+Rust streaming server for RTMP ingest, HLS output, recordings, and operator
+metrics.
+
+Zap.stream also works with [Route96], a NIP-96 and Blossom media backend for
+large video files, clips, and replayable content. Route96 can generate
+thumbnails, optimize media, mirror uploads across servers, and enforce
+Lightning-based storage limits, giving nostr apps a reusable media layer instead
+of forcing every client to build one from scratch.
+
+## Why fund it?
+
+Live streaming depends on bandwidth-heavy infrastructure, real-time chat,
+payments, storage, moderation tools, and discoverability. In the legacy model,
+those pieces usually come bundled inside a central platform that controls user
+accounts, monetization, and distribution. Zap.stream separates the client and
+backend pieces so streamers can publish through nostr, get paid over Lightning,
+and use infrastructure that can be run by independent operators.
+
+OpenSats first supported zap.stream in the [third wave of nostr grants][wave-3].
+Kieran later received [long-term support][lts] covering his work on zap.stream,
+snort.social, native zap.stream apps, and a new backend for a marketplace of
+streaming providers.
+
+## What's next?
+
+Ongoing work focuses on making nostr live streaming easier to use from both
+desktop and mobile. The mobile apps continue to improve the viewing and
+broadcasting experience, while the backend work makes streaming infrastructure
+more portable and self-hostable. Route96 adds durable media storage for video on
+nostr, opening the door to clips, video-on-demand, and richer media features
+across the ecosystem.
+
+Together, these pieces make zap.stream a practical test bed for
+user-controlled, open-protocol live streaming where creators can carry their
+identity, audience, and payments across clients.
+
+[Flutter]: https://github.com/nostrlabs-io/zap-stream-flutter
+[lts]: /blog/kieran-receives-lts-grant
+[NIP-53]: https://github.com/nostr-protocol/nips/blob/master/53.md
+[nostr]: /topics/nostr
+[Route96]: https://github.com/v0l/route96
+[wave-3]: /blog/nostr-grants-october-2023#zapstream
+[zaps]: /topics/zaps

--- a/data/projects/zapstream.mdx
+++ b/data/projects/zapstream.mdx
@@ -17,17 +17,17 @@ announcementLink: '/blog/nostr-grants-october-2023#zapstream'
 [nostr] and Bitcoin. Creators can broadcast video, host a live chat, receive
 Lightning [zaps], and keep their streaming identity tied to their nostr key
 instead of a platform account. The web app is a [NIP-53] client and works with
-externally hosted HLS streams, giving streamers an open alternative to
+externally hosted [HLS] streams, giving streamers an open alternative to
 closed-platform live video.
 
 The project has grown beyond the browser client. Kieran also maintains the
 mobile [Flutter] apps for iOS and Android, which let creators go live from a
 phone camera, receive notifications, open stream links, and connect a Lightning
-wallet through Nostr Wallet Connect. The broader stack includes a self-hostable
-Rust streaming server for RTMP ingest, HLS output, recordings, and operator
+wallet through [Nostr Wallet Connect][NWC]. The broader stack includes a self-hostable
+Rust streaming server for [RTMP] ingest, HLS output, recordings, and operator
 metrics.
 
-Zap.stream also works with [Route96], a NIP-96 and Blossom media backend for
+Zap.stream also works with [Route96], a NIP-96 and [Blossom] media backend for
 large video files, clips, and replayable content. Route96 can generate
 thumbnails, optimize media, mirror uploads across servers, and enforce
 Lightning-based storage limits, giving nostr apps a reusable media layer instead
@@ -67,3 +67,7 @@ identity, audience, and payments across clients.
 [Route96]: https://github.com/v0l/route96
 [wave-3]: /blog/nostr-grants-october-2023#zapstream
 [zaps]: /topics/zaps
+[HLS]: https://en.wikipedia.org/wiki/HTTP_Live_Streaming
+[NWC]: /topics/nostr-wallet-connect
+[RTMP]: https://en.wikipedia.org/wiki/Real-Time_Messaging_Protocol
+[Blossom]: /topics/blossom

--- a/tests/api/github.test.js
+++ b/tests/api/github.test.js
@@ -68,6 +68,7 @@ const validApplication = {
 
 describe('/api/github', () => {
   beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-15T12:00:00Z'))
     createIssue.mockReset()
     createIssue.mockResolvedValue({ data: { number: 1 } })
     assertTurnstile.mockReset()
@@ -82,6 +83,7 @@ describe('/api/github', () => {
   })
 
   afterEach(() => {
+    jest.useRealTimers()
     jest.restoreAllMocks()
   })
 

--- a/utils/projectClusters.ts
+++ b/utils/projectClusters.ts
@@ -98,6 +98,7 @@ export const CLUSTERS: Cluster[] = [
       'jumble',
       'soapbox',
       'wisp',
+      'zapstream',
     ],
   },
   {

--- a/utils/relatedPosts.test.js
+++ b/utils/relatedPosts.test.js
@@ -1,0 +1,29 @@
+/** @jest-environment node */
+/* eslint-env jest, node */
+
+const { getRelatedBlogPostsByTerms } = require('./relatedPosts.ts')
+
+describe('related posts', () => {
+  it('matches dotted project names across separator variants', () => {
+    const posts = [
+      {
+        title: 'Third Wave of Nostr Grants',
+        summary: '',
+        tags: ['grants'],
+        body: {
+          raw: 'Funding zap.stream as a nostr-native live-streaming client.',
+        },
+      },
+      {
+        title: 'Unrelated',
+        summary: '',
+        tags: [],
+        body: { raw: 'Funding zaps and streaming separately.' },
+      },
+    ]
+
+    expect(getRelatedBlogPostsByTerms(['Zap.stream'], posts)).toEqual([
+      posts[0],
+    ])
+  })
+})

--- a/utils/relatedPosts.ts
+++ b/utils/relatedPosts.ts
@@ -23,10 +23,10 @@ export function stripMarkdownForSearch(raw = ''): string {
  * Finds blog posts whose title, summary, tags, or body mention any of the
  * given terms as a whole word (case-insensitive).
  *
- * Internal separators in a term (whitespace, hyphen, underscore) are treated
- * as interchangeable, so a term like "BIP 324" matches "BIP 324", "BIP-324",
- * "BIP_324", and "BIP324" in blog text. Word boundaries still anchor both
- * ends, so "BIP 32" does not match "BIP 324".
+ * Internal separators in a term (whitespace, hyphen, underscore, dot) are
+ * treated as interchangeable, so a term like "BIP 324" matches "BIP 324",
+ * "BIP-324", "BIP_324", and "BIP324" in blog text. Word boundaries still
+ * anchor both ends, so "BIP 32" does not match "BIP 324".
  *
  * Body matching runs against plain text extracted from the MDX body, not the
  * raw markdown source. That keeps URLs, reference definitions, and MDX syntax
@@ -50,7 +50,7 @@ export function getRelatedBlogPostsByTerms(
         .map(escapeRegExp)
     )
     .filter((tokens) => tokens.length > 0)
-    .map((tokens) => new RegExp(`\\b${tokens.join('[\\s\\-_]*')}\\b`, 'i'))
+    .map((tokens) => new RegExp(`\\b${tokens.join('[\\s\\-_.]*')}\\b`, 'i'))
 
   if (patterns.length === 0) return []
 


### PR DESCRIPTION
Adds a new `Zap.stream` project page with verified copy and links for the public site, GitHub repository, OpenSats grant announcement, Kieran's LTS announcement, and related upstream repos.

- adds a new `/projects/zapstream` MDX page
- adds `zapstream` to the Nostr Clients showcase cluster
- updates related-post matching so dotted project names like `Zap.stream` match existing posts

Build preview:
- [/projects](https://os-website-git-content-add-zap-stream-project-page-opensats.vercel.app/projects)
- [/projects/zapstream](https://os-website-git-content-add-zap-stream-project-page-opensats.vercel.app/projects/zapstream)

Fixes OpenSats/content#273
