### PR TITLE
Fix nym21 spotlight publish date

### DIFF
--- a/data/blog/developer-spotlight-nym21-bitcoin-research-kit.mdx
+++ b/data/blog/developer-spotlight-nym21-bitcoin-research-kit.mdx
@@ -345,6 +345,6 @@ series, please reach out to spotlight@opensats.org.
 [General Fund]: /funds/general
 [cove-os]: /projects/cove
 [CheckOnChain]: https://www.checkonchain.com/
-[nh x thread]: https://x.com/_nym21_/status/2039028715758162277
+[nh x thread]: https://xcancel.com/_nym21_/status/2039028715758162277
 [Start9]: https://github.com/Start9Labs
 [Umbrel]: https://github.com/getumbrel/umbrel

--- a/data/blog/developer-spotlight-nym21-bitcoin-research-kit.mdx
+++ b/data/blog/developer-spotlight-nym21-bitcoin-research-kit.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Nym21 Made Bitcoin's On-Chain Metrics Free, and the Pros Who Sell Them Came Running"
-date: '2026-09-10'
+date: '2026-09-11'
 tags: ['bitcoin', 'research', 'spotlight']
 authors: ['ville', 'robos', 'tuma']
 images: ['/static/images/spotlight/nym21/featured.jpg', '/static/images/spotlight/nym21/hero.jpg']

--- a/data/blog/developer-spotlight-nym21-bitcoin-research-kit.mdx
+++ b/data/blog/developer-spotlight-nym21-bitcoin-research-kit.mdx
@@ -321,7 +321,8 @@ with two commands and a node.
 
 ---
 
-Nym21 has been an OpenSats grantee since December 2024. The grant lets him work on
+Nym21 has been an OpenSats grantee since [December 2024][kibo-grant], with his
+grant renewed in [July 2025][brk-grant]. That support lets him work on
 the [Bitcoin Research Kit][brk] full-time and keep it free to use, verify, and
 self-host. If you want to support nym21, tell someone the project exists. (Just
 remember to credit him for the work!)
@@ -335,6 +336,8 @@ For comments, corrections, or suggestions about our [Spotlight][OpenSats spotlig
 series, please reach out to spotlight@opensats.org.
 
 [brk]: /projects/bitcoinresearchkit
+[kibo-grant]: /blog/ninth-wave-of-bitcoin-grants#kibo
+[brk-grant]: /blog/twelfth-wave-of-bitcoin-grants#bitcoin-research-kit
 [bitview]: https://bitview.space/
 [glassnode]: https://glassnode.com/
 [glassnode-explainer]: https://youtu.be/-xFi-VJlotM


### PR DESCRIPTION
Corrects the nym21 developer spotlight publish date from September 10 to September 11.

- Update `date` in `developer-spotlight-nym21-bitcoin-research-kit.mdx` to `2026-09-11`
- Point the Newhedge thread at `xcancel.com`
- Link the closer to the [ninth](/blog/ninth-wave-of-bitcoin-grants#kibo) and [twelfth](/blog/twelfth-wave-of-bitcoin-grants#bitcoin-research-kit) wave announcements

Build preview: 
- [/blog/developer-spotlight-nym21-bitcoin-research-kit](https://os-website-git-fix-nym21-date-opensats.vercel.app/blog/developer-spotlight-nym21-bitcoin-research-kit)
