### PR TITLE
Fix funding decisions diagram zoom rendering

### DIFF
--- a/data/blog/avoiding-single-points-of-failure.mdx
+++ b/data/blog/avoiding-single-points-of-failure.mdx
@@ -34,6 +34,7 @@ To ensure that OpenSats doesn't corrupt over time, an unusually large board is a
   alt="Funding Decisions"
   width={1920}
   height={1080}
+  unoptimized
   className="w-full h-auto"
 />
 
@@ -148,4 +149,3 @@ It's a miracle that it's working at all, and we are grateful for everyone who ha
 
 [coldcard vulnerability]: /blog/code-red-supporting-first-responders
 [BTCPay Server vulnerability]: /blog/ongoing-exploits-of-bitcoin-open-source-software
-


### PR DESCRIPTION
Bypasses the Next image optimizer for the funding decisions diagram in the new single-points-of-failure post, so browser zoom no longer switches that image to the high-density optimized variant.

- keeps the reported fix scoped to the one affected diagram
- leaves the other post diagrams on the normal optimized image path
- verified the high-scale preview render uses the direct static image

Build preview:
- [/blog/avoiding-single-points-of-failure](https://os-website-git-fix-spof-blog-image-zoom-opensats.vercel.app/blog/avoiding-single-points-of-failure)
