### PR TITLE
Harden report submission with Turnstile and grant-id checks

### DIFF
--- a/components/GrantValidationForm.tsx
+++ b/components/GrantValidationForm.tsx
@@ -3,6 +3,7 @@ import { useForm } from 'react-hook-form'
 import { fetchPostJSON } from '../utils/api-helpers'
 import * as EmailValidator from 'email-validator'
 import { ERROR_MESSAGES } from '../utils/constants'
+import { GRANT_ID_PATTERN } from '../utils/grant-id'
 import { TURNSTILE_TOKEN_FIELD } from '../utils/turnstile'
 import TurnstileWidget, {
   TurnstileWidgetHandle,
@@ -118,11 +119,10 @@ export default function GrantValidationForm({
         </small>
         <input
           {...register('grant_id', {
-            required: 'Grant ID is required',
+            required: ERROR_MESSAGES.GRANT_ID_REQUIRED,
             pattern: {
-              value: /^\d{6,7}$/,
-              message:
-                'A valid Grant ID is required to start the submission process',
+              value: GRANT_ID_PATTERN,
+              message: ERROR_MESSAGES.GRANT_ID_INVALID,
             },
           })}
           type="text"

--- a/components/GrantValidationForm.tsx
+++ b/components/GrantValidationForm.tsx
@@ -1,8 +1,12 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { fetchPostJSON } from '../utils/api-helpers'
 import * as EmailValidator from 'email-validator'
 import { ERROR_MESSAGES } from '../utils/constants'
+import { TURNSTILE_TOKEN_FIELD } from '../utils/turnstile'
+import TurnstileWidget, {
+  TurnstileWidgetHandle,
+} from './grant-application/TurnstileWidget'
 
 interface ValidationResult {
   grant_details: {
@@ -27,6 +31,8 @@ export default function GrantValidationForm({
 }: GrantValidationFormProps) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string>()
+  const [turnstileReady, setTurnstileReady] = useState(false)
+  const turnstileRef = useRef<TurnstileWidgetHandle>(null)
   const {
     register,
     handleSubmit,
@@ -40,10 +46,20 @@ export default function GrantValidationForm({
     setError(undefined)
 
     try {
-      const response = await fetchPostJSON('/api/grant', data)
+      const token = await turnstileRef.current?.waitForToken()
+      if (!token) {
+        throw new Error('Please complete the bot verification challenge.')
+      }
+
+      const response = await fetchPostJSON('/api/grant', {
+        ...data,
+        [TURNSTILE_TOKEN_FIELD]: token,
+      })
 
       if (response.error) {
         setError(response.error)
+        setTurnstileReady(false)
+        turnstileRef.current?.reset()
         setLoading(false)
         return
       }
@@ -70,11 +86,19 @@ export default function GrantValidationForm({
       } else {
         // If neither format matches, show an error
         setError('Invalid response format from server')
+        setTurnstileReady(false)
+        turnstileRef.current?.reset()
       }
 
       setLoading(false)
     } catch (e) {
-      setError(ERROR_MESSAGES.GRANT_NOT_FOUND)
+      setError(
+        e instanceof Error && e.message.startsWith('Please complete')
+          ? e.message
+          : ERROR_MESSAGES.GRANT_NOT_FOUND
+      )
+      setTurnstileReady(false)
+      turnstileRef.current?.reset()
       setLoading(false)
     }
   }
@@ -129,12 +153,19 @@ export default function GrantValidationForm({
         )}
       </label>
 
+      <div className="my-8 flex flex-col items-center py-2">
+        <TurnstileWidget
+          ref={turnstileRef}
+          onTokenChange={(token) => setTurnstileReady(!!token)}
+        />
+      </div>
+
       <div className="mt-8 flex justify-end">
         <button
           type="submit"
-          disabled={loading}
+          disabled={loading || !turnstileReady}
           className={`rounded px-4 py-2 text-sm font-medium text-white ${
-            loading
+            loading || !turnstileReady
               ? 'cursor-not-allowed bg-gray-400'
               : 'bg-orange-500 hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2'
           }`}

--- a/pages/api/grant.ts
+++ b/pages/api/grant.ts
@@ -1,6 +1,11 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { Octokit } from '@octokit/rest'
 import { ERROR_MESSAGES } from '../../utils/constants'
+import {
+  isNumericGrantId,
+  normalizeGrantId,
+  titleMatchesGrantId,
+} from '../../utils/grant-id'
 import { assertTurnstile, TURNSTILE_FAILURE_MESSAGE } from '@/utils/turnstile'
 
 const GH_ACCESS_TOKEN = process.env.GH_ACCESS_TOKEN
@@ -31,10 +36,20 @@ export default async function handler(
 
   const { grant_id } = req.body
 
-  const normalizedGrantId = String(grant_id || '').trim()
+  const normalizedGrantId = normalizeGrantId(grant_id)
 
   if (!normalizedGrantId) {
-    return res.status(400).json({ valid: false, error: 'Grant ID is required' })
+    return res.status(400).json({
+      valid: false,
+      error: ERROR_MESSAGES.GRANT_ID_REQUIRED,
+    })
+  }
+
+  if (!isNumericGrantId(normalizedGrantId)) {
+    return res.status(400).json({
+      valid: false,
+      error: ERROR_MESSAGES.GRANT_ID_INVALID,
+    })
   }
 
   if (!GH_ACCESS_TOKEN || !GH_ORG || !GH_REPORTS_REPO) {
@@ -78,12 +93,9 @@ export default async function handler(
         per_page: 100,
       }
     )) {
-      const found = issues.find((issue) => {
-        const titleContainsGrantId = issue.title?.includes(normalizedGrantId)
-        const bodyContainsGrantId =
-          issue.body?.includes(normalizedGrantId) || false
-        return Boolean(titleContainsGrantId || bodyContainsGrantId)
-      })
+      const found = issues.find((issue) =>
+        titleMatchesGrantId(issue.title, normalizedGrantId)
+      )
 
       if (found) {
         matchingIssue = {

--- a/pages/api/grant.ts
+++ b/pages/api/grant.ts
@@ -1,11 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { Octokit } from '@octokit/rest'
-import { ERROR_MESSAGES } from '../../utils/constants'
-import {
-  isNumericGrantId,
-  normalizeGrantId,
-  titleMatchesGrantId,
-} from '../../utils/grant-id'
+import { findGrantIssue } from '../../utils/find-grant-issue'
+import { parseGrantIdInput, projectNameFromTitle } from '../../utils/grant-id'
 import { assertTurnstile, TURNSTILE_FAILURE_MESSAGE } from '@/utils/turnstile'
 
 const GH_ACCESS_TOKEN = process.env.GH_ACCESS_TOKEN
@@ -34,22 +30,9 @@ export default async function handler(
     })
   }
 
-  const { grant_id } = req.body
-
-  const normalizedGrantId = normalizeGrantId(grant_id)
-
-  if (!normalizedGrantId) {
-    return res.status(400).json({
-      valid: false,
-      error: ERROR_MESSAGES.GRANT_ID_REQUIRED,
-    })
-  }
-
-  if (!isNumericGrantId(normalizedGrantId)) {
-    return res.status(400).json({
-      valid: false,
-      error: ERROR_MESSAGES.GRANT_ID_INVALID,
-    })
+  const parsedGrantId = parseGrantIdInput(req.body.grant_id)
+  if (!parsedGrantId.ok) {
+    return res.status(400).json({ valid: false, error: parsedGrantId.error })
   }
 
   if (!GH_ACCESS_TOKEN || !GH_ORG || !GH_REPORTS_REPO) {
@@ -59,83 +42,19 @@ export default async function handler(
       .json({ valid: false, error: 'Server configuration error' })
   }
 
-  // Development/testing condition
-  if (
-    process.env.NODE_ENV === 'development' &&
-    normalizedGrantId === '123456'
-  ) {
-    return res.status(200).json({
-      valid: true,
-      project_name: 'Test Grant',
-      issue_number: 123,
+  const octokit = new Octokit({ auth: GH_ACCESS_TOKEN })
+  const result = await findGrantIssue(octokit, parsedGrantId.grantId)
+
+  if (!result.ok) {
+    return res.status(result.status).json({
+      valid: false,
+      error: result.error,
     })
   }
 
-  try {
-    const octokit = new Octokit({ auth: GH_ACCESS_TOKEN })
-
-    // Iterate through all issues using pagination and stop when we find a match
-    let matchingIssue:
-      | {
-          title: string
-          body?: string | null
-          number: number
-          state: 'open' | 'closed'
-        }
-      | undefined
-
-    for await (const { data: issues } of octokit.paginate.iterator(
-      octokit.rest.issues.listForRepo,
-      {
-        owner: GH_ORG,
-        repo: GH_REPORTS_REPO,
-        state: 'all',
-        per_page: 100,
-      }
-    )) {
-      const found = issues.find((issue) =>
-        titleMatchesGrantId(issue.title, normalizedGrantId)
-      )
-
-      if (found) {
-        matchingIssue = {
-          title: found.title,
-          body: found.body,
-          number: found.number,
-          state: found.state as 'open' | 'closed',
-        }
-        break
-      }
-    }
-
-    if (!matchingIssue) {
-      return res.status(404).json({
-        valid: false,
-        error: ERROR_MESSAGES.GRANT_NOT_FOUND,
-      })
-    }
-
-    if (matchingIssue.state === 'closed') {
-      return res.status(409).json({
-        valid: false,
-        error: ERROR_MESSAGES.PAST_GRANT,
-      })
-    }
-
-    // Extract project name from issue title
-    const project_name = matchingIssue.title
-      .replace(/^Grant #\d+:\s*/, '')
-      .replace(/\s+by\s+.*$/, '')
-
-    return res.status(200).json({
-      valid: true,
-      project_name,
-      issue_number: matchingIssue.number,
-    })
-  } catch (error) {
-    console.error('Error validating grant:', error)
-    return res
-      .status(500)
-      .json({ valid: false, error: 'Error validating grant' })
-  }
+  return res.status(200).json({
+    valid: true,
+    project_name: projectNameFromTitle(result.issue.title),
+    issue_number: result.issue.number,
+  })
 }

--- a/pages/api/grant.ts
+++ b/pages/api/grant.ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { Octokit } from '@octokit/rest'
 import { ERROR_MESSAGES } from '../../utils/constants'
+import { assertTurnstile, TURNSTILE_FAILURE_MESSAGE } from '@/utils/turnstile'
 
 const GH_ACCESS_TOKEN = process.env.GH_ACCESS_TOKEN
 const GH_ORG = process.env.GH_ORG
@@ -19,6 +20,13 @@ export default async function handler(
 ) {
   if (req.method !== 'POST') {
     return res.status(405).json({ valid: false, error: 'Method not allowed' })
+  }
+
+  if (!(await assertTurnstile(req))) {
+    return res.status(403).json({
+      valid: false,
+      error: TURNSTILE_FAILURE_MESSAGE,
+    })
   }
 
   const { grant_id } = req.body

--- a/pages/api/grant.ts
+++ b/pages/api/grant.ts
@@ -31,7 +31,7 @@ export default async function handler(
   }
 
   const parsedGrantId = parseGrantIdInput(req.body.grant_id)
-  if (!parsedGrantId.ok) {
+  if (parsedGrantId.ok === false) {
     return res.status(400).json({ valid: false, error: parsedGrantId.error })
   }
 
@@ -45,7 +45,7 @@ export default async function handler(
   const octokit = new Octokit({ auth: GH_ACCESS_TOKEN })
   const result = await findGrantIssue(octokit, parsedGrantId.grantId)
 
-  if (!result.ok) {
+  if (result.ok === false) {
     return res.status(result.status).json({
       valid: false,
       error: result.error,

--- a/pages/api/report.ts
+++ b/pages/api/report.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 import { Octokit } from '@octokit/rest'
 import { sendReportConfirmationEmail } from './sendgrid'
 import { generateReportContent } from '../../utils/api-helpers'
+import { assertTurnstile, TURNSTILE_FAILURE_MESSAGE } from '@/utils/turnstile'
 
 const GH_ACCESS_TOKEN = process.env.GH_ACCESS_TOKEN
 const GH_ORG = process.env.GH_ORG
@@ -59,6 +60,13 @@ export default async function handler(
     return res.status(405).json({
       success: false,
       error: 'Method not allowed',
+    })
+  }
+
+  if (!(await assertTurnstile(req))) {
+    return res.status(403).json({
+      success: false,
+      error: TURNSTILE_FAILURE_MESSAGE,
     })
   }
 

--- a/pages/api/report.ts
+++ b/pages/api/report.ts
@@ -109,7 +109,7 @@ export default async function handler(
       })
     }
 
-    if (!parsedGrantId.ok) {
+    if (parsedGrantId.ok === false) {
       return res.status(400).json({
         success: false,
         error: parsedGrantId.error,
@@ -122,7 +122,7 @@ export default async function handler(
     const octokit = new Octokit({ auth: GH_ACCESS_TOKEN })
     const grant = await findGrantIssue(octokit, parsedGrantId.grantId)
 
-    if (!grant.ok) {
+    if (grant.ok === false) {
       return res.status(grant.status).json({
         success: false,
         error: grant.error,

--- a/pages/api/report.ts
+++ b/pages/api/report.ts
@@ -2,6 +2,8 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 import { Octokit } from '@octokit/rest'
 import { sendReportConfirmationEmail } from './sendgrid'
 import { generateReportContent } from '../../utils/api-helpers'
+import { findGrantIssue } from '../../utils/find-grant-issue'
+import { parseGrantIdInput } from '../../utils/grant-id'
 import { assertTurnstile, TURNSTILE_FAILURE_MESSAGE } from '@/utils/turnstile'
 
 const GH_ACCESS_TOKEN = process.env.GH_ACCESS_TOKEN
@@ -16,7 +18,7 @@ interface ReportBotRequest extends NextApiRequest {
     next_quarter: string
     money_usage: string
     help_needed?: string
-    issue_number: number
+    grant_id: string
     email: string
   }
 }
@@ -86,9 +88,11 @@ export default async function handler(
       next_quarter,
       money_usage,
       help_needed,
-      issue_number,
+      grant_id,
       email,
     } = req.body
+
+    const parsedGrantId = parseGrantIdInput(grant_id)
 
     // Input validation
     if (
@@ -97,7 +101,6 @@ export default async function handler(
       !time_spent ||
       !next_quarter ||
       !money_usage ||
-      !issue_number ||
       !email
     ) {
       return res.status(400).json({
@@ -106,10 +109,25 @@ export default async function handler(
       })
     }
 
+    if (!parsedGrantId.ok) {
+      return res.status(400).json({
+        success: false,
+        error: parsedGrantId.error,
+      })
+    }
+
     // Clean up project name to remove the "by" part
     const project_name = original_project_name.replace(/\s+by\s+.*$/, '')
 
     const octokit = new Octokit({ auth: GH_ACCESS_TOKEN })
+    const grant = await findGrantIssue(octokit, parsedGrantId.grantId)
+
+    if (!grant.ok) {
+      return res.status(grant.status).json({
+        success: false,
+        error: grant.error,
+      })
+    }
 
     // Create report content in markdown format using the shared function
     const reportContent = generateReportContent({
@@ -125,7 +143,7 @@ export default async function handler(
     const response = await octokit.rest.issues.createComment({
       owner: GH_ORG,
       repo: GH_REPORTS_REPO,
-      issue_number: issue_number,
+      issue_number: grant.issue.number,
       body: reportContent,
     })
 

--- a/pages/reports/preview.tsx
+++ b/pages/reports/preview.tsx
@@ -86,7 +86,9 @@ export default function Preview() {
       router.push('/reports/success')
     } catch (e) {
       setError(
-        e instanceof Error ? e.message : 'Failed to submit report. Please try again.'
+        e instanceof Error
+          ? e.message
+          : 'Failed to submit report. Please try again.'
       )
       setTurnstileReady(false)
       turnstileRef.current?.reset()

--- a/pages/reports/preview.tsx
+++ b/pages/reports/preview.tsx
@@ -66,8 +66,9 @@ export default function Preview() {
         localStorage.getItem(STORAGE_KEYS.REPORT_DRAFT) || '{}'
       )
       const response = await fetchPostJSON('/api/report', {
-        ...grantDetails,
         ...reportData,
+        grant_id: grantDetails.grant_id,
+        email: grantDetails.email,
         [TURNSTILE_TOKEN_FIELD]: token,
       })
 

--- a/pages/reports/preview.tsx
+++ b/pages/reports/preview.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/router'
 import { STORAGE_KEYS } from '../../utils/constants'
 import { getReportPreview } from '../../utils/api-helpers'
@@ -6,10 +6,18 @@ import ReportPreview from '../../components/ReportPreview'
 import { PageSEO } from '../../components/SEO'
 import PageSection from '../../components/PageSection'
 import { fetchPostJSON } from '../../utils/api-helpers'
+import { TURNSTILE_TOKEN_FIELD } from '../../utils/turnstile'
+import TurnstileWidget, {
+  TurnstileWidgetHandle,
+} from '../../components/grant-application/TurnstileWidget'
 
 export default function Preview() {
   const router = useRouter()
   const [reportContent, setReportContent] = useState<string>('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string>()
+  const [turnstileReady, setTurnstileReady] = useState(false)
+  const turnstileRef = useRef<TurnstileWidgetHandle>(null)
 
   useEffect(() => {
     const loadPreview = async () => {
@@ -40,9 +48,17 @@ export default function Preview() {
   }
 
   const handleSubmit = async () => {
-    if (!reportContent) return
+    if (!reportContent || loading || !turnstileReady) return
+
+    setLoading(true)
+    setError(undefined)
 
     try {
+      const token = await turnstileRef.current?.waitForToken()
+      if (!token) {
+        throw new Error('Please complete the bot verification challenge.')
+      }
+
       const grantDetails = JSON.parse(
         localStorage.getItem(STORAGE_KEYS.GRANT_DETAILS) || '{}'
       )
@@ -52,10 +68,13 @@ export default function Preview() {
       const response = await fetchPostJSON('/api/report', {
         ...grantDetails,
         ...reportData,
+        [TURNSTILE_TOKEN_FIELD]: token,
       })
 
       if (response.error) {
-        console.error('Error submitting report:', response.error)
+        setError(response.error)
+        setTurnstileReady(false)
+        turnstileRef.current?.reset()
         return
       }
 
@@ -65,7 +84,13 @@ export default function Preview() {
       })
       router.push('/reports/success')
     } catch (e) {
-      console.error('Failed to submit report. Please try again.', e)
+      setError(
+        e instanceof Error ? e.message : 'Failed to submit report. Please try again.'
+      )
+      setTurnstileReady(false)
+      turnstileRef.current?.reset()
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -109,10 +134,22 @@ export default function Preview() {
             <ReportPreview reportContent={reportContent} />
           </div>
 
+          <div className="my-8 flex flex-col items-center py-2">
+            <TurnstileWidget
+              ref={turnstileRef}
+              onTokenChange={(token) => setTurnstileReady(!!token)}
+            />
+          </div>
+
+          {error && (
+            <p className="rounded bg-red-500 p-4 text-white">{error}</p>
+          )}
+
           <div className="mt-6 flex justify-between space-x-4">
             <button
               type="button"
               onClick={handleBack}
+              disabled={loading}
               className="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
             >
               <svg
@@ -133,9 +170,14 @@ export default function Preview() {
             </button>
             <button
               onClick={handleSubmit}
-              className="rounded bg-orange-500 px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors duration-200 hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2"
+              disabled={loading || !turnstileReady}
+              className={`rounded px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 ${
+                loading || !turnstileReady
+                  ? 'cursor-not-allowed bg-gray-400'
+                  : 'bg-orange-500 hover:bg-orange-600'
+              }`}
             >
-              Submit Report
+              {loading ? 'Submitting...' : 'Submit Report'}
             </button>
           </div>
         </div>

--- a/tests/api/grant.test.js
+++ b/tests/api/grant.test.js
@@ -6,12 +6,16 @@ process.env.GH_ORG = 'OpenSats'
 process.env.GH_REPORTS_REPO = 'reports'
 process.env.TURNSTILE_SECRET = 'test-turnstile-secret'
 
-jest.mock('@octokit/rest', () => ({
-  Octokit: jest.fn().mockImplementation(() => ({
-    paginate: { iterator: jest.fn() },
-    rest: { issues: { listForRepo: jest.fn() } },
-  })),
-}))
+jest.mock('@octokit/rest', () => {
+  const iterator = jest.fn()
+  return {
+    Octokit: jest.fn().mockImplementation(() => ({
+      paginate: { iterator },
+      rest: { issues: { listForRepo: jest.fn() } },
+    })),
+    __iterator: iterator,
+  }
+})
 
 jest.mock('@/utils/turnstile', () => {
   const actual = jest.requireActual('@/utils/turnstile')
@@ -21,7 +25,9 @@ jest.mock('@/utils/turnstile', () => {
   }
 })
 
+const { Octokit, __iterator: iterator } = require('@octokit/rest')
 const { assertTurnstile } = require('@/utils/turnstile')
+const { ERROR_MESSAGES } = require('../../utils/constants.ts')
 const handler = require('../../pages/api/grant.ts').default
 
 function responseMock() {
@@ -39,10 +45,19 @@ function responseMock() {
   }
 }
 
+function pages(issues) {
+  return (async function* () {
+    yield { data: issues }
+  })()
+}
+
 describe('/api/grant', () => {
   beforeEach(() => {
     assertTurnstile.mockReset()
     assertTurnstile.mockResolvedValue(true)
+    iterator.mockReset()
+    iterator.mockImplementation(() => pages([]))
+    Octokit.mockClear()
     jest.spyOn(console, 'error').mockImplementation(() => undefined)
   })
 
@@ -70,5 +85,96 @@ describe('/api/grant', () => {
     expect(response.payload.error).toBe(
       'Bot verification failed. Please try again.'
     )
+  })
+
+  it('rejects non-numeric grant ids before searching', async () => {
+    const response = responseMock()
+
+    await handler(
+      {
+        method: 'POST',
+        body: { grant_id: 'cashu', 'cf-turnstile-response': 'test-token' },
+      },
+      response
+    )
+
+    expect(response.statusCode).toBe(400)
+    expect(response.payload).toEqual({
+      valid: false,
+      error: ERROR_MESSAGES.GRANT_ID_INVALID,
+    })
+    expect(Octokit).not.toHaveBeenCalled()
+  })
+
+  it('rejects grant ids that are not 6 or 7 digits', async () => {
+    const response = responseMock()
+
+    await handler(
+      {
+        method: 'POST',
+        body: { grant_id: '12345', 'cf-turnstile-response': 'test-token' },
+      },
+      response
+    )
+
+    expect(response.statusCode).toBe(400)
+    expect(Octokit).not.toHaveBeenCalled()
+  })
+
+  it('matches a numeric grant id as a whole token in the title', async () => {
+    iterator.mockImplementation(() =>
+      pages([
+        {
+          title: '946366 - Cashu-TS and Cashu.me',
+          body: null,
+          number: 361,
+          state: 'open',
+        },
+      ])
+    )
+    const response = responseMock()
+
+    await handler(
+      {
+        method: 'POST',
+        body: { grant_id: '946366', 'cf-turnstile-response': 'test-token' },
+      },
+      response
+    )
+
+    expect(response.statusCode).toBe(200)
+    expect(response.payload).toEqual({
+      valid: true,
+      project_name: '946366 - Cashu-TS and Cashu.me',
+      issue_number: 361,
+    })
+  })
+
+  it('does not match an id that only appears in the issue body', async () => {
+    iterator.mockImplementation(() =>
+      pages([
+        {
+          title: 'Some other project',
+          body: 'Mentions cashu and 946366 in the body',
+          number: 361,
+          state: 'open',
+        },
+      ])
+    )
+    const response = responseMock()
+
+    await handler(
+      {
+        method: 'POST',
+        body: { grant_id: '946366', 'cf-turnstile-response': 'test-token' },
+      },
+      response
+    )
+
+    expect(response.statusCode).toBe(404)
+    expect(response.payload).toEqual({
+      valid: false,
+      error: ERROR_MESSAGES.GRANT_NOT_FOUND,
+    })
   })
 })

--- a/tests/api/grant.test.js
+++ b/tests/api/grant.test.js
@@ -1,0 +1,74 @@
+/** @jest-environment node */
+/* eslint-env jest, node */
+
+process.env.GH_ACCESS_TOKEN = 'test-token'
+process.env.GH_ORG = 'OpenSats'
+process.env.GH_REPORTS_REPO = 'reports'
+process.env.TURNSTILE_SECRET = 'test-turnstile-secret'
+
+jest.mock('@octokit/rest', () => ({
+  Octokit: jest.fn().mockImplementation(() => ({
+    paginate: { iterator: jest.fn() },
+    rest: { issues: { listForRepo: jest.fn() } },
+  })),
+}))
+
+jest.mock('@/utils/turnstile', () => {
+  const actual = jest.requireActual('@/utils/turnstile')
+  return {
+    ...actual,
+    assertTurnstile: jest.fn(),
+  }
+})
+
+const { assertTurnstile } = require('@/utils/turnstile')
+const handler = require('../../pages/api/grant.ts').default
+
+function responseMock() {
+  return {
+    statusCode: undefined,
+    payload: undefined,
+    status(code) {
+      this.statusCode = code
+      return this
+    },
+    json(payload) {
+      this.payload = payload
+      return this
+    },
+  }
+}
+
+describe('/api/grant', () => {
+  beforeEach(() => {
+    assertTurnstile.mockReset()
+    assertTurnstile.mockResolvedValue(true)
+    jest.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('rejects requests that fail Turnstile verification', async () => {
+    assertTurnstile.mockResolvedValue(false)
+    const response = responseMock()
+
+    await handler(
+      {
+        method: 'POST',
+        body: {
+          grant_id: '123456',
+          'cf-turnstile-response': 'test-token',
+        },
+      },
+      response
+    )
+
+    expect(response.statusCode).toBe(403)
+    expect(response.payload.valid).toBe(false)
+    expect(response.payload.error).toBe(
+      'Bot verification failed. Please try again.'
+    )
+  })
+})

--- a/tests/api/report.test.js
+++ b/tests/api/report.test.js
@@ -1,0 +1,104 @@
+/** @jest-environment node */
+/* eslint-env jest, node */
+
+process.env.GH_ACCESS_TOKEN = 'test-token'
+process.env.GH_ORG = 'OpenSats'
+process.env.GH_REPORTS_REPO = 'reports'
+process.env.TURNSTILE_SECRET = 'test-turnstile-secret'
+
+jest.mock('@octokit/rest', () => {
+  const createComment = jest.fn()
+  return {
+    Octokit: jest.fn().mockImplementation(() => ({
+      rest: { issues: { createComment } },
+    })),
+    __createComment: createComment,
+  }
+})
+
+jest.mock('../../pages/api/sendgrid.ts', () => ({
+  sendReportConfirmationEmail: jest.fn(),
+}))
+
+jest.mock('@/utils/turnstile', () => {
+  const actual = jest.requireActual('@/utils/turnstile')
+  return {
+    ...actual,
+    assertTurnstile: jest.fn(),
+  }
+})
+
+const { __createComment: createComment } = require('@octokit/rest')
+const { sendReportConfirmationEmail } = require('../../pages/api/sendgrid.ts')
+const { assertTurnstile } = require('@/utils/turnstile')
+const handler = require('../../pages/api/report.ts').default
+
+function responseMock() {
+  return {
+    statusCode: undefined,
+    payload: undefined,
+    status(code) {
+      this.statusCode = code
+      return this
+    },
+    json(payload) {
+      this.payload = payload
+      return this
+    },
+  }
+}
+
+const validReport = {
+  project_name: 'Test project',
+  own_words: 'Worked on the thing',
+  time_spent: '40 hours',
+  next_quarter: 'More work',
+  money_usage: 'Hosting',
+  issue_number: 361,
+  email: 'grantee@example.org',
+  'cf-turnstile-response': 'test-token',
+}
+
+describe('/api/report', () => {
+  beforeEach(() => {
+    createComment.mockReset()
+    createComment.mockResolvedValue({
+      data: { id: 1, html_url: 'https://github.com/OpenSats/reports/issues/361#issuecomment-1' },
+    })
+    sendReportConfirmationEmail.mockReset()
+    sendReportConfirmationEmail.mockResolvedValue(true)
+    assertTurnstile.mockReset()
+    assertTurnstile.mockResolvedValue(true)
+    jest.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('creates a comment when Turnstile verification succeeds', async () => {
+    const response = responseMock()
+
+    await handler({ method: 'POST', body: validReport }, response)
+
+    expect(response.statusCode).toBe(200)
+    expect(response.payload.success).toBe(true)
+    expect(createComment).toHaveBeenCalled()
+    expect(sendReportConfirmationEmail).toHaveBeenCalled()
+  })
+
+  it('rejects requests that fail Turnstile verification', async () => {
+    assertTurnstile.mockResolvedValue(false)
+    const response = responseMock()
+
+    await handler({ method: 'POST', body: validReport }, response)
+
+    expect(response.statusCode).toBe(403)
+    expect(response.payload.success).toBe(false)
+    expect(response.payload.error).toBe(
+      'Bot verification failed. Please try again.'
+    )
+    expect(createComment).not.toHaveBeenCalled()
+    expect(sendReportConfirmationEmail).not.toHaveBeenCalled()
+  })
+})

--- a/tests/api/report.test.js
+++ b/tests/api/report.test.js
@@ -8,11 +8,14 @@ process.env.TURNSTILE_SECRET = 'test-turnstile-secret'
 
 jest.mock('@octokit/rest', () => {
   const createComment = jest.fn()
+  const iterator = jest.fn()
   return {
     Octokit: jest.fn().mockImplementation(() => ({
-      rest: { issues: { createComment } },
+      paginate: { iterator },
+      rest: { issues: { createComment, listForRepo: jest.fn() } },
     })),
     __createComment: createComment,
+    __iterator: iterator,
   }
 })
 
@@ -28,9 +31,12 @@ jest.mock('@/utils/turnstile', () => {
   }
 })
 
-const { __createComment: createComment } = require('@octokit/rest')
+const { __createComment: createComment, __iterator: iterator } = require(
+  '@octokit/rest'
+)
 const { sendReportConfirmationEmail } = require('../../pages/api/sendgrid.ts')
 const { assertTurnstile } = require('@/utils/turnstile')
+const { ERROR_MESSAGES } = require('../../utils/constants.ts')
 const handler = require('../../pages/api/report.ts').default
 
 function responseMock() {
@@ -48,13 +54,27 @@ function responseMock() {
   }
 }
 
+function pages(issues) {
+  return (async function* () {
+    yield { data: issues }
+  })()
+}
+
+const matchingIssue = {
+  title: '946366 - Cashu-TS and Cashu.me',
+  body: null,
+  number: 361,
+  state: 'open',
+}
+
 const validReport = {
   project_name: 'Test project',
   own_words: 'Worked on the thing',
   time_spent: '40 hours',
   next_quarter: 'More work',
   money_usage: 'Hosting',
-  issue_number: 361,
+  grant_id: '946366',
+  issue_number: 1,
   email: 'grantee@example.org',
   'cf-turnstile-response': 'test-token',
 }
@@ -63,8 +83,14 @@ describe('/api/report', () => {
   beforeEach(() => {
     createComment.mockReset()
     createComment.mockResolvedValue({
-      data: { id: 1, html_url: 'https://github.com/OpenSats/reports/issues/361#issuecomment-1' },
+      data: {
+        id: 1,
+        html_url:
+          'https://github.com/OpenSats/reports/issues/361#issuecomment-1',
+      },
     })
+    iterator.mockReset()
+    iterator.mockImplementation(() => pages([matchingIssue]))
     sendReportConfirmationEmail.mockReset()
     sendReportConfirmationEmail.mockResolvedValue(true)
     assertTurnstile.mockReset()
@@ -76,15 +102,82 @@ describe('/api/report', () => {
     jest.restoreAllMocks()
   })
 
-  it('creates a comment when Turnstile verification succeeds', async () => {
+  it('creates a comment on the issue resolved from grant_id', async () => {
     const response = responseMock()
 
     await handler({ method: 'POST', body: validReport }, response)
 
     expect(response.statusCode).toBe(200)
     expect(response.payload.success).toBe(true)
-    expect(createComment).toHaveBeenCalled()
+    expect(createComment).toHaveBeenCalledWith(
+      expect.objectContaining({ issue_number: 361 })
+    )
     expect(sendReportConfirmationEmail).toHaveBeenCalled()
+  })
+
+  it('ignores a client-supplied issue_number', async () => {
+    const response = responseMock()
+
+    await handler(
+      { method: 'POST', body: { ...validReport, issue_number: 999 } },
+      response
+    )
+
+    expect(response.statusCode).toBe(200)
+    expect(createComment).toHaveBeenCalledWith(
+      expect.objectContaining({ issue_number: 361 })
+    )
+  })
+
+  it('rejects an unknown grant id without writing', async () => {
+    iterator.mockImplementation(() => pages([]))
+    const response = responseMock()
+
+    await handler({ method: 'POST', body: validReport }, response)
+
+    expect(response.statusCode).toBe(404)
+    expect(response.payload).toEqual({
+      success: false,
+      error: ERROR_MESSAGES.GRANT_NOT_FOUND,
+    })
+    expect(createComment).not.toHaveBeenCalled()
+    expect(sendReportConfirmationEmail).not.toHaveBeenCalled()
+  })
+
+  it('rejects a closed grant without writing', async () => {
+    iterator.mockImplementation(() =>
+      pages([{ ...matchingIssue, state: 'closed' }])
+    )
+    const response = responseMock()
+
+    await handler({ method: 'POST', body: validReport }, response)
+
+    expect(response.statusCode).toBe(409)
+    expect(response.payload).toEqual({
+      success: false,
+      error: ERROR_MESSAGES.PAST_GRANT,
+    })
+    expect(createComment).not.toHaveBeenCalled()
+  })
+
+  it('rejects a missing or invalid grant id', async () => {
+    const missing = responseMock()
+    await handler(
+      { method: 'POST', body: { ...validReport, grant_id: '' } },
+      missing
+    )
+    expect(missing.statusCode).toBe(400)
+    expect(missing.payload.error).toBe(ERROR_MESSAGES.GRANT_ID_REQUIRED)
+    expect(createComment).not.toHaveBeenCalled()
+
+    const invalid = responseMock()
+    await handler(
+      { method: 'POST', body: { ...validReport, grant_id: 'cashu' } },
+      invalid
+    )
+    expect(invalid.statusCode).toBe(400)
+    expect(invalid.payload.error).toBe(ERROR_MESSAGES.GRANT_ID_INVALID)
+    expect(createComment).not.toHaveBeenCalled()
   })
 
   it('rejects requests that fail Turnstile verification', async () => {

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -7,6 +7,9 @@ export const STORAGE_KEYS = {
 } as const
 
 export const ERROR_MESSAGES = {
+  GRANT_ID_REQUIRED: 'Grant ID is required',
+  GRANT_ID_INVALID:
+    'A valid Grant ID is required to start the submission process',
   GRANT_NOT_FOUND: 'Grant not found, contact support for assistance',
   PAST_GRANT:
     'This is a past grant that already ended. Please use your new grant number.',

--- a/utils/find-grant-issue.ts
+++ b/utils/find-grant-issue.ts
@@ -1,0 +1,69 @@
+import { Octokit } from '@octokit/rest'
+import { ERROR_MESSAGES } from './constants'
+import { titleMatchesGrantId } from './grant-id'
+
+export type GrantIssue = {
+  title: string
+  number: number
+  state: 'open' | 'closed'
+}
+
+export type FindGrantIssueResult =
+  | { ok: true; issue: GrantIssue }
+  | { ok: false; status: 404 | 409 | 500; error: string }
+
+const DEV_GRANT_ID = '123456'
+
+export async function findGrantIssue(
+  octokit: Octokit,
+  grantId: string
+): Promise<FindGrantIssueResult> {
+  if (process.env.NODE_ENV === 'development' && grantId === DEV_GRANT_ID) {
+    return {
+      ok: true,
+      issue: { title: 'Test Grant', number: 123, state: 'open' },
+    }
+  }
+
+  const owner = process.env.GH_ORG
+  const repo = process.env.GH_REPORTS_REPO
+  if (!owner || !repo) {
+    return { ok: false, status: 500, error: 'Server configuration error' }
+  }
+
+  try {
+    for await (const { data: issues } of octokit.paginate.iterator(
+      octokit.rest.issues.listForRepo,
+      {
+        owner,
+        repo,
+        state: 'all',
+        per_page: 100,
+      }
+    )) {
+      const found = issues.find((issue) =>
+        titleMatchesGrantId(issue.title, grantId)
+      )
+
+      if (!found) continue
+
+      if (found.state === 'closed') {
+        return { ok: false, status: 409, error: ERROR_MESSAGES.PAST_GRANT }
+      }
+
+      return {
+        ok: true,
+        issue: {
+          title: found.title,
+          number: found.number,
+          state: found.state as 'open' | 'closed',
+        },
+      }
+    }
+
+    return { ok: false, status: 404, error: ERROR_MESSAGES.GRANT_NOT_FOUND }
+  } catch (error) {
+    console.error('Error looking up grant:', error)
+    return { ok: false, status: 500, error: 'Error validating grant' }
+  }
+}

--- a/utils/grant-id.test.js
+++ b/utils/grant-id.test.js
@@ -1,0 +1,49 @@
+/** @jest-environment node */
+/* eslint-env jest, node */
+
+const {
+  GRANT_ID_PATTERN,
+  isNumericGrantId,
+  normalizeGrantId,
+  titleMatchesGrantId,
+} = require('./grant-id.ts')
+
+describe('grant id helpers', () => {
+  it('accepts 6 or 7 digit ids', () => {
+    expect(isNumericGrantId('123456')).toBe(true)
+    expect(isNumericGrantId('1234567')).toBe(true)
+    expect(GRANT_ID_PATTERN.test('123456')).toBe(true)
+  })
+
+  it('rejects non-numeric and wrong-length ids', () => {
+    expect(isNumericGrantId('')).toBe(false)
+    expect(isNumericGrantId('cashu')).toBe(false)
+    expect(isNumericGrantId('12345')).toBe(false)
+    expect(isNumericGrantId('12345678')).toBe(false)
+    expect(isNumericGrantId('123456-1')).toBe(false)
+  })
+
+  it('trims incoming values', () => {
+    expect(normalizeGrantId(' 946366 ')).toBe('946366')
+    expect(normalizeGrantId(946366)).toBe('946366')
+    expect(normalizeGrantId(undefined)).toBe('')
+  })
+
+  it('matches a grant id as a whole number in the title', () => {
+    expect(titleMatchesGrantId('946366 - Cashu-TS and Cashu.me', '946366')).toBe(
+      true
+    )
+    expect(titleMatchesGrantId('Grant #946366: Cashu-TS', '946366')).toBe(true)
+    expect(titleMatchesGrantId('Project by 946366', '946366')).toBe(true)
+  })
+
+  it('does not match a substring or a body-only mention', () => {
+    expect(titleMatchesGrantId('19463661 - Other project', '946366')).toBe(
+      false
+    )
+    expect(titleMatchesGrantId('94636 - Short id', '946366')).toBe(false)
+    expect(titleMatchesGrantId('Some project', '946366')).toBe(false)
+    expect(titleMatchesGrantId(null, '946366')).toBe(false)
+    expect(titleMatchesGrantId('946366 - Cashu', 'cashu')).toBe(false)
+  })
+})

--- a/utils/grant-id.test.js
+++ b/utils/grant-id.test.js
@@ -5,8 +5,12 @@ const {
   GRANT_ID_PATTERN,
   isNumericGrantId,
   normalizeGrantId,
+  parseGrantIdInput,
+  projectNameFromTitle,
   titleMatchesGrantId,
 } = require('./grant-id.ts')
+
+const { ERROR_MESSAGES } = require('./constants.ts')
 
 describe('grant id helpers', () => {
   it('accepts 6 or 7 digit ids', () => {
@@ -27,6 +31,28 @@ describe('grant id helpers', () => {
     expect(normalizeGrantId(' 946366 ')).toBe('946366')
     expect(normalizeGrantId(946366)).toBe('946366')
     expect(normalizeGrantId(undefined)).toBe('')
+  })
+
+  it('parses grant ids for the API', () => {
+    expect(parseGrantIdInput(' 946366 ')).toEqual({
+      ok: true,
+      grantId: '946366',
+    })
+    expect(parseGrantIdInput('')).toEqual({
+      ok: false,
+      error: ERROR_MESSAGES.GRANT_ID_REQUIRED,
+    })
+    expect(parseGrantIdInput('cashu')).toEqual({
+      ok: false,
+      error: ERROR_MESSAGES.GRANT_ID_INVALID,
+    })
+  })
+
+  it('strips grant prefixes from issue titles', () => {
+    expect(projectNameFromTitle('Grant #12: Cashu-TS by Alice')).toBe('Cashu-TS')
+    expect(projectNameFromTitle('946366 - Cashu-TS and Cashu.me')).toBe(
+      '946366 - Cashu-TS and Cashu.me'
+    )
   })
 
   it('matches a grant id as a whole number in the title', () => {

--- a/utils/grant-id.ts
+++ b/utils/grant-id.ts
@@ -1,0 +1,18 @@
+export const GRANT_ID_PATTERN = /^\d{6,7}$/
+
+export function normalizeGrantId(value: unknown): string {
+  return String(value ?? '').trim()
+}
+
+export function isNumericGrantId(value: string): boolean {
+  return GRANT_ID_PATTERN.test(value)
+}
+
+/** True when the grant id appears in the title as its own number, not a substring. */
+export function titleMatchesGrantId(
+  title: string | null | undefined,
+  grantId: string
+): boolean {
+  if (!title || !isNumericGrantId(grantId)) return false
+  return new RegExp(`(^|[^\\d])${grantId}([^\\d]|$)`).test(title)
+}

--- a/utils/grant-id.ts
+++ b/utils/grant-id.ts
@@ -1,3 +1,5 @@
+import { ERROR_MESSAGES } from './constants'
+
 export const GRANT_ID_PATTERN = /^\d{6,7}$/
 
 export function normalizeGrantId(value: unknown): string {
@@ -6,6 +8,23 @@ export function normalizeGrantId(value: unknown): string {
 
 export function isNumericGrantId(value: string): boolean {
   return GRANT_ID_PATTERN.test(value)
+}
+
+export function parseGrantIdInput(
+  value: unknown
+): { ok: true; grantId: string } | { ok: false; error: string } {
+  const grantId = normalizeGrantId(value)
+  if (!grantId) {
+    return { ok: false, error: ERROR_MESSAGES.GRANT_ID_REQUIRED }
+  }
+  if (!isNumericGrantId(grantId)) {
+    return { ok: false, error: ERROR_MESSAGES.GRANT_ID_INVALID }
+  }
+  return { ok: true, grantId }
+}
+
+export function projectNameFromTitle(title: string): string {
+  return title.replace(/^Grant #\d+:\s*/, '').replace(/\s+by\s+.*$/, '')
 }
 
 /** True when the grant id appears in the title as its own number, not a substring. */


### PR DESCRIPTION
Report lookup and submit now require Cloudflare Turnstile, the same as apply. Grant ids must be 6 or 7 digits and match as a whole number in the issue title. `/api/report` looks up that id on the server and ignores a client-supplied `issue_number`.