### PR TITLE
Make LTS application references optional

### DIFF
--- a/components/LTSApplicationForm.tsx
+++ b/components/LTSApplicationForm.tsx
@@ -60,12 +60,7 @@ const STEPS: StepConfig[] = [
   {
     id: 'prerequisites',
     title: 'Prerequisites',
-    fields: [
-      'read_criteria',
-      'read_faq',
-      'free_open_source',
-      'lts_right_fit',
-    ],
+    fields: ['read_criteria', 'read_faq', 'free_open_source', 'lts_right_fit'],
     render: (props) => <Prerequisites {...props} />,
   },
   {

--- a/components/LTSApplicationForm.tsx
+++ b/components/LTSApplicationForm.tsx
@@ -63,7 +63,6 @@ const STEPS: StepConfig[] = [
     fields: [
       'read_criteria',
       'read_faq',
-      'has_references',
       'free_open_source',
       'lts_right_fit',
     ],

--- a/components/grant-application/steps/Prerequisites.tsx
+++ b/components/grant-application/steps/Prerequisites.tsx
@@ -18,7 +18,6 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
     ? ([
         'read_criteria',
         'read_faq',
-        'has_references',
         'free_open_source',
         'lts_right_fit',
       ] as const)
@@ -122,20 +121,22 @@ export default function Prerequisites({ register, watch, errors }: StepProps) {
         </span>
       </label>
 
-      <label className="inline-flex items-start gap-2">
-        <input
-          type="checkbox"
-          className={`mt-1 ${checkboxClass}`}
-          {...register('has_references', { required: true })}
-        />
-        <span>
-          I understand that at least two{' '}
-          <CustomLink href="/faq/application#what-are-you-looking-for-in-terms-of-references">
-            written reference letters
-          </CustomLink>{' '}
-          from people familiar with my work are required
-        </span>
-      </label>
+      {!isLts && (
+        <label className="inline-flex items-start gap-2">
+          <input
+            type="checkbox"
+            className={`mt-1 ${checkboxClass}`}
+            {...register('has_references', { required: true })}
+          />
+          <span>
+            I understand that at least two{' '}
+            <CustomLink href="/faq/application#what-are-you-looking-for-in-terms-of-references">
+              written reference letters
+            </CustomLink>{' '}
+            from people familiar with my work are required
+          </span>
+        </label>
+      )}
 
       <label className="inline-flex items-start gap-2">
         <input

--- a/components/grant-application/steps/ReferencesReview.tsx
+++ b/components/grant-application/steps/ReferencesReview.tsx
@@ -8,7 +8,8 @@ export default function ReferencesReview({
 }: StepProps) {
   const applicantName = watch?.('your_name') || '[Applicant Name]'
   const projectName = watch?.('project_name') || '[Project Name]'
-  const suggestedSubject = watch?.('LTS')
+  const isLts = watch?.('LTS')
+  const suggestedSubject = isLts
     ? `Reference Letter for ${applicantName} (LTS)`
     : `Reference Letter for ${projectName} by ${applicantName}`
 
@@ -17,18 +18,17 @@ export default function ReferencesReview({
       <h2>Written References</h2>
 
       <label className="block">
-        References *<br />
+        References{!isLts && ' *'}
+        <br />
         <small>
-          Please provide at least 2 written reference letters from people in the
-          Bitcoin community or open-source space who are familiar with you or
-          your project. Include the email address of each reference so we can
-          reach out to verify. Cryptographically signed references (e.g. using
-          PGP or Nostr) are a plus.
+          {isLts
+            ? 'Optional. If you have written reference letters from people in the Bitcoin community or open-source space who are familiar with you or your work, include them here. Include the email address of each reference so we can reach out to verify. Cryptographically signed references (e.g. using PGP or Nostr) are a plus.'
+            : 'Please provide at least 2 written reference letters from people in the Bitcoin community or open-source space who are familiar with you or your project. Include the email address of each reference so we can reach out to verify. Cryptographically signed references (e.g. using PGP or Nostr) are a plus.'}
         </small>
         <textarea
           rows={5}
           className={inputClass}
-          {...register('references', { required: true })}
+          {...register('references', { required: !isLts })}
         />
         <FieldError errors={errors} name="references" />
         <small className="mt-1 block">

--- a/data/pages/faq-application.mdx
+++ b/data/pages/faq-application.mdx
@@ -152,10 +152,11 @@ can be longer.
 
 ### What are you looking for in terms of references?
 
-We require at least two written reference letters from people who are
-familiar with your work. Good references come from peers, collaborators, or
-community members who can speak to your past contributions. Keep in mind that
-generic praise is not very helpful.
+For general grants, we require at least two written reference letters from
+people who are familiar with your work. LTS applications do not require
+reference letters, though they are welcome. Good references come from peers,
+collaborators, or community members who can speak to your past contributions.
+Keep in mind that generic praise is not very helpful.
 
 A strong reference will address things like:
 
@@ -171,8 +172,9 @@ signed references, e.g. using PGP or Nostr, are a plus.
 
 References can be included as part of your application or emailed directly to
 [references@opensats.org](mailto:references@opensats.org) using the subject
-line "Reference Letter for [Project Name] by [Applicant Name]". The evaluation
-of your application will not start until we have two written references.
+line "Reference Letter for [Project Name] by [Applicant Name]". For general
+grants, the evaluation of your application will not start until we have two
+written references.
 
 ### If my application is rejected, can I reapply?
 

--- a/pages/apply/lts.tsx
+++ b/pages/apply/lts.tsx
@@ -3,7 +3,7 @@ import PageSection from '@/components/PageSection'
 import CustomLink from '@/components/Link'
 import { PageSEO } from '@/components/SEO'
 import ClosedNotice from '@/components/ClosedNotice'
-import { areApplicationsOpen } from '@/utils/applicationWindow'
+import { showGrantApplicationForm } from '@/utils/applicationWindow'
 
 const LTSApplicationForm = dynamic(
   () => import('@/components/LTSApplicationForm'),
@@ -61,7 +61,7 @@ export default function Apply() {
           <CustomLink href="/apply/grant">General Grant</CustomLink> instead.
         </p>
         <ClosedNotice />
-        {areApplicationsOpen() && <LTSApplicationForm />}
+        {showGrantApplicationForm() && <LTSApplicationForm />}
       </PageSection>
     </>
   )


### PR DESCRIPTION
LTS applicants can skip written reference letters. The required-references checkbox and the required references field now apply to general grants only. OpenSats/operations#643

- Drop the "two written reference letters are required" checkbox from the LTS form
- Keep the references textarea on LTS as optional; prior contributions and years of experience stay required
- Show the LTS form on Vercel preview builds so it can be tested while applications are closed

Build preview: 
- [/apply/lts](https://os-website-git-fix-lts-optional-references-opensats.vercel.app/apply/lts)
- [/faq/application#what-are-you-looking-for-in-terms-of-references](https://os-website-git-fix-lts-optional-references-opensats.vercel.app/faq/application#what-are-you-looking-for-in-terms-of-references)
- [/apply/grant](https://os-website-git-fix-lts-optional-references-opensats.vercel.app/apply/grant)
