### PR TITLE
Add FAQ entries for grant disclosure and board selection

### DIFF
--- a/data/pages/faq.mdx
+++ b/data/pages/faq.mdx
@@ -10,7 +10,7 @@ Frequently asked questions:
 - [What are you doing at OpenSats?](#what-are-you-doing-at-opensats)
 - [Why the name OpenSats?](#why-the-name-opensats)
 - [How are funds distributed?](#how-are-funds-distributed)
-- [Do you disclose grant amounts publicly?](#do-you-disclose-grant-amounts-publicly)
+- [Why aren't all grant amounts publicly disclosed?](#why-arent-all-grant-amounts-publicly-disclosed)
 - [How much of my donation goes towards open-source contributors?](#how-much-of-my-donation-goes-towards-open-source-contributors)
 - [How can I donate to OpenSats?](#how-can-i-donate-to-opensats)
 - [Do you distribute grants in bitcoin or fiat?](#do-you-distribute-grants-in-bitcoin-or-fiat)
@@ -19,7 +19,7 @@ Frequently asked questions:
 - [How often are funding opportunities announced?](#how-often-are-funding-opportunities-announced)
 - [How do I apply for funding?](#how-do-i-apply-for-funding)
 - [When is the best time to apply?](#when-is-the-best-time-to-apply)
-- [How did you choose the board?](#how-did-you-choose-the-board)
+- [How are board members selected?](#how-are-board-members-selected)
 - [Do board members benefit financially from donations?](#do-board-members-benefit-financially-from-donations)
 - [Tell me more about your board. How does it work?](#tell-me-more-about-your-board-how-does-it-work)
 - [Are you really 100% passthrough?](#are-you-really-100-passthrough)
@@ -58,13 +58,17 @@ impact projects in the Bitcoin space.
 You can find a list of past and active grantees, as well as links to our reports
 at our [transparency](/transparency) section.
 
-## Do you disclose grant amounts publicly?
+<span id="do-you-disclose-grant-amounts-publicly" />
 
-We do not usually disclose individual grant amounts publicly.
+## Why aren't all grant amounts publicly disclosed?
 
-We support grantees in [more than 40 countries](/map), and some grantees ask
-us not to disclose detailed amounts because doing so could endanger them or
-their families. We take the privacy and security of our grantees seriously.
+OpenSats announces every grant. We usually keep individual grant amounts
+private.
+
+Some grantees live or work in places where public funding details can create
+safety risks for them or their families. We take the privacy and security of our
+grantees seriously. Grantees are free to disclose details of their own grant
+agreement if they choose.
 
 Please refer to our [transparency](/transparency) page for detailed financial
 reports.
@@ -160,17 +164,19 @@ improvements and do some housekeeping.
 If you are helping Bitcoin and FOSS, please [submit an application](/apply) on
 our website.
 
-## How did you choose the board?
+<span id="how-did-you-choose-the-board" />
 
-We didn't want any one person or small group to have control of the
-decision-making process of OpenSats, so we created a transparent, public-facing,
-and accountable nine person board to make all organizational decisions.
+## How are board members selected?
 
-OpenSats' board members have deep-seated values and will stop at nothing to
-support and ensure the survival of free and open-source technology like Bitcoin.
+OpenSats has a [public nine-person board][board]. Board members are selected
+for their judgment, values, and record of support for Bitcoin and free and
+open-source software.
 
-[The board][board] is composed of well-known and respected public-facing
-individuals who will carry the torch and be held accountable for their choices.
+The board is intentionally larger than a typical nonprofit board so no single
+person or small group can control OpenSats. Standard funding decisions require a
+simple majority of the board. Board-related and structural changes require a 6-3
+supermajority, and new members are announced publicly.
+
 We encourage community feedback, dialogue, and constructive criticism. We can
 only promise to do our best to ensure that all funds go to deserving projects
 which support OpenSats' mission of creating a sustainable and consistent

--- a/data/pages/faq.mdx
+++ b/data/pages/faq.mdx
@@ -172,15 +172,16 @@ applications and progress reports in their respective verticals. A prospective
 board member first has to serve on one of these committees.
 
 Over time, committee members who consistently show good judgment, technical
-competence, reliability, and alignment with our mission may be invited to join
-the board if they are willing to take on the role.
+competence, reliability, and alignment with our [mission][mission] may be
+invited to join the board if they are willing to take on the role.
 
 We keep the current board list up to date on our [about page][board].
 
 The board is intentionally larger than a typical nonprofit board so no single
 person or small group can control OpenSats. Standard funding decisions require a
 simple majority of the board. Board-related and structural changes require a 6-3
-supermajority.
+supermajority, as explained in our latest [single-points-of-failure blog
+post][spof].
 
 We encourage community feedback, dialogue, and constructive criticism. We can
 only promise to do our best to ensure that all funds go to deserving projects
@@ -198,7 +199,7 @@ a volunteer basis.
 We have [nine board members][board] and we vote by majority. All standard
 decisions (like which new projects are added to the website or which projects
 will receive grants allocated from the general fund) are made by simple majority
-(5-4), while board-related changes will require a 6-3 majority.
+(5-4), while board-related changes require a [6-3 supermajority][spof].
 
 The current board list is kept up to date on our [about page][board].
 
@@ -246,3 +247,4 @@ Visit [opensats.org/donate](/donate) for more information on donations.
 [mission]: /mission
 [board]: /about#board-of-directors
 [ops]: /funds/ops
+[spof]: /blog/avoiding-single-points-of-failure#no-benevolent-dictator

--- a/data/pages/faq.mdx
+++ b/data/pages/faq.mdx
@@ -175,6 +175,8 @@ Over time, committee members who consistently show good judgment, technical
 competence, reliability, and alignment with our mission may be invited to join
 the board if they are willing to take on the role.
 
+We keep the current board list up to date on our [about page][board].
+
 The board is intentionally larger than a typical nonprofit board so no single
 person or small group can control OpenSats. Standard funding decisions require a
 simple majority of the board. Board-related and structural changes require a 6-3
@@ -197,6 +199,8 @@ We have [nine board members][board] and we vote by majority. All standard
 decisions (like which new projects are added to the website or which projects
 will receive grants allocated from the general fund) are made by simple majority
 (5-4), while board-related changes will require a 6-3 majority.
+
+The current board list is kept up to date on our [about page][board].
 
 ## Are you really 100% passthrough?
 

--- a/data/pages/faq.mdx
+++ b/data/pages/faq.mdx
@@ -177,17 +177,6 @@ invited to join the board if they are willing to take on the role.
 
 We keep the current board list up to date on our [about page][board].
 
-The board is intentionally larger than a typical nonprofit board so no single
-person or small group can control OpenSats. Standard funding decisions require a
-simple majority of the board. Board-related and structural changes require a 6-3
-supermajority, as explained in our latest [single-points-of-failure blog
-post][spof].
-
-We encourage community feedback, dialogue, and constructive criticism. We can
-only promise to do our best to ensure that all funds go to deserving projects
-which support OpenSats' mission of creating a sustainable and consistent
-ecosystem of funding for Bitcoin and Bitcoin-related FOSS contributors.
-
 ## Do board members benefit financially from donations?
 
 No. Board members are not compensated for their board member duties and do not

--- a/data/pages/faq.mdx
+++ b/data/pages/faq.mdx
@@ -196,8 +196,7 @@ a volunteer basis.
 We have [nine board members][board] and we vote by majority. All standard
 decisions (like which new projects are added to the website or which projects
 will receive grants allocated from the general fund) are made by simple majority
-(5-4), while board-related changes will require 6-3 majority. New members to the
-board will be announced publicly.
+(5-4), while board-related changes will require a 6-3 majority.
 
 ## Are you really 100% passthrough?
 

--- a/data/pages/faq.mdx
+++ b/data/pages/faq.mdx
@@ -62,13 +62,16 @@ at our [transparency](/transparency) section.
 
 ## Why aren't all grant amounts publicly disclosed?
 
-OpenSats announces every grant. We usually keep individual grant amounts
-private.
+There is an inherent tradeoff between privacy and transparency. From the first
+grant wave onward, multiple grantees have asked us not to announce grant
+details, specifically individual grant amounts, because that information could
+endanger them or their families.
 
-Some grantees live or work in places where public funding details can create
-safety risks for them or their families. We take the privacy and security of our
-grantees seriously. Grantees are free to disclose details of their own grant
-agreement if they choose.
+OpenSats awards grants worldwide, independent of the applicant's background or
+socioeconomic status. In some parts of the world, the news that someone is
+funded for their work can put them at risk. We therefore announce every grant
+while keeping grant amounts private by default. Grantees are free to disclose
+details of their own [grant agreement](/docs/agreement.pdf), and some do.
 
 Please refer to our [transparency](/transparency) page for detailed financial
 reports.

--- a/data/pages/faq.mdx
+++ b/data/pages/faq.mdx
@@ -62,13 +62,8 @@ at our [transparency](/transparency) section.
 
 ## Why aren't all grant amounts publicly disclosed?
 
-There is an inherent tradeoff between privacy and transparency. From the first
-grant wave onward, multiple grantees have asked us not to announce grant
-details, specifically individual grant amounts, because that information could
-endanger them or their families.
-
-OpenSats awards grants worldwide, independent of the applicant's background or
-socioeconomic status. In some parts of the world, the news that someone is
+OpenSats awards grants worldwide, independently of the applicant's background
+or socioeconomic status. In some parts of the world, the news that someone is
 funded for their work can put them at risk. We therefore announce every grant
 while keeping grant amounts private by default. Grantees are free to disclose
 details of their own [grant agreement](/docs/agreement.pdf), and some do.
@@ -183,7 +178,7 @@ the board if they are willing to take on the role.
 The board is intentionally larger than a typical nonprofit board so no single
 person or small group can control OpenSats. Standard funding decisions require a
 simple majority of the board. Board-related and structural changes require a 6-3
-supermajority, and new members are announced publicly.
+supermajority.
 
 We encourage community feedback, dialogue, and constructive criticism. We can
 only promise to do our best to ensure that all funds go to deserving projects

--- a/data/pages/faq.mdx
+++ b/data/pages/faq.mdx
@@ -186,9 +186,9 @@ a volunteer basis.
 ## Tell me more about your board. How does it work?
 
 We have [nine board members][board] and we vote by majority. All standard
-decisions (like which new projects are added to the website or which projects
-will receive grants allocated from the general fund) are made by simple majority
-(5-4), while board-related changes require a [6-3 supermajority][spof].
+decisions (like which projects will receive grants allocated from the general
+fund) are made by simple majority (5-4), while board-related changes require a
+[6-3 supermajority][spof].
 
 The current board list is kept up to date on our [about page][board].
 

--- a/data/pages/faq.mdx
+++ b/data/pages/faq.mdx
@@ -172,8 +172,13 @@ our website.
 ## How are board members selected?
 
 OpenSats has a [public nine-person board][board]. Board members are selected
-for their judgment, values, and record of support for Bitcoin and free and
-open-source software.
+from our volunteer technical committees, which help us review grant
+applications and progress reports in their respective verticals. A prospective
+board member first has to serve on one of these committees.
+
+Over time, committee members who consistently show good judgment, technical
+competence, reliability, and alignment with our mission may be invited to join
+the board if they are willing to take on the role.
 
 The board is intentionally larger than a typical nonprofit board so no single
 person or small group can control OpenSats. Standard funding decisions require a


### PR DESCRIPTION
Adds FAQ entries for grant amount disclosure and board member selection, aligned with the latest single-points-of-failure blog post.

- explains the privacy and transparency tradeoff behind keeping individual grant amounts private by default
- explains the technical committee pipeline for prospective board members
- preserves legacy FAQ anchors used by existing blog links

Build preview:
- [/faq#why-arent-all-grant-amounts-publicly-disclosed](https://os-website-git-content-add-faq-answers-304-305-opensats.vercel.app/faq#why-arent-all-grant-amounts-publicly-disclosed)
- [/faq#how-are-board-members-selected](https://os-website-git-content-add-faq-answers-304-305-opensats.vercel.app/faq#how-are-board-members-selected)

Fixes OpenSats/content#304
Fixes OpenSats/content#305
